### PR TITLE
Removing unnecessary type check in AbstractElasticsearchRepository

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/AbstractElasticsearchRepository.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/AbstractElasticsearchRepository.java
@@ -169,9 +169,6 @@ public abstract class AbstractElasticsearchRepository<T, ID extends Serializable
 	@Override
 	public <S extends T> Iterable<S> save(Iterable<S> entities) {
 		Assert.notNull(entities, "Cannot insert 'null' as a List.");
-		if (!(entities instanceof Collection<?>)) {
-			throw new InvalidDataAccessApiUsageException("Entities have to be inside a collection");
-		}
 		List<IndexQuery> queries = new ArrayList<IndexQuery>();
 		for (S s : entities) {
 			queries.add(createIndexQuery(s));


### PR DESCRIPTION
(Trivial change)
This check is not needed and it breaks contract. 
i.e: Stream&lt;S&gt;::iterator is valid Iterable&lt;S&gt; but will not be accepted. 