### PR TITLE
Improvements for the ElasticsearchRepository

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/repository/ElasticsearchRepository.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/ElasticsearchRepository.java
@@ -40,6 +40,10 @@ public interface ElasticsearchRepository<T, ID extends Serializable> extends Ela
 
 	<S extends T> S index(S entity);
 
+	void refresh();
+
+	void refresh(boolean waitForOperation);
+
 	Iterable<T> search(QueryBuilder query);
 
 	FacetedPage<T> search(QueryBuilder query, Pageable pageable);

--- a/src/main/java/org/springframework/data/elasticsearch/repository/ElasticsearchRepository.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/ElasticsearchRepository.java
@@ -16,6 +16,7 @@
 package org.springframework.data.elasticsearch.repository;
 
 import java.io.Serializable;
+import java.util.List;
 
 import org.elasticsearch.index.query.QueryBuilder;
 import org.springframework.data.domain.Page;
@@ -32,6 +33,10 @@ import org.springframework.data.repository.NoRepositoryBean;
  */
 @NoRepositoryBean
 public interface ElasticsearchRepository<T, ID extends Serializable> extends ElasticsearchCrudRepository<T, ID> {
+
+	<S extends T> List<S> index(List<S> entities);
+
+	<S extends T> Iterable<S> index(Iterable<S> entities);
 
 	<S extends T> S index(S entity);
 

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/AbstractElasticsearchRepository.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/AbstractElasticsearchRepository.java
@@ -144,13 +144,13 @@ public abstract class AbstractElasticsearchRepository<T, ID extends Serializable
 	@Override
 	public <S extends T> S save(S entity) {
 		entity = index(entity);
-		elasticsearchOperations.refresh(entityInformation.getIndexName(), true);
+		refresh();
 		return entity;
 	}
 
 	public <S extends T> List<S> save(List<S> entities) {
 		entities = index(entities);
-		elasticsearchOperations.refresh(entityInformation.getIndexName(), true);
+		refresh();
 		return entities;
 	}
 
@@ -188,9 +188,19 @@ public abstract class AbstractElasticsearchRepository<T, ID extends Serializable
 	}
 
 	@Override
+	public void refresh() {
+		refresh(true);
+	}
+
+	@Override
+	public void refresh(boolean waitForOperation) {
+		elasticsearchOperations.refresh(entityInformation.getIndexName(), waitForOperation);
+	}
+
+	@Override
 	public <S extends T> Iterable<S> save(Iterable<S> entities) {
 		entities = index(entities);
-		elasticsearchOperations.refresh(entityInformation.getIndexName(), true);
+		refresh();
 		return entities;
 	}
 
@@ -239,14 +249,14 @@ public abstract class AbstractElasticsearchRepository<T, ID extends Serializable
 		Assert.notNull(id, "Cannot delete entity with id 'null'.");
 		elasticsearchOperations.delete(entityInformation.getIndexName(), entityInformation.getType(),
 				stringIdRepresentation(id));
-		elasticsearchOperations.refresh(entityInformation.getIndexName(), true);
+		refresh();
 	}
 
 	@Override
 	public void delete(T entity) {
 		Assert.notNull(entity, "Cannot delete 'null' entity.");
 		delete(extractIdFromBean(entity));
-		elasticsearchOperations.refresh(entityInformation.getIndexName(), true);
+		refresh();
 	}
 
 	@Override
@@ -262,7 +272,7 @@ public abstract class AbstractElasticsearchRepository<T, ID extends Serializable
 		DeleteQuery deleteQuery = new DeleteQuery();
 		deleteQuery.setQuery(matchAllQuery());
 		elasticsearchOperations.delete(deleteQuery, getEntityClass());
-		elasticsearchOperations.refresh(entityInformation.getIndexName(), true);
+		refresh();
 	}
 
 	private IndexQuery createIndexQuery(T entity) {

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/AbstractElasticsearchRepository.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/AbstractElasticsearchRepository.java
@@ -143,8 +143,7 @@ public abstract class AbstractElasticsearchRepository<T, ID extends Serializable
 
 	@Override
 	public <S extends T> S save(S entity) {
-		Assert.notNull(entity, "Cannot save 'null' entity.");
-		elasticsearchOperations.index(createIndexQuery(entity));
+		entity = index(entity);
 		elasticsearchOperations.refresh(entityInformation.getIndexName(), true);
 		return entity;
 	}
@@ -163,7 +162,9 @@ public abstract class AbstractElasticsearchRepository<T, ID extends Serializable
 
 	@Override
 	public <S extends T> S index(S entity) {
-		return save(entity);
+		Assert.notNull(entity, "Cannot save 'null' entity.");
+		elasticsearchOperations.index(createIndexQuery(entity));
+		return entity;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/AbstractElasticsearchRepository.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/AbstractElasticsearchRepository.java
@@ -149,6 +149,13 @@ public abstract class AbstractElasticsearchRepository<T, ID extends Serializable
 	}
 
 	public <S extends T> List<S> save(List<S> entities) {
+		entities = index(entities);
+		elasticsearchOperations.refresh(entityInformation.getIndexName(), true);
+		return entities;
+	}
+
+	@Override
+	public <S extends T> List<S> index(List<S> entities) {
 		Assert.notNull(entities, "Cannot insert 'null' as a List.");
 		Assert.notEmpty(entities, "Cannot insert empty List.");
 		List<IndexQuery> queries = new ArrayList<IndexQuery>();
@@ -156,7 +163,20 @@ public abstract class AbstractElasticsearchRepository<T, ID extends Serializable
 			queries.add(createIndexQuery(s));
 		}
 		elasticsearchOperations.bulkIndex(queries);
-		elasticsearchOperations.refresh(entityInformation.getIndexName(), true);
+		return entities;
+	}
+	
+	@Override
+	public <S extends T> Iterable<S> index(Iterable<S> entities) {
+		Assert.notNull(entities, "Cannot insert 'null' as a List.");
+		if (!(entities instanceof Collection<?>)) {
+			throw new InvalidDataAccessApiUsageException("Entities have to be inside a collection");
+		}
+		List<IndexQuery> queries = new ArrayList<IndexQuery>();
+		for (S s : entities) {
+			queries.add(createIndexQuery(s));
+		}
+		elasticsearchOperations.bulkIndex(queries);
 		return entities;
 	}
 
@@ -169,15 +189,7 @@ public abstract class AbstractElasticsearchRepository<T, ID extends Serializable
 
 	@Override
 	public <S extends T> Iterable<S> save(Iterable<S> entities) {
-		Assert.notNull(entities, "Cannot insert 'null' as a List.");
-		if (!(entities instanceof Collection<?>)) {
-			throw new InvalidDataAccessApiUsageException("Entities have to be inside a collection");
-		}
-		List<IndexQuery> queries = new ArrayList<IndexQuery>();
-		for (S s : entities) {
-			queries.add(createIndexQuery(s));
-		}
-		elasticsearchOperations.bulkIndex(queries);
+		entities = index(entities);
 		elasticsearchOperations.refresh(entityInformation.getIndexName(), true);
 		return entities;
 	}

--- a/src/test/java/org/springframework/data/elasticsearch/repository/support/SimpleElasticsearchRepositoryTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repository/support/SimpleElasticsearchRepositoryTests.java
@@ -485,6 +485,7 @@ public class SimpleElasticsearchRepositoryTests {
 		sampleEntity.setMessage("some message");
 		// when
 		repository.index(sampleEntity);
+		repository.refresh();
 		// then
 		Page<SampleEntity> entities = repository.search(termQuery("id", documentId), new PageRequest(0, 50));
 		assertThat(entities.getTotalElements(), equalTo(1L));


### PR DESCRIPTION
This PR improves the following:

* `ElasticsearchRepository.index()` now does not implicit call refresh, which makes no sense IMO
* new overloads for `index()` to support bulk indexing without using `ElasticsearchTemplate`
* expose `refresh()` from `ElasticsearchTemplate` over `ElasticsearchRepository`

@olivergierke let me know if we need a Jira Issue for this.
