### PR TITLE
DATAES-60 - Java config support - default values in TransportClientFactoryBean

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/client/TransportClientFactoryBean.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/TransportClientFactoryBean.java
@@ -36,14 +36,15 @@ import org.springframework.util.Assert;
  * @author Rizwan Idrees
  * @author Mohsin Husen
  * @author Jakub Vavrik
+ * @author Piotr Betkier
  */
 
 public class TransportClientFactoryBean implements FactoryBean<TransportClient>, InitializingBean, DisposableBean {
 
 	private static final Logger logger = LoggerFactory.getLogger(TransportClientFactoryBean.class);
-	private String clusterNodes;
-	private String clusterName;
-	private Boolean clientTransportSniff;
+	private String clusterNodes = "127.0.0.1:9300";
+	private String clusterName = "elasticsearch";
+	private Boolean clientTransportSniff = true;
 	private Boolean clientIgnoreClusterName = Boolean.FALSE;
 	private String clientPingTimeout = "5s";
 	private String clientNodesSamplerInterval = "5s";


### PR DESCRIPTION
Some of the properties of TransportClientFactoryBean class are not initialized with default values, those are defined in xsd only. If you use Java config you have to set them explicitly, which is not clear when you follow the quick start. This PR adds those default values and makes it easier to create a TransportClient.
