### PR TITLE
Support field exclusion in _source.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/annotations/Field.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/Field.java
@@ -53,4 +53,7 @@ public @interface Field {
 	String[] ignoreFields() default {};
 
 	boolean includeInParent() default false;
+
+	boolean excludeFromSource() default false;
+
 }

--- a/src/test/java/org/springframework/data/elasticsearch/builder/SourceExcludedEntityBuilder.java
+++ b/src/test/java/org/springframework/data/elasticsearch/builder/SourceExcludedEntityBuilder.java
@@ -1,0 +1,36 @@
+package org.springframework.data.elasticsearch.builder;
+
+import org.springframework.data.elasticsearch.core.query.IndexQuery;
+import org.springframework.data.elasticsearch.entities.SourceExcludedEntity;
+
+public class SourceExcludedEntityBuilder {
+
+	private SourceExcludedEntity result;
+
+	public SourceExcludedEntityBuilder(String id) {
+		this.result = new SourceExcludedEntity();
+		this.result.setId(id);
+	}
+
+	public SourceExcludedEntityBuilder indexOnlyField(String value) {
+		this.result.setIndexOnlyField(value);
+		return this;
+	}
+
+	public SourceExcludedEntityBuilder simpleField(String value) {
+		this.result.setSimpleField(value);
+		return this;
+	}
+
+	public SourceExcludedEntity build() {
+		return result;
+	}
+
+	public IndexQuery buildIndex() {
+		IndexQuery indexQuery = new IndexQuery();
+		indexQuery.setId(result.getId());
+		indexQuery.setObject(result);
+		return indexQuery;
+	}
+
+}

--- a/src/test/java/org/springframework/data/elasticsearch/entities/SourceExcludedEntity.java
+++ b/src/test/java/org/springframework/data/elasticsearch/entities/SourceExcludedEntity.java
@@ -1,0 +1,44 @@
+package org.springframework.data.elasticsearch.entities;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+@Document(indexName = "test-source-exclusion", type = "mapping", indexStoreType = "memory", shards = 1, replicas = 0, refreshInterval = "-1")
+public class SourceExcludedEntity {
+
+	@Id
+	private String id;
+
+	@Field(type = FieldType.String, excludeFromSource = true)
+	private String indexOnlyField;
+
+	@Field(type = FieldType.String)
+	private String simpleField;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getIndexOnlyField() {
+		return indexOnlyField;
+	}
+
+	public void setIndexOnlyField(String indexOnlyField) {
+		this.indexOnlyField = indexOnlyField;
+	}
+
+	public String getSimpleField() {
+		return simpleField;
+	}
+
+	public void setSimpleField(String simpleField) {
+		this.simpleField = simpleField;
+	}
+
+}


### PR DESCRIPTION
Elasticsearch allows us to specify field level exclusions when creating a mapping. See: https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html#include-exclude

This functionality allows us to create a so called "indexed but not stored" kind of document field. The @Field annotation's existing store attribute is not equivalent with this.

Spring Data ES currently lacks this feature in the document annotations, It should be possible to enable it using a custom mapping configuration file however it would be more expressive to specify this on the @Field annotation directly.

This pull request implements the described functionality.
