### PR TITLE
Add support for IndicesOptions in search queries.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
@@ -913,6 +913,10 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, Applicati
 		SearchRequestBuilder searchRequestBuilder = client.prepareSearch(toArray(query.getIndices()))
 				.setSearchType(query.getSearchType()).setTypes(toArray(query.getTypes()));
 
+		if (query.getIndicesOptions() != null) {
+			searchRequestBuilder.setIndicesOptions(query.getIndicesOptions());
+		}
+
 		if (query.getPageable() != null) {
 			startRecord = query.getPageable().getPageNumber() * query.getPageable().getPageSize();
 			searchRequestBuilder.setSize(query.getPageable().getPageSize());

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/AbstractQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/AbstractQuery.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.util.Assert;
@@ -43,6 +44,7 @@ abstract class AbstractQuery implements Query {
 	protected Collection<String> ids;
 	protected String route;
 	protected SearchType searchType = SearchType.DFS_QUERY_THEN_FETCH;
+	protected IndicesOptions indicesOptions;
 
 	@Override
 	public Sort getSort() {
@@ -136,5 +138,13 @@ abstract class AbstractQuery implements Query {
 
 	public SearchType getSearchType() {
 		return searchType;
+	}
+
+	public IndicesOptions getIndicesOptions() {
+		return indicesOptions;
+	}
+
+	public void setIndicesOptions(IndicesOptions indicesOptions) {
+		this.indicesOptions = indicesOptions;
 	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/NativeSearchQueryBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/NativeSearchQueryBuilder.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.index.query.FilterBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
@@ -53,6 +54,7 @@ public class NativeSearchQueryBuilder {
 	private Collection<String> ids;
 	private String route;
 	private SearchType searchType;
+	private IndicesOptions indicesOptions;
 
 	public NativeSearchQueryBuilder withQuery(QueryBuilder queryBuilder) {
 		this.queryBuilder = queryBuilder;
@@ -124,6 +126,11 @@ public class NativeSearchQueryBuilder {
 		return this;
 	}
 
+	public NativeSearchQueryBuilder withIndicesOptions(IndicesOptions indicesOptions) {
+		this.indicesOptions = indicesOptions;
+		return this;
+	}
+
 	public NativeSearchQuery build() {
 		NativeSearchQuery nativeSearchQuery = new NativeSearchQuery(queryBuilder, filterBuilder, sortBuilders, highlightFields);
 		if (pageable != null) {
@@ -164,6 +171,10 @@ public class NativeSearchQueryBuilder {
 
 		if (searchType != null) {
 			nativeSearchQuery.setSearchType(searchType);
+		}
+
+		if (indicesOptions != null) {
+			nativeSearchQuery.setIndicesOptions(indicesOptions);
 		}
 
 		return nativeSearchQuery;

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/Query.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/Query.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -139,4 +140,11 @@ public interface Query {
 	 * @return
 	 */
 	SearchType getSearchType();
+
+	/**
+	 * Get indices options
+	 *
+	 * @return null if not set
+	 */
+	IndicesOptions getIndicesOptions();
 }


### PR DESCRIPTION
This is important for use cases where there's one index per day or one index per month for time-based data.  Let's say we have a daily index, like `logs-20150820`.  When we want to search a date range, we have to specify multiple indices to search.  To search logs from August 18 to August 20, we would need to search indices `logs-20150818`, `logs-20150819` and `logs-20150820`.  This works fine using `ElasticsearchTemplate` using

```
new NativeSearchQueryBuilder().withIndices("logs-20150818", "logs-20150819", "logs-20150820")
```

However, let's say that we had a problem on August 19th and no logs were indexed, so the index `logs-20150819` doesn't exist, but the other indices do.  Trying to do this search using `ElasticsearchTemplate` results in

```
org.elasticsearch.indices.IndexMissingException: [logs-20150819] missing
```

Elasticsearch has support for ignoring missing indices for this use case.  This is done by passing `IndicesOptions.lenientExpandOpen()` to `org.elasticsearch.action.search.SearchRequestBuilder.setIndicesOptions()`

IndicesOptions has other values as well.  This pull request adds support for passing arbitrary IndicesOptions values with the search query.
