### PR TITLE
DATAES-104: Add client setting to node client factory.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/client/NodeClientFactoryBean.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/NodeClientFactoryBean.java
@@ -38,6 +38,7 @@ public class NodeClientFactoryBean implements FactoryBean<NodeClient>, Initializ
 	private static final Logger logger = LoggerFactory.getLogger(NodeClientFactoryBean.class);
 	private boolean local;
 	private boolean enableHttp;
+	private boolean client = false;
 	private String clusterName;
 	private NodeClient nodeClient;
 
@@ -68,7 +69,7 @@ public class NodeClientFactoryBean implements FactoryBean<NodeClient>, Initializ
 		ImmutableSettings.Builder settings = ImmutableSettings.settingsBuilder().put("http.enabled",
 				String.valueOf(this.enableHttp));
 
-		nodeClient = (NodeClient) nodeBuilder().settings(settings).clusterName(this.clusterName).local(this.local).node()
+		nodeClient = (NodeClient) nodeBuilder().settings(settings).clusterName(this.clusterName).client(this.client).local(this.local).node()
 				.client();
 	}
 
@@ -82,6 +83,10 @@ public class NodeClientFactoryBean implements FactoryBean<NodeClient>, Initializ
 
 	public void setClusterName(String clusterName) {
 		this.clusterName = clusterName;
+	}
+
+	public void setClient(boolean client) {
+		this.client = client;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/elasticsearch/config/NodeClientBeanDefinitionParser.java
+++ b/src/main/java/org/springframework/data/elasticsearch/config/NodeClientBeanDefinitionParser.java
@@ -41,6 +41,7 @@ public class NodeClientBeanDefinitionParser extends AbstractBeanDefinitionParser
 
 	private void setLocalSettings(Element element, BeanDefinitionBuilder builder) {
 		builder.addPropertyValue("local", Boolean.valueOf(element.getAttribute("local")));
+		builder.addPropertyValue("client", Boolean.valueOf(element.getAttribute("client")));
 		builder.addPropertyValue("clusterName", element.getAttribute("cluster-name"));
 		builder.addPropertyValue("enableHttp", Boolean.valueOf(element.getAttribute("http-enabled")));
 	}

--- a/src/main/resources/org/springframework/data/elasticsearch/config/spring-elasticsearch-1.0.xsd
+++ b/src/main/resources/org/springframework/data/elasticsearch/config/spring-elasticsearch-1.0.xsd
@@ -62,6 +62,13 @@
                             <xsd:documentation><![CDATA[to enable or desable http port]]> </xsd:documentation>
                         </xsd:annotation>
                     </xsd:attribute>
+                    <xsd:attribute name="client" type="xsd:boolean" default="false">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                                <![CDATA[Client should hold data or not. true to set just a client, false to allow this client to hold data.]]>
+                            </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:attribute>
                 </xsd:extension>
             </xsd:complexContent>
         </xsd:complexType>


### PR DESCRIPTION
ElasticSearch Java API allows to define a client that does not hold data. Client may connect cluster without allocating data on it.
