### PR TITLE
DATAES-98 Jackson's ObjectMapper is hard to customize

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/DefaultEntityMapper.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/DefaultEntityMapper.java
@@ -15,10 +15,10 @@
  */
 package org.springframework.data.elasticsearch.core;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
 
 /**
  * DocumentMapper using jackson
@@ -31,9 +31,18 @@ public class DefaultEntityMapper implements EntityMapper {
 	private ObjectMapper objectMapper;
 
 	public DefaultEntityMapper() {
-		objectMapper = new ObjectMapper();
+		this(DefaultEntityMapper.getDefaultObjectMapper());
+	}
+
+	public DefaultEntityMapper(final ObjectMapper objectMapper) {
+		this.objectMapper = objectMapper;
+	}
+
+	protected static ObjectMapper getDefaultObjectMapper() {
+		ObjectMapper objectMapper = new ObjectMapper();
 		objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 		objectMapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+		return objectMapper;
 	}
 
 	@Override
@@ -44,5 +53,9 @@ public class DefaultEntityMapper implements EntityMapper {
 	@Override
 	public <T> T mapToObject(String source, Class<T> clazz) throws IOException {
 		return objectMapper.readValue(source, clazz);
+	}
+
+	ObjectMapper getObjectMapper() {
+		return objectMapper;
 	}
 }

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateCustomObjectMapperTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateCustomObjectMapperTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Artur Konczak
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("classpath:elasticsearch-template-custom-objectmapper.xml")
+public class ElasticsearchTemplateCustomObjectMapperTests {
+
+	@Autowired
+	private ElasticsearchTemplate elasticsearchTemplate;
+
+	@Autowired
+	private DefaultEntityMapper entityMapper;
+	@Qualifier("customObjectMapper")
+	@Autowired
+	private ObjectMapper customObjectMapper;
+
+	@Test
+	public void shouldUseCustomObjectMapper() {
+		//given
+		//when
+		//them
+		assertThat(elasticsearchTemplate.getResultsMapper().getEntityMapper(), is((EntityMapper)entityMapper));
+		assertThat(entityMapper.getObjectMapper(), is(customObjectMapper));
+	}
+}

--- a/src/test/resources/elasticsearch-template-custom-objectmapper.xml
+++ b/src/test/resources/elasticsearch-template-custom-objectmapper.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+
+    <import resource="infrastructure.xml"/>
+
+    <bean name="elasticsearchTemplate"
+          class="org.springframework.data.elasticsearch.core.ElasticsearchTemplate">
+        <constructor-arg name="client" ref="client"/>
+        <constructor-arg name="entityMapper" ref="entityMapper"/>
+    </bean>
+
+    <bean name="entityMapper" class="org.springframework.data.elasticsearch.core.DefaultEntityMapper">
+            <constructor-arg name="objectMapper" ref="customObjectMapper"/>
+    </bean>
+
+    <bean id="customObjectMapper" class="com.fasterxml.jackson.databind.ObjectMapper"/>
+
+</beans>


### PR DESCRIPTION
This allows to use a custom ObjectMapper in the DefaultEntityMapper.

Please note that this won't work without DATAES-141 (Pull Request #88)

E.g:

```
<bean name="elasticsearchTemplate"
     class="org.springframework.data.elasticsearch.core.ElasticsearchTemplate">
    <constructor-arg name="client" ref="client"/>
    <constructor-arg name="entityMapper" ref="entityMapper"/>
</bean>
<bean name="entityMapper" class="org.springframework.data.elasticsearch.core.DefaultEntityMapper">
        <constructor-arg name="objectMapper" ref="customObjectMapper"/>
</bean>
    <bean id="customObjectMapper" class="org.springframework.http.converter.json.Jackson2ObjectMapperFactoryBean">
        <property name="featuresToEnable">[...]</property>
        <property name="featuresToDisable">[...]</property>
</bean>
```
