### PR TITLE
DATAES-129 : Custom Repository Method for simple geo request does not wo...

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/CriteriaQueryProcessor.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/CriteriaQueryProcessor.java
@@ -24,10 +24,10 @@ import java.util.List;
 import java.util.ListIterator;
 
 import org.apache.lucene.queryparser.flexible.core.util.StringUtils;
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.BoostableQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.*;
+import org.springframework.data.elasticsearch.core.geo.GeoPoint;
 import org.springframework.data.elasticsearch.core.query.Criteria;
+import org.springframework.data.geo.Point;
 import org.springframework.util.Assert;
 
 /**
@@ -118,9 +118,9 @@ class CriteriaQueryProcessor {
 		}
 		QueryBuilder query = null;
 
-		String searchText = StringUtils.toString(value);
+        String searchText = StringUtils.toString(value);
 
-		switch (key) {
+        switch (key) {
 			case EQUALS:
 				query = queryString(searchText).field(fieldName);
 				break;

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/Criteria.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/Criteria.java
@@ -193,7 +193,7 @@ public class Criteria {
 	 * @return
 	 */
 	public Criteria is(Object o) {
-		queryCriteria.add(new CriteriaEntry(OperationKey.EQUALS, o));
+        queryCriteria.add(new CriteriaEntry(OperationKey.EQUALS, o));
 		return this;
 	}
 

--- a/src/test/java/org/springframework/data/elasticsearch/repositories/CustomMethodRepositoryTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repositories/CustomMethodRepositoryTests.java
@@ -495,6 +495,55 @@ public class CustomMethodRepositoryTests {
 		assertThat(sampleEntities.size(), is(1));
 	}
 
+    @Test
+    public void shouldExecuteCustomMethodWithGeoPoint() {
+        // given
+        String documentId = randomNumeric(5);
+        SampleEntity sampleEntity = new SampleEntity();
+        sampleEntity.setId(documentId);
+        sampleEntity.setType("test");
+        sampleEntity.setRate(10);
+        sampleEntity.setMessage("foo");
+        sampleEntity.setLocation(new GeoPoint(45.7806d, 3.0875d));
+
+        repository.save(sampleEntity);
+
+        // when
+        Page<SampleEntity> page = repository.findByLocation(new GeoPoint(45.7806d, 3.0875d), new PageRequest(0, 10));
+        // then
+        assertThat(page, is(notNullValue()));
+        assertThat(page.getTotalElements(), is(equalTo(1L)));
+    }
+    @Test
+    public void shouldExecuteCustomMethodWithGeoPointAndString() {
+        // given
+        String documentId = randomNumeric(5);
+        SampleEntity sampleEntity = new SampleEntity();
+        sampleEntity.setId(documentId);
+        sampleEntity.setType("test");
+        sampleEntity.setRate(10);
+        sampleEntity.setMessage("foo");
+        sampleEntity.setLocation(new GeoPoint(45.7806d, 3.0875d));
+
+        repository.save(sampleEntity);
+
+        documentId = randomNumeric(5);
+        sampleEntity = new SampleEntity();
+        sampleEntity.setId(documentId);
+        sampleEntity.setType("test");
+        sampleEntity.setRate(10);
+        sampleEntity.setMessage("foo");
+        sampleEntity.setLocation(new GeoPoint(48.7806d, 3.0875d));
+
+        repository.save(sampleEntity);
+
+        // when
+        Page<SampleEntity> page = repository.findByLocationAndMessage(new GeoPoint(45.7806d, 3.0875d), "foo", new PageRequest(0, 10));
+        // then
+        assertThat(page, is(notNullValue()));
+        assertThat(page.getTotalElements(), is(equalTo(1L)));
+    }
+
 	@Test
 	public void shouldExecuteCustomMethodWithWithinGeoPoint() {
 		// given

--- a/src/test/java/org/springframework/data/elasticsearch/repositories/custom/SampleCustomMethodRepository.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repositories/custom/SampleCustomMethodRepository.java
@@ -71,7 +71,11 @@ public interface SampleCustomMethodRepository extends ElasticsearchRepository<Sa
 
 	Page<SampleEntity> findByMessageOrderByTypeAsc(String message, Pageable pageable);
 
-	Page<SampleEntity> findByLocationWithin(GeoPoint point, String distance, Pageable pageable);
+	Page<SampleEntity> findByLocation(GeoPoint point, Pageable pageable);
+
+	Page<SampleEntity> findByLocationAndMessage(GeoPoint point, String msg, Pageable pageable);
+
+    Page<SampleEntity> findByLocationWithin(GeoPoint point, String distance, Pageable pageable);
 
 	Page<SampleEntity> findByLocationWithin(Point point, Distance distance, Pageable pageable);
 


### PR DESCRIPTION
If you have a field named "Location" which is a geo-point and if you call a method in a custom repository called "findByLocation" then it will try to execute a query_string instead of doing a "match all" with a geo filter. It means the type of the field is not detected as a geo-point.

I just noticed that there is no query or filter in ES to retrieve an exact geopoint so I used a trick : I used a "geo distance" filter with a distance of 0.001km. 