### PR TITLE
DATAES-74 NPE in MappingElasticsearchEntityInformation

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/SimpleElasticsearchPersistentProperty.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/SimpleElasticsearchPersistentProperty.java
@@ -55,7 +55,7 @@ public class SimpleElasticsearchPersistentProperty extends
 
 	@Override
 	public boolean isIdProperty() {
-		return super.isIdProperty() || field != null ? SUPPORTED_ID_PROPERTY_NAMES.contains(getFieldName()) : false;
+		return super.isIdProperty() || (field != null ? SUPPORTED_ID_PROPERTY_NAMES.contains(getFieldName()) : false);
 	}
 
 	@Override


### PR DESCRIPTION
Fix of DATAES-74 issue, the problem was using illegal operator precedence.
