### PR TITLE
Displaying proper error message for entities that don't have an IdProvid...

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchEntityInformationCreatorImpl.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchEntityInformationCreatorImpl.java
@@ -47,6 +47,7 @@ public class ElasticsearchEntityInformationCreatorImpl implements ElasticsearchE
 				.getPersistentEntity(domainClass);
 
 		Assert.notNull(persistentEntity, String.format("Unable to obtain mapping metadata for %s!", domainClass));
+		Assert.notNull(persistentEntity.getIdProperty(), String.format("No id property found for %s!", domainClass));
 
 		return new MappingElasticsearchEntityInformation<T, ID>(persistentEntity);
 	}

--- a/src/test/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchEntityInformationCreatorImplTest.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchEntityInformationCreatorImplTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.repository.support;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentEntity;
+import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentProperty;
+import org.springframework.data.mapping.context.MappingContext;
+
+import static org.mockito.Mockito.doReturn;
+
+/**
+ * @author Florian Hopf
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ElasticsearchEntityInformationCreatorImplTest {
+
+    @Mock
+    private MappingContext<? extends ElasticsearchPersistentEntity<?>, ElasticsearchPersistentProperty> mappingContext;
+    @Mock
+    private ElasticsearchPersistentEntity<String> persistentEntity;
+    private ElasticsearchEntityInformationCreatorImpl entityInfoCreator;
+    
+    @Before
+    public void before() {
+	entityInfoCreator = new ElasticsearchEntityInformationCreatorImpl(mappingContext);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionOnMissingEntity() {
+	entityInfoCreator.getEntityInformation(String.class);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionOnMissingIdAnnotation() {
+	doReturn(persistentEntity).when(mappingContext).getPersistentEntity(String.class);
+	doReturn(String.class).when(persistentEntity).getType();
+	doReturn(null).when(persistentEntity).getIdProperty();
+	entityInfoCreator.getEntityInformation(String.class);
+    }
+    
+}


### PR DESCRIPTION
...er

When creating a Repository for a class that has no Id annotation this results in a NullPointerException. With this fix this issues a proper error message.
