### PR TITLE
Issue #DATAES-66: Add Ip support to FieldType

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/annotations/FieldType.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/FieldType.java
@@ -21,5 +21,5 @@ package org.springframework.data.elasticsearch.annotations;
  * @author Artur Konczak
  */
 public enum FieldType {
-	String, Integer, Long, Date, Float, Double, Boolean, Object, Auto, Nested
+	String, Integer, Long, Date, Float, Double, Boolean, Object, Auto, Nested, Ip
 }


### PR DESCRIPTION
This is as trivial as adding a value to the FieldType enum. It doesn't have any
extra properties following the IP type so the
MappingBuilder.addSingleFieldMapping will do the job.
