### PR TITLE
Added missing include_in_root property to Field annoation

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/annotations/Field.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/Field.java
@@ -53,4 +53,6 @@ public @interface Field {
 	String[] ignoreFields() default {};
 
 	boolean includeInParent() default false;
+
+    boolean includeInRoot() default false;
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/MappingBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/MappingBuilder.java
@@ -99,6 +99,9 @@ class MappingBuilder {
 			if (nestedOrObjectField && FieldType.Nested == fieldType && fieldAnnotation.includeInParent()) {
 				t.field("include_in_parent", fieldAnnotation.includeInParent());
 			}
+            if (nestedOrObjectField && FieldType.Nested == fieldType && fieldAnnotation.includeInRoot()) {
+                t.field("include_in_root", fieldAnnotation.includeInRoot());
+            }
 			t.startObject(FIELD_PROPERTIES);
 		}
 


### PR DESCRIPTION
Hi, I use spring-data-elasticsearch in my project and require the inlcude_in_root property for one of my mappings so I baked it in into the code. Would be nice to have it in the distribution.
