### PR TITLE
DATAES-188: Source filtering feature Implementation

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
@@ -536,7 +536,7 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, Applicati
 		Assert.notNull(query.getUpdateRequest(), "No IndexRequest define for Query");
 		UpdateRequestBuilder updateRequestBuilder = client.prepareUpdate(indexName, type, query.getId());
 
-		if(query.getUpdateRequest().script() == null) {
+		if (query.getUpdateRequest().script() == null) {
 			// doc
 			if (query.DoUpsert()) {
 				updateRequestBuilder.setDocAsUpsert(true)
@@ -912,6 +912,11 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, Applicati
 		int startRecord = 0;
 		SearchRequestBuilder searchRequestBuilder = client.prepareSearch(toArray(query.getIndices()))
 				.setSearchType(query.getSearchType()).setTypes(toArray(query.getTypes()));
+
+		if (query.getFetchSourceFilter() != null) {
+			SourceFilter sourceFilter = query.getFetchSourceFilter();
+			searchRequestBuilder.setFetchSource(sourceFilter.getIncludes(), sourceFilter.getExcludes());
+		}
 
 		if (query.getPageable() != null) {
 			startRecord = query.getPageable().getPageNumber() * query.getPageable().getPageSize();

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/AbstractQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/AbstractQuery.java
@@ -39,6 +39,7 @@ abstract class AbstractQuery implements Query {
 	protected List<String> indices = new ArrayList<String>();
 	protected List<String> types = new ArrayList<String>();
 	protected List<String> fields = new ArrayList<String>();
+	protected SourceFilter sourceFilter;
 	protected float minScore;
 	protected Collection<String> ids;
 	protected String route;
@@ -89,6 +90,16 @@ abstract class AbstractQuery implements Query {
 	@Override
 	public List<String> getTypes() {
 		return types;
+	}
+
+	@Override
+	public void addSourceFilter(SourceFilter sourceFilter) {
+		this.sourceFilter = sourceFilter;
+	}
+
+	@Override
+	public SourceFilter getFetchSourceFilter() {
+		return sourceFilter;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/FetchSourceFilter.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/FetchSourceFilter.java
@@ -1,0 +1,27 @@
+package org.springframework.data.elasticsearch.core.query;
+
+/**
+ * SourceFilter implementation for providing includes and excludes.
+ *
+ * @Author Jon Tsiros
+ */
+public class FetchSourceFilter implements SourceFilter {
+
+	private final String[] includes;
+	private final String[] excludes;
+
+	public FetchSourceFilter(final String[] includes, final String[] excludes) {
+		this.includes = includes;
+		this.excludes = excludes;
+	}
+
+	@Override
+	public String[] getIncludes() {
+		return includes;
+	}
+
+	@Override
+	public String[] getExcludes() {
+		return excludes;
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/FetchSourceFilterBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/FetchSourceFilterBuilder.java
@@ -1,0 +1,30 @@
+package org.springframework.data.elasticsearch.core.query;
+
+/**
+ * SourceFilter builder for providing includes and excludes.
+ *
+ * @Author Jon Tsiros
+ */
+public class FetchSourceFilterBuilder {
+
+	private String[] includes;
+	private String[] excludes;
+
+	public FetchSourceFilterBuilder withIncludes(String... includes) {
+		this.includes = includes;
+		return this;
+	}
+
+	public FetchSourceFilterBuilder withExcludes(String... excludes) {
+		this.excludes = excludes;
+		return this;
+	}
+
+	public SourceFilter build() {
+		if (includes == null) includes = new String[0];
+		if (excludes == null) excludes = new String[0];
+
+		SourceFilter sourceFilter = new FetchSourceFilter(includes, excludes);
+		return sourceFilter;
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/NativeSearchQueryBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/NativeSearchQueryBuilder.java
@@ -49,6 +49,7 @@ public class NativeSearchQueryBuilder {
 	private String[] indices;
 	private String[] types;
 	private String[] fields;
+	private SourceFilter sourceFilter;
 	private float minScore;
 	private Collection<String> ids;
 	private String route;
@@ -104,6 +105,11 @@ public class NativeSearchQueryBuilder {
 		return this;
 	}
 
+	public NativeSearchQueryBuilder withSourceFilter(SourceFilter sourceFilter) {
+		this.sourceFilter = sourceFilter;
+		return this;
+	}
+
 	public NativeSearchQueryBuilder withMinScore(float minScore) {
 		this.minScore = minScore;
 		return this;
@@ -140,6 +146,10 @@ public class NativeSearchQueryBuilder {
 
 		if (fields != null) {
 			nativeSearchQuery.addFields(fields);
+		}
+
+		if (sourceFilter != null) {
+			nativeSearchQuery.addSourceFilter(sourceFilter);
 		}
 
 		if (CollectionUtils.isNotEmpty(facetRequests)) {

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/Query.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/Query.java
@@ -112,6 +112,21 @@ public interface Query {
 	List<String> getFields();
 
 	/**
+	 * Add source filter to be added as part of search request
+	 *
+	 * @param sourceFilter
+	 */
+	void addSourceFilter(SourceFilter sourceFilter);
+
+	/**
+	 * Get SourceFilter to be returned to get include and exclude source
+	 * fields as part of search request.
+	 *
+	 * @return SourceFilter
+	 */
+	SourceFilter getFetchSourceFilter();
+
+	/**
 	 * Get minimum score
 	 *
 	 * @return

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/SourceFilter.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/SourceFilter.java
@@ -1,0 +1,12 @@
+package org.springframework.data.elasticsearch.core.query;
+
+/**
+ * SourceFilter for providing includes and excludes.
+ *
+ * @Author Jon Tsiros
+ */
+public interface SourceFilter {
+	String[] getIncludes();
+
+	String[] getExcludes();
+}

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.index.engine.DocumentMissingException;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHitField;
 import org.elasticsearch.search.highlight.HighlightBuilder;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.SortOrder;
@@ -614,6 +615,32 @@ public class ElasticsearchTemplateTests {
 	}
 
 	@Test
+	public void shouldReturnFieldsBasedOnSourceFilter() {
+		// given
+		String documentId = randomNumeric(5);
+		String message = "some test message";
+		SampleEntity sampleEntity = new SampleEntityBuilder(documentId).message(message)
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class, true);
+
+		FetchSourceFilterBuilder sourceFilter = new FetchSourceFilterBuilder();
+		sourceFilter.withIncludes("message");
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).withIndices(INDEX_NAME)
+				.withTypes(TYPE_NAME).withSourceFilter(sourceFilter.build()).build();
+		// when
+		Page<SampleEntity> page = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(equalTo(1L)));
+		assertThat(page.getContent().get(0).getMessage(), is(message));
+	}
+
+	@Test
 	public void shouldReturnSimilarResultsGivenMoreLikeThisQuery() {
 		// given
 		String sampleMessage = "So we build a web site or an application and want to add search to it, "
@@ -1144,6 +1171,7 @@ public class ElasticsearchTemplateTests {
 		String documentId = randomNumeric(5);
 		SampleEntity sampleEntity = new SampleEntityBuilder(documentId)
 				.message("some message")
+				.type(TYPE_NAME)
 				.version(System.currentTimeMillis()).build();
 
 		IndexQuery indexQuery = getIndexQuery(sampleEntity);


### PR DESCRIPTION
This implements source filtering to allow control over what field(s) are returned in the _source field with every hit.

See https://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-request-source-filtering.html