### PR TITLE
DATAES-33: Mapping of parent-child relationships

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/annotations/Parent.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/Parent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.annotations;
+
+import java.lang.annotation.*;
+
+import org.springframework.data.annotation.Persistent;
+
+/**
+ * Parent
+ * 
+ * @author Philipp Jardas
+ */
+
+@Persistent
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Parent {
+	String type();
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
@@ -123,7 +123,7 @@ public class ElasticsearchTemplate implements ElasticsearchOperations {
 
         try {
             XContentBuilder xContentBuilder = buildMapping(clazz, persistentEntity.getIndexType(), persistentEntity
-                    .getIdProperty().getFieldName());
+                    .getIdProperty().getFieldName(), persistentEntity.getParentType());
             return requestBuilder.setSource(xContentBuilder).execute().actionGet().isAcknowledged();
         } catch (Exception e) {
             throw new ElasticsearchException("Failed to build mapping for " + clazz.getSimpleName(), e);
@@ -545,6 +545,11 @@ public class ElasticsearchTemplate implements ElasticsearchOperations {
                 indexRequestBuilder.setVersion(query.getVersion());
                 indexRequestBuilder.setVersionType(EXTERNAL);
             }
+            
+            if (query.getParentId() != null) {
+                indexRequestBuilder.setParent(query.getParentId());
+            }
+            
             return indexRequestBuilder;
         } catch (IOException e) {
             throw new ElasticsearchException("failed to index the document [id: " + query.getId() + "]", e);

--- a/src/main/java/org/springframework/data/elasticsearch/core/MappingBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/MappingBuilder.java
@@ -23,6 +23,7 @@ import org.springframework.data.elasticsearch.core.geo.GeoPoint;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
 import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.TypeInformation;
+import org.springframework.util.StringUtils;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -47,6 +48,7 @@ class MappingBuilder {
     public static final String FIELD_SEARCH_ANALYZER = "search_analyzer";
     public static final String FIELD_INDEX_ANALYZER = "index_analyzer";
     public static final String FIELD_PROPERTIES = "properties";
+    public static final String FIELD_PARENT = "_parent";
 
     public static final String INDEX_VALUE_NOT_ANALYZED = "not_analyzed";
     public static final String TYPE_VALUE_STRING = "string";
@@ -55,9 +57,16 @@ class MappingBuilder {
 
     private static SimpleTypeHolder SIMPLE_TYPE_HOLDER = new SimpleTypeHolder();
 
-    static XContentBuilder buildMapping(Class clazz, String indexType, String idFieldName) throws IOException {
-        XContentBuilder xContentBuilder = jsonBuilder().startObject().startObject(indexType).startObject(FIELD_PROPERTIES);
-
+    static XContentBuilder buildMapping(Class clazz, String indexType, String idFieldName, String parentType) throws IOException {
+        XContentBuilder mapping = jsonBuilder().startObject().startObject(indexType);
+        
+        // Parent
+        if (StringUtils.hasText(parentType)) {
+        	mapping.startObject(FIELD_PARENT).field(FIELD_TYPE,parentType).endObject();
+        }
+        
+        // Properties
+        XContentBuilder xContentBuilder = mapping.startObject(FIELD_PROPERTIES);
         mapEntity(xContentBuilder, clazz, true, idFieldName, EMPTY);
 
         return xContentBuilder.endObject().endObject().endObject();

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentEntity.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentEntity.java
@@ -39,4 +39,8 @@ public interface ElasticsearchPersistentEntity<T> extends PersistentEntity<T, El
 	String getIndexStoreType();
 
 	ElasticsearchPersistentProperty getVersionProperty();
+	
+	String getParentType();
+	
+	ElasticsearchPersistentProperty getParentIdProperty();
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/SimpleElasticsearchPersistentEntity.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/SimpleElasticsearchPersistentEntity.java
@@ -21,8 +21,8 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.expression.BeanFactoryAccessor;
 import org.springframework.context.expression.BeanFactoryResolver;
 import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Parent;
 import org.springframework.data.mapping.model.BasicPersistentEntity;
-import org.springframework.data.mapping.model.MappingException;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.util.Assert;
@@ -49,6 +49,8 @@ public class SimpleElasticsearchPersistentEntity<T> extends BasicPersistentEntit
 	private short replicas;
 	private String refreshInterval;
 	private String indexStoreType;
+	private String parentType;
+	private ElasticsearchPersistentProperty parentIdProperty;
 
 	public SimpleElasticsearchPersistentEntity(TypeInformation<T> typeInformation) {
 		super(typeInformation);
@@ -105,8 +107,28 @@ public class SimpleElasticsearchPersistentEntity<T> extends BasicPersistentEntit
 	}
 
 	@Override
+	public String getParentType() {
+		return parentType;
+	}
+
+	@Override
+	public ElasticsearchPersistentProperty getParentIdProperty() {
+		return parentIdProperty;
+	}
+
+	@Override
 	public void addPersistentProperty(ElasticsearchPersistentProperty property) {
 		super.addPersistentProperty(property);
+		
+		Parent parent = property.getField().getAnnotation(Parent.class);
+		if (parent !=null) {
+			Assert.isNull(this.parentIdProperty, "Only one field can hold a @Parent annotation");
+			Assert.isNull(this.parentType, "Only one field can hold a @Parent annotation");
+			Assert.isTrue(property.getType() == String.class, "Parent ID property should be String");
+			this.parentIdProperty = property;
+			this.parentType = parent.type();
+		}
+		
 		if (property.isVersionProperty()) {
 			Assert.isTrue(property.getType() == Long.class, "Version property should be Long");
 		}

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/IndexQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/IndexQuery.java
@@ -30,6 +30,7 @@ public class IndexQuery {
 	private String indexName;
 	private String type;
     private String source;
+	private String parentId;
 
 	public String getId() {
 		return id;
@@ -78,4 +79,12 @@ public class IndexQuery {
     public void setSource(String source) {
         this.source = source;
     }
+
+	public String getParentId() {
+		return parentId;
+	}
+
+	public void setParentId(String parentId) {
+		this.parentId = parentId;
+	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/AbstractElasticsearchRepository.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/AbstractElasticsearchRepository.java
@@ -244,6 +244,7 @@ public abstract class AbstractElasticsearchRepository<T, ID extends Serializable
 		query.setObject(entity);
 		query.setId(stringIdRepresentation(extractIdFromBean(entity)));
 		query.setVersion(extractVersionFromBean(entity));
+		query.setParentId(extractParentIdFromBean(entity));
 		return query;
 	}
 
@@ -305,5 +306,11 @@ public abstract class AbstractElasticsearchRepository<T, ID extends Serializable
 		}
 		return null;
 	}
-
+	
+	private String extractParentIdFromBean(T entity) {
+		if (entityInformation != null) {
+			return entityInformation.getParentId(entity);
+		}
+		return null;
+	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchEntityInformation.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchEntityInformation.java
@@ -35,4 +35,6 @@ public interface ElasticsearchEntityInformation<T, ID extends Serializable> exte
 	String getType();
 
 	Long getVersion(T entity);
+	
+	String getParentId(T entity);
 }

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/MappingElasticsearchEntityInformation.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/MappingElasticsearchEntityInformation.java
@@ -104,4 +104,17 @@ public class MappingElasticsearchEntityInformation<T, ID extends Serializable> e
 		}
 		return null;
 	}
+	
+	@Override
+	public String getParentId(T entity) {
+		ElasticsearchPersistentProperty parentProperty = entityMetadata.getParentIdProperty();
+		try {
+			if (parentProperty != null) {
+				return (String) BeanWrapper.create(entity, null).getProperty(parentProperty);
+			}
+		} catch (Exception e) {
+			throw new IllegalStateException("failed to load parent ID: " + e, e);
+		}
+		return null;
+	}
 }

--- a/src/test/java/org/springframework/data/elasticsearch/MinimalEntity.java
+++ b/src/test/java/org/springframework/data/elasticsearch/MinimalEntity.java
@@ -1,0 +1,10 @@
+package org.springframework.data.elasticsearch;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+
+@Document(indexName = "index", type = "type")
+public class MinimalEntity {
+	@Id
+	private String id;
+}

--- a/src/test/java/org/springframework/data/elasticsearch/ParentEntity.java
+++ b/src/test/java/org/springframework/data/elasticsearch/ParentEntity.java
@@ -1,0 +1,76 @@
+package org.springframework.data.elasticsearch;
+
+import org.springframework.core.style.ToStringCreator;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceConstructor;
+import org.springframework.data.elasticsearch.annotations.*;
+
+@Document(indexName = ParentEntity.INDEX, type = ParentEntity.PARENT_TYPE, indexStoreType = "memory", shards = 1, replicas = 0, refreshInterval = "-1")
+public class ParentEntity {
+	public static final String INDEX = "parent-child";
+	public static final String PARENT_TYPE = "parent-entity";
+	public static final String CHILD_TYPE = "child-entity";
+
+	@Id
+	private String id;
+	@Field(type = FieldType.String, index = FieldIndex.analyzed, store = true)
+	private String name;
+
+	public ParentEntity() {
+	}
+
+	public ParentEntity(String id, String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringCreator(this).append("id", id).append("name", name).toString();
+	}
+
+	@Document(indexName = INDEX, type = CHILD_TYPE, indexStoreType = "memory", shards = 1, replicas = 0, refreshInterval = "-1")
+	public static class ChildEntity {
+		@Id
+		private String id;
+		@Field(type = FieldType.String, store = true)
+		@Parent(type = PARENT_TYPE)
+		private String parentId;
+		@Field(type = FieldType.String, index = FieldIndex.analyzed, store = true)
+		private String name;
+
+		public ChildEntity() {
+		}
+
+		public ChildEntity(String id, String parentId, String name) {
+			this.id = id;
+			this.parentId = parentId;
+			this.name = name;
+		}
+
+		public String getId() {
+			return id;
+		}
+
+		public String getParentId() {
+			return parentId;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		@Override
+		public String toString() {
+			return new ToStringCreator(this).append("id", id).append("parentId", parentId).append("name", name).toString();
+		}
+	}
+}

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateParentChildTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateParentChildTests.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.junit.*;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.elasticsearch.ParentEntity;
+import org.springframework.data.elasticsearch.ParentEntity.ChildEntity;
+import org.springframework.data.elasticsearch.core.query.IndexQuery;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQuery;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Philipp Jardas
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("classpath:elasticsearch-template-test.xml")
+public class ElasticsearchTemplateParentChildTests {
+
+	@Autowired
+	private ElasticsearchTemplate elasticsearchTemplate;
+
+	@Before
+	public void before() {
+		clean();
+		elasticsearchTemplate.createIndex(ParentEntity.class);
+		elasticsearchTemplate.createIndex(ChildEntity.class);
+		elasticsearchTemplate.putMapping(ParentEntity.class);
+		elasticsearchTemplate.putMapping(ChildEntity.class);
+	}
+
+	@After
+	public void clean() {
+		elasticsearchTemplate.deleteIndex(ChildEntity.class);
+		elasticsearchTemplate.deleteIndex(ParentEntity.class);
+	}
+
+	@Test
+	public void test() {
+		// index two parents
+		ParentEntity parent1 = index("parent1", "First Parent");
+		ParentEntity parent2 = index("parent2", "Second Parent");
+
+		// index a child for each parent
+		String child1name = "First";
+		index("child1", parent1.getId(), child1name);
+		index("child2", parent2.getId(), "Second");
+
+		elasticsearchTemplate.refresh(ParentEntity.class, true);
+		elasticsearchTemplate.refresh(ChildEntity.class, true);
+
+		// find all parents that have the first child
+		QueryBuilder query = QueryBuilders.hasChildQuery(ParentEntity.CHILD_TYPE, QueryBuilders.fieldQuery("name", child1name));
+		System.out.println("query: " + query);
+		List<ParentEntity> parents = elasticsearchTemplate.queryForList(new NativeSearchQuery(query), ParentEntity.class);
+
+		// we're expecting only the first parent as result
+		assertThat("parents", parents, contains(hasProperty("id", is(parent1.getId()))));
+	}
+
+	private ParentEntity index(String parentId, String name) {
+		ParentEntity parent = new ParentEntity(parentId, name);
+		IndexQuery index = new IndexQuery();
+		index.setId(parent.getId());
+		index.setObject(parent);
+		elasticsearchTemplate.index(index);
+
+		return parent;
+	}
+
+	private ChildEntity index(String childId, String parentId, String name) {
+		ChildEntity child = new ChildEntity(childId, parentId, name);
+		IndexQuery index = new IndexQuery();
+		index.setId(child.getId());
+		index.setObject(child);
+		index.setParentId(child.getParentId());
+		elasticsearchTemplate.index(index);
+
+		return child;
+	}
+}

--- a/src/test/java/org/springframework/data/elasticsearch/core/MappingBuilderTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/MappingBuilderTests.java
@@ -4,8 +4,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.elasticsearch.SampleTransientEntity;
-import org.springframework.data.elasticsearch.SimpleRecursiveEntity;
+import org.springframework.data.elasticsearch.*;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -33,12 +32,20 @@ public class MappingBuilderTests {
 
     @Test
     public void testInfiniteLoopAvoidance() throws IOException {
-        final String expected = "{\"mapping\":{\"properties\":{\"message\":{\"store\":true,\"" +
-                "type\":\"string\",\"index\":\"not_analyzed\",\"search_analyzer\":\"standard\"," +
-                "\"index_analyzer\":\"standard\"}}}}";
+    	final String expected = "{\"mapping\":{\"properties\":{\"message\":{\"store\":true,\"" +
+    			"type\":\"string\",\"index\":\"not_analyzed\",\"search_analyzer\":\"standard\"," +
+    			"\"index_analyzer\":\"standard\"}}}}";
 
-        XContentBuilder xContentBuilder = MappingBuilder.buildMapping(SampleTransientEntity.class, "mapping", "id");
+        XContentBuilder xContentBuilder = MappingBuilder.buildMapping(SampleTransientEntity.class, "mapping", "id", null);
         assertThat(xContentBuilder.string(), is(expected));
+    }
+    
+    @Test
+    public void testParentType() throws IOException {
+    	final String expected = "{\"mapping\":{\"_parent\":{\"type\":\"parentType\"},\"properties\":{}}}";
+    	
+    	XContentBuilder xContentBuilder = MappingBuilder.buildMapping(MinimalEntity.class, "mapping", "id", "parentType");
+    	assertThat(xContentBuilder.string(), is(expected));
     }
 
 }

--- a/src/test/java/org/springframework/data/elasticsearch/core/SimpleElasticsearchDateMappingTest.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/SimpleElasticsearchDateMappingTest.java
@@ -20,7 +20,7 @@ public class SimpleElasticsearchDateMappingTest {
 
     @Test
     public void testCorrectDateMappings() throws NoSuchFieldException, IntrospectionException, IOException {
-        XContentBuilder xContentBuilder = MappingBuilder.buildMapping(SampleDateMappingEntity.class, "mapping", "id");
+        XContentBuilder xContentBuilder = MappingBuilder.buildMapping(SampleDateMappingEntity.class, "mapping", "id", null);
         Assert.assertEquals(EXPECTED_MAPPING, xContentBuilder.string());
     }
 }


### PR DESCRIPTION
Elasticsearch allows parent-child relationships for documents, see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping-parent-field.html
- The parent document requires no special treatment.
- The child document has to be configured with a special mapping indicating the type of the parent document.
- Each inserted child document must have a reference to the ID of its parent document.

Here's my approach:
- We need a new field annotation (my suggestion: @ParentId) that marks the field which contains a child document's parent ID. Only one field may be annotated with this.
- The mapping builder needs to be updated to handle this new annotation.
- ElasticsearchTemplate queries need to be able to insert child documents with a parent references.

see https://jira.springsource.org/browse/DATAES-33
