### PR TITLE
DATAES-156 - Nested and Multi-field should not re-use field name

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/annotations/NestedField.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/NestedField.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 public @interface NestedField {
 
-	String dotSuffix();
+	String suffix();
 
 	FieldType type();
 

--- a/src/main/java/org/springframework/data/elasticsearch/core/MappingBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/MappingBuilder.java
@@ -234,7 +234,7 @@ class MappingBuilder {
 	 */
 	private static void addNestedFieldMapping(XContentBuilder builder, java.lang.reflect.Field field,
 											  NestedField annotation) throws IOException {
-		builder.startObject(field.getName() + "." + annotation.dotSuffix());
+		builder.startObject(annotation.suffix());
 		builder.field(FIELD_STORE, annotation.store());
 		if (FieldType.Auto != annotation.type()) {
 			builder.field(FIELD_TYPE, annotation.type().name().toLowerCase());

--- a/src/test/java/org/springframework/data/elasticsearch/core/facet/ArticleEntity.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/facet/ArticleEntity.java
@@ -45,8 +45,8 @@ public class ArticleEntity {
 	@MultiField(
 			mainField = @Field(type = String, index = analyzed),
 			otherFields = {
-					@NestedField(dotSuffix = "untouched", type = String, store = true, index = not_analyzed),
-					@NestedField(dotSuffix = "sort", type = String, store = true, indexAnalyzer = "keyword")
+					@NestedField(suffix = "untouched", type = String, store = true, index = not_analyzed),
+					@NestedField(suffix = "sort", type = String, store = true, indexAnalyzer = "keyword")
 			}
 	)
 	private List<String> authors = new ArrayList<String>();


### PR DESCRIPTION
I would like to use spring-data-elastic search as part of a larger data-project.
While I was pleasantly surprised to see the fine-grained control the @Field annotation is providing I am a bit confused by the repeating field.name repetition as part of the multi-field and nested Types:
in MappingBuilder.java
```
 private static void addNestedFieldMapping(...) throws IOException {
    builder.startObject(field.getName() + "." + annotation.dotSuffix());
    ...
 }
```
should it not read:
```
private static void addNestedFieldMapping(...) throws IOException {
   builder.startObject(annotation.suffix());
   ...
}
```