### PR TITLE
DATAES-166: improve scroll implementation to support scroll without scan

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,12 @@
+<!--
+
 Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
 Make sure that:
+
+-->
 
 - [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
 - [ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
 - [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
 - [ ] You submit test cases (unit or integration tests) that back your changes.
 - [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
-- [ ] You provide your full name and an email address registered with your GitHub account. If you’re a first-time submitter, make sure you have completed the [Contributor’s License Agreement form](https://support.springsource.com/spring_committer_signup).

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Here are some ways for you to get involved in the community:
 * Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](http://help.github.com/forking/). If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
 * Watch for upcoming articles on Spring by [subscribing](http://www.springsource.org/node/feed) to springframework.org
 
-Before we accept a non-trivial patch or pull request we will need you to sign the [contributor's agreement](https://support.springsource.com/spring_committer_signup).  Signing the contributor's agreement does not grant anyone commit rights to the main repository, but it does mean that we can accept your contributions, and you will get an author credit if we do.  Active contributors might be asked to join the core team, and given the ability to merge pull requests.
+Before we accept a non-trivial patch or pull request we will need you to [sign the Contributor License Agreement](https://cla.pivotal.io/sign/spring). Signing the contributor’s agreement does not grant anyone commit rights to the main repository, but it does mean that we can accept your contributions, and you will get an author credit if we do. If you forget to do so, you'll be reminded when you submit a pull request. Active contributors might be asked to join the core team, and given the ability to merge pull requests.
 
 
 Code formatting for [Eclipse and Intellij](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide)

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.springframework.data.build</groupId>
         <artifactId>spring-data-parent</artifactId>
-        <version>1.9.0.BUILD-SNAPSHOT</version>
+        <version>1.9.0.RELEASE</version>
         <relativePath>../spring-data-build/parent/pom.xml</relativePath>
     </parent>
 
@@ -24,7 +24,7 @@
         <commonscollections>3.2.1</commonscollections>
         <commonslang>2.6</commonslang>
         <elasticsearch>2.4.0</elasticsearch>
-        <springdata.commons>1.13.0.BUILD-SNAPSHOT</springdata.commons>
+        <springdata.commons>1.13.0.RELEASE</springdata.commons>
 
     </properties>
 
@@ -176,8 +176,8 @@
 
     <repositories>
         <repository>
-            <id>spring-libs-snapshot</id>
-            <url>https://repo.spring.io/libs-snapshot</url>
+            <id>spring-libs-release</id>
+            <url>https://repo.spring.io/libs-release</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.springframework.data.build</groupId>
         <artifactId>spring-data-parent</artifactId>
-        <version>1.9.0.RELEASE</version>
+        <version>1.10.0.BUILD-SNAPSHOT</version>
         <relativePath>../spring-data-build/parent/pom.xml</relativePath>
     </parent>
 
@@ -24,7 +24,7 @@
         <commonscollections>3.2.1</commonscollections>
         <commonslang>2.6</commonslang>
         <elasticsearch>2.4.0</elasticsearch>
-        <springdata.commons>1.13.0.RELEASE</springdata.commons>
+        <springdata.commons>1.14.0.BUILD-SNAPSHOT</springdata.commons>
 
     </properties>
 
@@ -176,8 +176,8 @@
 
     <repositories>
         <repository>
-            <id>spring-libs-release</id>
-            <url>https://repo.spring.io/libs-release</url>
+            <id>spring-libs-snapshot</id>
+            <url>https://repo.spring.io/libs-snapshot</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.springframework.data</groupId>
     <artifactId>spring-data-elasticsearch</artifactId>
-    <version>2.1.0.BUILD-SNAPSHOT</version>
+    <version>2.1.0.RELEASE</version>
 
     <parent>
         <groupId>org.springframework.data.build</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.springframework.data</groupId>
     <artifactId>spring-data-elasticsearch</artifactId>
-    <version>2.1.0.BUILD-SNAPSHOT</version>
+    <version>2.1.0.RC1</version>
 
     <parent>
         <groupId>org.springframework.data.build</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.springframework.data</groupId>
     <artifactId>spring-data-elasticsearch</artifactId>
-    <version>2.1.0.RELEASE</version>
+    <version>2.2.0.BUILD-SNAPSHOT</version>
 
     <parent>
         <groupId>org.springframework.data.build</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.springframework.data.build</groupId>
         <artifactId>spring-data-parent</artifactId>
-        <version>1.9.0.RC1</version>
+        <version>1.9.0.BUILD-SNAPSHOT</version>
         <relativePath>../spring-data-build/parent/pom.xml</relativePath>
     </parent>
 
@@ -24,7 +24,7 @@
         <commonscollections>3.2.1</commonscollections>
         <commonslang>2.6</commonslang>
         <elasticsearch>2.4.0</elasticsearch>
-        <springdata.commons>1.13.0.RC1</springdata.commons>
+        <springdata.commons>1.13.0.BUILD-SNAPSHOT</springdata.commons>
 
     </properties>
 
@@ -176,8 +176,8 @@
 
     <repositories>
         <repository>
-            <id>spring-libs-milestone</id>
-            <url>https://repo.spring.io/libs-milestone</url>
+            <id>spring-libs-snapshot</id>
+            <url>https://repo.spring.io/libs-snapshot</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.springframework.data</groupId>
     <artifactId>spring-data-elasticsearch</artifactId>
-    <version>2.1.0.RC1</version>
+    <version>2.1.0.BUILD-SNAPSHOT</version>
 
     <parent>
         <groupId>org.springframework.data.build</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.springframework.data.build</groupId>
         <artifactId>spring-data-parent</artifactId>
-        <version>1.9.0.BUILD-SNAPSHOT</version>
+        <version>1.9.0.RC1</version>
         <relativePath>../spring-data-build/parent/pom.xml</relativePath>
     </parent>
 
@@ -24,7 +24,7 @@
         <commonscollections>3.2.1</commonscollections>
         <commonslang>2.6</commonslang>
         <elasticsearch>2.4.0</elasticsearch>
-        <springdata.commons>1.13.0.BUILD-SNAPSHOT</springdata.commons>
+        <springdata.commons>1.13.0.RC1</springdata.commons>
 
     </properties>
 
@@ -176,8 +176,8 @@
 
     <repositories>
         <repository>
-            <id>spring-libs-snapshot</id>
-            <url>https://repo.spring.io/libs-snapshot</url>
+            <id>spring-libs-milestone</id>
+            <url>https://repo.spring.io/libs-milestone</url>
         </repository>
     </repositories>
 

--- a/src/main/java/org/springframework/data/elasticsearch/core/DefaultResultMapper.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/DefaultResultMapper.java
@@ -38,8 +38,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.ElasticsearchException;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.ScriptedField;
-import org.springframework.data.elasticsearch.core.aggregation.AggregatedPage;
-import org.springframework.data.elasticsearch.core.aggregation.impl.AggregatedPageImpl;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentEntity;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentProperty;
 import org.springframework.data.mapping.PersistentProperty;
@@ -50,6 +48,7 @@ import org.springframework.data.mapping.context.MappingContext;
  * @author Petar Tahchiev
  * @author Young Gu
  * @author Oliver Gierke
+ * @author Sascha Woo
  */
 public class DefaultResultMapper extends AbstractResultMapper {
 
@@ -76,7 +75,7 @@ public class DefaultResultMapper extends AbstractResultMapper {
 	}
 
 	@Override
-	public <T> AggregatedPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
+	public <T> ScrollPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
 		long totalHits = response.getHits().totalHits();
 		List<T> results = new ArrayList<T>();
 		for (SearchHit hit : response.getHits()) {
@@ -93,7 +92,7 @@ public class DefaultResultMapper extends AbstractResultMapper {
 			}
 		}
 
-		return new AggregatedPageImpl<T>(results, pageable, totalHits, response.getAggregations());
+		return new ScrollPageImpl<T>(results, pageable, totalHits, response.getAggregations(), response.getScrollId());
 	}
 
 	private <T> void populateScriptFields(T result, SearchHit hit) {

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchOperations.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchOperations.java
@@ -34,6 +34,7 @@ import java.util.Map;
  * @author Rizwan Idrees
  * @author Mohsin Husen
  * @author Kevin Leturc
+ * @author Sascha Woo
  */
 public interface ElasticsearchOperations {
 
@@ -532,6 +533,50 @@ public interface ElasticsearchOperations {
 	<T> String scan(SearchQuery query, long scrollTimeInMillis, boolean noFields, Class<T> clazz);
 
 	/**
+	 * Starts scroll the results for the given query
+	 *
+	 * @param query
+	 * @param scrollTimeInMillis
+	 * @param noFields
+	 * @param clazz
+	 * @return The page including the scroll id
+	 */
+	<T> ScrollPage<T> scroll(CriteriaQuery query, long scrollTimeInMillis, boolean noFields, Class<T> clazz);
+
+	/**
+	 * Starts scroll the results for the given query
+	 *
+	 * @param query
+	 * @param scrollTimeInMillis
+	 * @param noFields
+	 * @param clazz
+	 * @return The page including the scroll id
+	 */
+	<T> ScrollPage<T> scroll(SearchQuery query, long scrollTimeInMillis, boolean noFields, Class<T> clazz);
+
+	/**
+	 * Starts scroll the results for the given query
+	 *
+	 * @param query
+	 * @param scrollTimeInMillis
+	 * @param noFields
+	 * @param mapper
+	 * @return The page including the scroll id
+	 */
+	<T> ScrollPage<T> scroll(CriteriaQuery query, long scrollTimeInMillis, boolean noFields, SearchResultMapper mapper);
+
+	/**
+	 * Starts scroll the results for the given query
+	 *
+	 * @param query
+	 * @param scrollTimeInMillis
+	 * @param noFields
+	 * @param mapper
+	 * @return The page including the scroll id
+	 */
+	<T> ScrollPage<T> scroll(SearchQuery query, long scrollTimeInMillis, boolean noFields, SearchResultMapper mapper);
+
+	/**
 	 * Scrolls the results for give scroll id
 	 *
 	 * @param scrollId
@@ -540,7 +585,7 @@ public interface ElasticsearchOperations {
 	 * @param <T>
 	 * @return
 	 */
-	<T> Page<T> scroll(String scrollId, long scrollTimeInMillis, Class<T> clazz);
+	<T> ScrollPage<T> scroll(String scrollId, long scrollTimeInMillis, Class<T> clazz);
 
 	/**
 	 * Scrolls the results for give scroll id using custom result mapper
@@ -551,7 +596,7 @@ public interface ElasticsearchOperations {
 	 * @param <T>
 	 * @return
 	 */
-	<T> Page<T> scroll(String scrollId, long scrollTimeInMillis, SearchResultMapper mapper);
+	<T> ScrollPage<T> scroll(String scrollId, long scrollTimeInMillis, SearchResultMapper mapper);
 
 	/**
 	 * Clears the search contexts associated with specified scroll ids.

--- a/src/main/java/org/springframework/data/elasticsearch/core/MappingBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/MappingBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.springframework.core.GenericCollectionTypeResolver;
+import org.springframework.core.ResolvableType;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.annotation.Transient;
 import org.springframework.data.elasticsearch.annotations.*;
@@ -47,8 +47,8 @@ import org.springframework.data.util.TypeInformation;
  * @author Alexander Volz
  * @author Dennis Maaß
  * @author Pavel Luhin
+ * @author Mark Paluch
  */
-
 class MappingBuilder {
 
 	public static final String FIELD_STORE = "store";
@@ -315,12 +315,20 @@ class MappingBuilder {
 	}
 
 	protected static Class<?> getFieldType(java.lang.reflect.Field field) {
-		Class<?> clazz = field.getType();
-		TypeInformation typeInformation = ClassTypeInformation.from(clazz);
-		if (typeInformation.isCollectionLike()) {
-			clazz = GenericCollectionTypeResolver.getCollectionFieldType(field) != null ? GenericCollectionTypeResolver.getCollectionFieldType(field) : typeInformation.getComponentType().getType();
+
+		ResolvableType resolvableType = ResolvableType.forField(field);
+
+		if (resolvableType.isArray()) {
+			return resolvableType.getComponentType().getRawClass();
 		}
-		return clazz;
+
+		ResolvableType componentType = resolvableType.getGeneric(0);
+		if (Iterable.class.isAssignableFrom(field.getType())
+				&& componentType != ResolvableType.NONE) {
+			return componentType.getRawClass();
+		}
+
+		return resolvableType.getRawClass();
 	}
 
 	private static boolean isAnyPropertyAnnotatedAsField(java.lang.reflect.Field[] fields) {

--- a/src/main/java/org/springframework/data/elasticsearch/core/ScrollPage.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ScrollPage.java
@@ -15,15 +15,12 @@
  */
 package org.springframework.data.elasticsearch.core;
 
-import org.elasticsearch.action.search.SearchResponse;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.aggregation.AggregatedPage;
 
 /**
- * @author Artur Konczak
- * @author Petar Tahchiev
  * @author Sascha Woo
  */
-public interface SearchResultMapper {
+public interface ScrollPage<T> extends AggregatedPage<T> {
 
-	<T> ScrollPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable);
+	String getScrollId();
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/ScrollPageImpl.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ScrollPageImpl.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core;
+
+import java.util.List;
+
+import org.elasticsearch.search.aggregations.Aggregations;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.aggregation.impl.AggregatedPageImpl;
+
+/**
+ * Container for scroll results
+ *
+ * @author Sascha Woo
+ */
+public class ScrollPageImpl<T> extends AggregatedPageImpl<T> implements ScrollPage<T> {
+
+	private final String scrollId;
+
+	public ScrollPageImpl(List<T> content, Pageable pageable, long total, Aggregations aggregations, String scrollId) {
+		super(content, pageable, total, aggregations);
+		this.scrollId = scrollId;
+	}
+
+	public ScrollPageImpl(List<T> content, Pageable pageable, long total, String scrollId) {
+		super(content, pageable, total);
+		this.scrollId = scrollId;
+	}
+
+	public ScrollPageImpl(List<T> content, String scrollId) {
+		super(content);
+		this.scrollId = scrollId;
+	}
+
+	@Override
+	public String getScrollId() {
+		return scrollId;
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/convert/MappingElasticsearchConverter.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/convert/MappingElasticsearchConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,8 +31,8 @@ import org.springframework.util.Assert;
  *
  * @author Rizwan Idrees
  * @author Mohsin Husen
+ * @author Mark Paluch
  */
-
 public class MappingElasticsearchConverter implements ElasticsearchConverter, ApplicationContextAware {
 
 	private final MappingContext<? extends ElasticsearchPersistentEntity<?>, ElasticsearchPersistentProperty> mappingContext;
@@ -43,7 +43,9 @@ public class MappingElasticsearchConverter implements ElasticsearchConverter, Ap
 
 	public MappingElasticsearchConverter(
 			MappingContext<? extends ElasticsearchPersistentEntity<?>, ElasticsearchPersistentProperty> mappingContext) {
-		Assert.notNull(mappingContext);
+		
+		Assert.notNull(mappingContext, "MappingContext must not be null!");
+		
 		this.mappingContext = mappingContext;
 		this.conversionService = new DefaultConversionService();
 	}

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/AbstractQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/AbstractQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.util.Assert;
  *
  * @author Rizwan Idrees
  * @author Mohsin Husen
+ * @author Mark Paluch
  */
 abstract class AbstractQuery implements Query {
 
@@ -55,7 +56,9 @@ abstract class AbstractQuery implements Query {
 
 	@Override
 	public final <T extends Query> T setPageable(Pageable pageable) {
-		Assert.notNull(pageable);
+		
+		Assert.notNull(pageable, "Pageable must not be null!");
+		
 		this.pageable = pageable;
 		return (T) this.addSort(pageable.getSort());
 	}

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/AbstractElasticsearchRepository.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/AbstractElasticsearchRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import org.springframework.util.Assert;
  * @author Mohsin Husen
  * @author Ryan Henszey
  * @author Kevin Leturc
+ * @author Mark Paluch
  */
 public abstract class AbstractElasticsearchRepository<T, ID extends Serializable> implements
 		ElasticsearchRepository<T, ID> {
@@ -56,14 +57,18 @@ public abstract class AbstractElasticsearchRepository<T, ID extends Serializable
 	}
 
 	public AbstractElasticsearchRepository(ElasticsearchOperations elasticsearchOperations) {
-		Assert.notNull(elasticsearchOperations);
+		
+		Assert.notNull(elasticsearchOperations, "ElasticsearchOperations must not be null!");
+		
 		this.setElasticsearchOperations(elasticsearchOperations);
 	}
 
 	public AbstractElasticsearchRepository(ElasticsearchEntityInformation<T, ID> metadata,
 										   ElasticsearchOperations elasticsearchOperations) {
 		this(elasticsearchOperations);
-		Assert.notNull(metadata);
+		
+		Assert.notNull(metadata, "ElasticsearchEntityInformation must not be null!");
+		
 		this.entityInformation = metadata;
 		setEntityClass(this.entityInformation.getJavaType());
 		try {

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchEntityInformationCreatorImpl.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchEntityInformationCreatorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.util.Assert;
  * @author Rizwan Idrees
  * @author Mohsin Husen
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 public class ElasticsearchEntityInformationCreatorImpl implements ElasticsearchEntityInformationCreator {
 
@@ -35,7 +36,9 @@ public class ElasticsearchEntityInformationCreatorImpl implements ElasticsearchE
 
 	public ElasticsearchEntityInformationCreatorImpl(
 			MappingContext<? extends ElasticsearchPersistentEntity<?>, ElasticsearchPersistentProperty> mappingContext) {
-		Assert.notNull(mappingContext);
+		
+		Assert.notNull(mappingContext, "MappingContext must not be null!");
+		
 		this.mappingContext = mappingContext;
 	}
 

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchRepositoryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import org.springframework.util.Assert;
  * @author Mohsin Husen
  * @author Ryan Henszey
  * @author Gad Akuka
+ * @author Mark Paluch
  */
 public class ElasticsearchRepositoryFactory extends RepositoryFactorySupport {
 
@@ -50,7 +51,9 @@ public class ElasticsearchRepositoryFactory extends RepositoryFactorySupport {
 	private final ElasticsearchEntityInformationCreator entityInformationCreator;
 
 	public ElasticsearchRepositoryFactory(ElasticsearchOperations elasticsearchOperations) {
-		Assert.notNull(elasticsearchOperations);
+		
+		Assert.notNull(elasticsearchOperations, "ElasticsearchOperations must not be null!");
+		
 		this.elasticsearchOperations = elasticsearchOperations;
 		this.entityInformationCreator = new ElasticsearchEntityInformationCreatorImpl(elasticsearchOperations
 				.getElasticsearchConverter().getMappingContext());

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchRepositoryFactoryBean.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchRepositoryFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.util.Assert;
  *
  * @author Rizwan Idrees
  * @author Mohsin Husen
+ * @author Mark Paluch
  */
 public class ElasticsearchRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extends Serializable> extends
 		RepositoryFactoryBeanSupport<T, S, ID> {
@@ -50,7 +51,9 @@ public class ElasticsearchRepositoryFactoryBean<T extends Repository<S, ID>, S, 
 	 * @param operations the operations to set
 	 */
 	public void setElasticsearchOperations(ElasticsearchOperations operations) {
-		Assert.notNull(operations);
+		
+		Assert.notNull(operations, "ElasticsearchOperations must not be null!");
+		
 		setMappingContext(operations.getElasticsearchConverter().getMappingContext());
 		this.operations = operations;
 	}

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchRepositoryFactoryBean.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchRepositoryFactoryBean.java
@@ -36,6 +36,15 @@ public class ElasticsearchRepositoryFactoryBean<T extends Repository<S, ID>, S, 
 	private ElasticsearchOperations operations;
 
 	/**
+	 * Creates a new {@link ElasticsearchRepositoryFactoryBean} for the given repository interface.
+	 * 
+	 * @param repositoryInterface must not be {@literal null}.
+	 */
+	public ElasticsearchRepositoryFactoryBean(Class<? extends T> repositoryInterface) {
+		super(repositoryInterface);
+	}
+
+	/**
 	 * Configures the {@link ElasticsearchOperations} to be used to create Elasticsearch repositories.
 	 *
 	 * @param operations the operations to set

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.data.repository.core.support.RepositoryFactorySupport=org.springframework.data.elasticsearch.repository.support.ElasticsearchRepositoryFactory

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,6 +1,11 @@
 Spring Data Elasticsearch Changelog
 ===================================
 
+Changes in version 2.0.6.RELEASE (2016-12-21)
+---------------------------------------------
+* DATAES-304 - Release 2.0.6 (Hopper SR6).
+
+
 Changes in version 2.1.0.RC1 (2016-12-21)
 -----------------------------------------
 * DATAES-315 - Adapt API in RepositoryFactoryBeanSupport implementation.

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,6 +1,11 @@
 Spring Data Elasticsearch Changelog
 ===================================
 
+Changes in version 2.0.7.RELEASE (2017-01-26)
+---------------------------------------------
+* DATAES-319 - Release 2.0.7 (Hopper SR7).
+
+
 Changes in version 2.1.0.RELEASE (2017-01-26)
 ---------------------------------------------
 * DATAES-322 - Update project documentation with the CLA tool integration.

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,6 +1,12 @@
 Spring Data Elasticsearch Changelog
 ===================================
 
+Changes in version 3.0.0.M1 (2016-11-23)
+----------------------------------------
+* DATAES-307 - Set up 3.0 development.
+* DATAES-306 - Release 3.0 M1 (Kay).
+
+
 Changes in version 2.0.5.RELEASE (2016-11-03)
 ---------------------------------------------
 * DATAES-300 - Release 2.0.5 (Hopper SR5).

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,6 +1,12 @@
 Spring Data Elasticsearch Changelog
 ===================================
 
+Changes in version 2.1.0.RELEASE (2017-01-26)
+---------------------------------------------
+* DATAES-322 - Update project documentation with the CLA tool integration.
+* DATAES-320 - Release 2.1 GA (Ingalls).
+
+
 Changes in version 2.0.6.RELEASE (2016-12-21)
 ---------------------------------------------
 * DATAES-304 - Release 2.0.6 (Hopper SR6).

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,6 +1,13 @@
 Spring Data Elasticsearch Changelog
 ===================================
 
+Changes in version 2.1.1.RELEASE (2017-03-02)
+---------------------------------------------
+* DATAES-329 - Remove references to single-argument assertion methods of Spring.
+* DATAES-327 - Release 2.1.1 (Ingalls SR1).
+* DATAES-325 - Remove references to GenericCollectionTypeResolver in favor of ResolvableType.
+
+
 Changes in version 2.0.7.RELEASE (2017-01-26)
 ---------------------------------------------
 * DATAES-319 - Release 2.0.7 (Hopper SR7).

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,6 +1,16 @@
 Spring Data Elasticsearch Changelog
 ===================================
 
+Changes in version 2.1.0.RC1 (2016-12-21)
+-----------------------------------------
+* DATAES-315 - Adapt API in RepositoryFactoryBeanSupport implementation.
+* DATAES-313 - Register repository factory in spring.factories for multi-store support.
+* DATAES-289 - Upgrade to Elasticsearch 2.4.
+* DATAES-284 - Downgrade to Jackson 2.7.5 until Elasticsearch is compatible with 2.8.
+* DATAES-281 - Can't save entity without id setter.
+* DATAES-275 - Release 2.1 RC1 (Ingalls).
+
+
 Changes in version 3.0.0.M1 (2016-11-23)
 ----------------------------------------
 * DATAES-307 - Set up 3.0 development.

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data Elasticsearch 2.1 RC1
+Spring Data Elasticsearch 2.1 GA
 Copyright (c) [2013-2016] Pivotal Software, Inc.
 
 This product is licensed to you under the Apache License, Version 2.0 (the "License").

--- a/src/main/resources/notice.txt
+++ b/src/main/resources/notice.txt
@@ -1,4 +1,4 @@
-Spring Data Elasticsearch 2.1 M1
+Spring Data Elasticsearch 2.1 RC1
 Copyright (c) [2013-2016] Pivotal Software, Inc.
 
 This product is licensed to you under the Apache License, Version 2.0 (the "License").

--- a/src/test/java/org/springframework/data/elasticsearch/core/CustomResultMapper.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/CustomResultMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.data.elasticsearch.core.aggregation.AggregatedPage;
 /**
  * @author Artur Konczak
  * @author Mohsin Husen
+ * @author Sascha Woo
  */
 public class CustomResultMapper implements ResultsMapper {
 
@@ -48,7 +49,7 @@ public class CustomResultMapper implements ResultsMapper {
 	}
 
 	@Override
-	public <T> AggregatedPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
+	public <T> ScrollPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
 		return null;  //To change body of implemented methods use File | Settings | File Templates.
 	}
 
@@ -56,4 +57,5 @@ public class CustomResultMapper implements ResultsMapper {
 	public <T> LinkedList<T> mapResults(MultiGetResponse responses, Class<T> clazz) {
 		return null;
 	}
+
 }

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
@@ -62,6 +62,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Abdul Mohammed
  * @author Kevin Leturc
  * @author Mason Chan
+ * @author Sascha Woo
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("classpath:elasticsearch-template-test.xml")
@@ -637,12 +638,12 @@ public class ElasticsearchTemplateTests {
 		// when
 		Page<String> page = elasticsearchTemplate.queryForPage(searchQuery, String.class, new SearchResultMapper() {
 			@Override
-			public <T> AggregatedPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
+			public <T> ScrollPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
 				List<String> values = new ArrayList<String>();
 				for (SearchHit searchHit : response.getHits()) {
 					values.add((String) searchHit.field("message").value());
 				}
-				return new AggregatedPageImpl<T>((List<T>) values);
+				return new ScrollPageImpl<T>((List<T>) values, response.getScrollId());
 			}
 		});
 		// then
@@ -734,8 +735,9 @@ public class ElasticsearchTemplateTests {
 		List<SampleEntity> sampleEntities = new ArrayList<SampleEntity>();
 		boolean hasRecords = true;
 		while (hasRecords) {
-			Page<SampleEntity> page = elasticsearchTemplate.scroll(scrollId, 5000L, SampleEntity.class);
+			ScrollPage<SampleEntity> page = elasticsearchTemplate.scroll(scrollId, 5000L, SampleEntity.class);
 			if (page.hasContent()) {
+				scrollId = page.getScrollId();
 				sampleEntities.addAll(page.getContent());
 			} else {
 				hasRecords = false;
@@ -761,8 +763,9 @@ public class ElasticsearchTemplateTests {
 		List<SampleEntity> sampleEntities = new ArrayList<SampleEntity>();
 		boolean hasRecords = true;
 		while (hasRecords) {
-			Page<SampleEntity> page = elasticsearchTemplate.scroll(scrollId, 5000L, SampleEntity.class);
+			ScrollPage<SampleEntity> page = elasticsearchTemplate.scroll(scrollId, 5000L, SampleEntity.class);
 			if (page.hasContent()) {
+				scrollId = page.getScrollId();
 				sampleEntities.addAll(page.getContent());
 			} else {
 				hasRecords = false;
@@ -794,9 +797,9 @@ public class ElasticsearchTemplateTests {
 		List<SampleEntity> sampleEntities = new ArrayList<SampleEntity>();
 		boolean hasRecords = true;
 		while (hasRecords) {
-			Page<SampleEntity> page = elasticsearchTemplate.scroll(scrollId, 5000L, new SearchResultMapper() {
+			ScrollPage<SampleEntity> page = elasticsearchTemplate.scroll(scrollId, 5000L, new SearchResultMapper() {
 				@Override
-				public <T> AggregatedPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
+				public <T> ScrollPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
 					List<SampleEntity> result = new ArrayList<SampleEntity>();
 					for (SearchHit searchHit : response.getHits()) {
 						String message = searchHit.getFields().get("message").getValue();
@@ -807,12 +810,13 @@ public class ElasticsearchTemplateTests {
 					}
 
 					if (result.size() > 0) {
-						return new AggregatedPageImpl<T>((List<T>) result);
+						return new ScrollPageImpl((List<T>) result, response.getScrollId());
 					}
 					return null;
 				}
 			});
 			if (page != null) {
+				scrollId = page.getScrollId();
 				sampleEntities.addAll(page.getContent());
 			} else {
 				hasRecords = false;
@@ -846,9 +850,9 @@ public class ElasticsearchTemplateTests {
 		List<SampleEntity> sampleEntities = new ArrayList<SampleEntity>();
 		boolean hasRecords = true;
 		while (hasRecords) {
-			Page<SampleEntity> page = elasticsearchTemplate.scroll(scrollId, 10000L, new SearchResultMapper() {
+			ScrollPage<SampleEntity> page = elasticsearchTemplate.scroll(scrollId, 10000L, new SearchResultMapper() {
 				@Override
-				public <T> AggregatedPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
+				public <T> ScrollPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
 					List<SampleEntity> result = new ArrayList<SampleEntity>();
 					for (SearchHit searchHit : response.getHits()) {
 						String message = searchHit.getFields().get("message").getValue();
@@ -859,12 +863,13 @@ public class ElasticsearchTemplateTests {
 					}
 
 					if (result.size() > 0) {
-						return new AggregatedPageImpl<T>((List<T>) result);
+						return new ScrollPageImpl<T>((List<T>) result, response.getScrollId());
 					}
 					return null;
 				}
 			});
 			if (page != null) {
+				scrollId = page.getScrollId();
 				sampleEntities.addAll(page.getContent());
 			} else {
 				hasRecords = false;
@@ -895,9 +900,9 @@ public class ElasticsearchTemplateTests {
 		List<SampleEntity> sampleEntities = new ArrayList<SampleEntity>();
 		boolean hasRecords = true;
 		while (hasRecords) {
-			Page<SampleEntity> page = elasticsearchTemplate.scroll(scrollId, 5000L, new SearchResultMapper() {
+			ScrollPage<SampleEntity> page = elasticsearchTemplate.scroll(scrollId, 5000L, new ScrollResultMapper() {
 				@Override
-				public <T> AggregatedPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
+				public <T> ScrollPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
 					List<SampleEntity> chunk = new ArrayList<SampleEntity>();
 					for (SearchHit searchHit : response.getHits()) {
 						if (response.getHits().getHits().length <= 0) {
@@ -909,12 +914,13 @@ public class ElasticsearchTemplateTests {
 						chunk.add(user);
 					}
 					if (chunk.size() > 0) {
-						return new AggregatedPageImpl<T>((List<T>) chunk);
+						return new ScrollPageImpl<T>((List<T>) chunk, response.getScrollId());
 					}
 					return null;
 				}
 			});
 			if (page != null) {
+				scrollId = page.getScrollId();
 				sampleEntities.addAll(page.getContent());
 			} else {
 				hasRecords = false;
@@ -940,9 +946,9 @@ public class ElasticsearchTemplateTests {
 		List<SampleEntity> sampleEntities = new ArrayList<SampleEntity>();
 		boolean hasRecords = true;
 		while (hasRecords) {
-			Page<SampleEntity> page = elasticsearchTemplate.scroll(scrollId, 5000L, new SearchResultMapper() {
+			ScrollPage<SampleEntity> page = elasticsearchTemplate.scroll(scrollId, 5000L, new SearchResultMapper() {
 				@Override
-				public <T> AggregatedPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
+				public <T> ScrollPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
 					List<SampleEntity> chunk = new ArrayList<SampleEntity>();
 					for (SearchHit searchHit : response.getHits()) {
 						if (response.getHits().getHits().length <= 0) {
@@ -954,12 +960,13 @@ public class ElasticsearchTemplateTests {
 						chunk.add(user);
 					}
 					if (chunk.size() > 0) {
-						return new AggregatedPageImpl<T>((List<T>) chunk);
+						return new ScrollPageImpl<T>((List<T>) chunk, response.getScrollId());
 					}
 					return null;
 				}
 			});
 			if (page != null) {
+				scrollId = page.getScrollId();
 				sampleEntities.addAll(page.getContent());
 			} else {
 				hasRecords = false;
@@ -1248,7 +1255,7 @@ public class ElasticsearchTemplateTests {
 
 		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class, new SearchResultMapper() {
 			@Override
-			public <T> AggregatedPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
+			public <T> ScrollPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
 				List<SampleEntity> chunk = new ArrayList<SampleEntity>();
 				for (SearchHit searchHit : response.getHits()) {
 					if (response.getHits().getHits().length <= 0) {
@@ -1261,7 +1268,7 @@ public class ElasticsearchTemplateTests {
 					chunk.add(user);
 				}
 				if (chunk.size() > 0) {
-					return new AggregatedPageImpl<T>((List<T>) chunk);
+					return new ScrollPageImpl<T>((List<T>) chunk, response.getScrollId());
 				}
 				return null;
 			}
@@ -1315,7 +1322,7 @@ public class ElasticsearchTemplateTests {
 		// then
 		Page<SampleEntity> page = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class, new SearchResultMapper() {
 			@Override
-			public <T> AggregatedPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
+			public <T> ScrollPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
 				List<SampleEntity> values = new ArrayList<SampleEntity>();
 				for (SearchHit searchHit : response.getHits()) {
 					SampleEntity sampleEntity = new SampleEntity();
@@ -1323,7 +1330,7 @@ public class ElasticsearchTemplateTests {
 					sampleEntity.setMessage((String) searchHit.getSource().get("message"));
 					values.add(sampleEntity);
 				}
-				return new AggregatedPageImpl<T>((List<T>) values);
+				return new ScrollPageImpl<T>((List<T>) values, response.getScrollId());
 			}
 		});
 		assertThat(page, is(notNullValue()));
@@ -1485,7 +1492,7 @@ public class ElasticsearchTemplateTests {
 				.withTypes(TYPE_NAME).withQuery(matchAllQuery()).build();
 		Page<Map> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, Map.class, new SearchResultMapper() {
 			@Override
-			public <T> AggregatedPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
+			public <T> ScrollPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
 				List<Map> chunk = new ArrayList<Map>();
 				for (SearchHit searchHit : response.getHits()) {
 					if (response.getHits().getHits().length <= 0) {
@@ -1500,7 +1507,7 @@ public class ElasticsearchTemplateTests {
 					chunk.add(person);
 				}
 				if (chunk.size() > 0) {
-					return new AggregatedPageImpl<T>((List<T>) chunk);
+					return new ScrollPageImpl<T>((List<T>) chunk, response.getScrollId());
 				}
 				return null;
 			}
@@ -1999,7 +2006,7 @@ public class ElasticsearchTemplateTests {
 		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).withTypes("hetro").withIndices(INDEX_1_NAME, INDEX_2_NAME).build();
 		Page<ResultAggregator> page = elasticsearchTemplate.queryForPage(searchQuery, ResultAggregator.class, new SearchResultMapper() {
 			@Override
-			public <T> AggregatedPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
+			public <T> ScrollPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
 				List<ResultAggregator> values = new ArrayList<ResultAggregator>();
 				for (SearchHit searchHit : response.getHits()) {
 					String id = String.valueOf(searchHit.getSource().get("id"));
@@ -2007,7 +2014,7 @@ public class ElasticsearchTemplateTests {
 					String lastName = StringUtils.isNotEmpty((String) searchHit.getSource().get("lastName")) ? (String) searchHit.getSource().get("lastName") : "";
 					values.add(new ResultAggregator(id, firstName, lastName));
 				}
-				return new AggregatedPageImpl<T>((List<T>) values);
+				return new ScrollPageImpl<T>((List<T>) values, response.getScrollId());
 			}
 		});
 


### PR DESCRIPTION
This PR improves the scroll implementation to support scrolling without the search type "scan". It adds a new `ScrollPage` interface to include the `scrollId`, because the initial search request and each subsequent scroll request returns a new scroll id and only the most recent scroll id should be used.

For more details see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html
