### PR TITLE
Typo in error message

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/query/Criteria.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/Criteria.java
@@ -485,7 +485,7 @@ public class Criteria {
 	private void assertNoBlankInWildcardedQuery(String searchString, boolean leadingWildcard, boolean trailingWildcard) {
 		if (StringUtils.contains(searchString, CRITERIA_VALUE_SEPERATOR)) {
 			throw new InvalidDataAccessApiUsageException("Cannot constructQuery '" + (leadingWildcard ? "*" : "") + "\""
-					+ searchString + "\"" + (trailingWildcard ? "*" : "") + "'. Use epxression or mulitple clauses instead.");
+					+ searchString + "\"" + (trailingWildcard ? "*" : "") + "'. Use expression or multiple clauses instead.");
 		}
 	}
 


### PR DESCRIPTION
The message is
`Use epxression or mulitple clauses instead.`
instead of :
`Use expression or multiple clauses instead.`