### PR TITLE
DATAES-143 Auto Index creation should be configurable

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/annotations/Document.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/Document.java
@@ -24,6 +24,7 @@ import org.springframework.data.annotation.Persistent;
  *
  * @author Rizwan Idrees
  * @author Mohsin Husen
+ * @author Mason Chan
  */
 
 @Persistent
@@ -43,4 +44,8 @@ public @interface Document {
 	String refreshInterval() default "1s";
 
 	String indexStoreType() default "fs";
+
+	String createIndex() default "true";
+
+
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
@@ -104,6 +104,7 @@ import static org.springframework.data.elasticsearch.core.MappingBuilder.buildMa
  * @author Mohsin Husen
  * @author Artur Konczak
  * @author Kevin Leturc
+ * @author Mason Chan
  */
 
 public class ElasticsearchTemplate implements ElasticsearchOperations, ApplicationContextAware {
@@ -736,7 +737,11 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, Applicati
 	}
 
 	private <T> boolean createIndexIfNotCreated(Class<T> clazz) {
-		return indexExists(getPersistentEntityFor(clazz).getIndexName()) || createIndexWithSettings(clazz);
+		return indexExists(getPersistentEntityFor(clazz).getIndexName()) || documentCreateIndexFalse(clazz) || createIndexWithSettings(clazz);
+	}
+
+	private <T> boolean documentCreateIndexFalse(Class<T> clazz) {
+		return (clazz.isAnnotationPresent(Document.class) && !new Boolean(clazz.getAnnotation(Document.class).createIndex()));
 	}
 
 	private <T> boolean createIndexWithSettings(Class<T> clazz) {
@@ -1031,7 +1036,7 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, Applicati
 
 		return stringBuilder.toString();
 	}
-
+	
 	public SuggestResponse suggest(SuggestBuilder.SuggestionBuilder<?> suggestion, String... indices) {
 		SuggestRequestBuilder suggestRequestBuilder = client.prepareSuggest(indices);
 		suggestRequestBuilder.addSuggestion(suggestion);

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
@@ -40,6 +40,7 @@ import org.springframework.data.elasticsearch.builder.SampleEntityBuilder;
 import org.springframework.data.elasticsearch.core.query.*;
 import org.springframework.data.elasticsearch.entities.HetroEntity1;
 import org.springframework.data.elasticsearch.entities.HetroEntity2;
+import org.springframework.data.elasticsearch.entities.CreateIndexFalseEntity;
 import org.springframework.data.elasticsearch.entities.SampleEntity;
 import org.springframework.data.elasticsearch.entities.SampleMappingEntity;
 import org.springframework.test.context.ContextConfiguration;
@@ -60,6 +61,7 @@ import static org.junit.Assert.*;
  * @author Franck Marchand
  * @author Abdul Mohammed
  * @author Kevin Leturc
+ * @author Mason Chan
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("classpath:elasticsearch-template-test.xml")
@@ -1465,6 +1467,19 @@ public class ElasticsearchTemplateTests {
 
 		// when
 		elasticsearchTemplate.deleteIndex("test-index");
+		// then
+		assertThat(elasticsearchTemplate.indexExists("test-index"), is(false));
+	}
+
+	/*
+	DATAES-143
+	*/
+	@Test
+	public void shouldNotCreateIndexWithCreateIndexFalse() {
+		// given
+		elasticsearchTemplate.deleteIndex("test-index");
+		// when
+		elasticsearchTemplate.createIndex(CreateIndexFalseEntity.class);
 		// then
 		assertThat(elasticsearchTemplate.indexExists("test-index"), is(false));
 	}

--- a/src/test/java/org/springframework/data/elasticsearch/entities/CreateIndexFalseEntity.java
+++ b/src/test/java/org/springframework/data/elasticsearch/entities/CreateIndexFalseEntity.java
@@ -1,0 +1,17 @@
+package org.springframework.data.elasticsearch.entities;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+
+/**
+ * CreateIndexFalseEntity
+ *
+ * @author Mason Chan
+ */
+
+@Document(indexName = "test-index", type = "test-type", createIndex = "false")
+public class CreateIndexFalseEntity {
+    @Id
+    private String id;
+
+}


### PR DESCRIPTION
When the application is loaded, indexes are created automatically from the Entity definitions/annotations. This should be an optional setting as automatically generating indexes interferes with template definitions.

Example:
@Document(indexName = "test-index", type = "test-type", createIndex = "false")