### PR TITLE
Support injecting Id in immutable beans

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/DefaultResultMapper.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/DefaultResultMapper.java
@@ -18,6 +18,7 @@ package org.springframework.data.elasticsearch.core;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -158,12 +159,18 @@ public class DefaultResultMapper extends AbstractResultMapper {
 			// Only deal with String because ES generated Ids are strings !
 			if (idProperty != null && idProperty.getType().isAssignableFrom(String.class)) {
 				Method setter = idProperty.getSetter();
-				if (setter != null) {
-					try {
+				try {
+					if (setter != null) {
 						setter.invoke(result, id);
-					} catch (Throwable t) {
-						t.printStackTrace();
+					} else if(idProperty.getField() != null){
+						final Field field = idProperty.getField();
+						if(!field.isAccessible()) {
+							field.setAccessible(true);
+						}
+						field.set(result, id);
 					}
+				} catch (Throwable t) {
+					t.printStackTrace();
 				}
 			}
 		}

--- a/src/test/java/org/springframework/data/elasticsearch/core/DefaultResultMapperTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/DefaultResultMapperTests.java
@@ -34,7 +34,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
 import org.springframework.data.elasticsearch.entities.Car;
+import org.springframework.data.elasticsearch.entities.ImmutableCar;
+import org.springframework.data.elasticsearch.entities.MutableCar;
 
 /**
  * @author Artur Konczak
@@ -50,7 +53,7 @@ public class DefaultResultMapperTests {
 	@Before
 	public void init() {
 		MockitoAnnotations.initMocks(this);
-		resultMapper = new DefaultResultMapper();
+		resultMapper = new DefaultResultMapper(new SimpleElasticsearchMappingContext());
 	}
 
 	@Test
@@ -100,6 +103,42 @@ public class DefaultResultMapperTests {
 
 		//Then
 		assertThat(result, notNullValue());
+		assertThat(result.getModel(), is("Grat"));
+		assertThat(result.getName(), is("Ford"));
+	}
+	
+	@Test
+	public void shouldMapImmutableCar() {
+		//Given
+		GetResponse response = mock(GetResponse.class);
+		final String id = "carId";
+		when(response.getId()).thenReturn(id);
+		when(response.getSourceAsString()).thenReturn(createJsonCar("Ford", "Grat"));
+
+		//When
+		ImmutableCar result = resultMapper.mapResult(response, ImmutableCar.class);
+
+		//Then
+		assertThat(result, notNullValue());
+		assertThat(result.getId(), is(id));
+		assertThat(result.getModel(), is("Grat"));
+		assertThat(result.getName(), is("Ford"));
+	}
+	
+	@Test
+	public void shouldMapMutableCar() {
+		//Given
+		GetResponse response = mock(GetResponse.class);
+		final String id = "carId";
+		when(response.getId()).thenReturn(id);
+		when(response.getSourceAsString()).thenReturn(createJsonCar("Ford", "Grat"));
+
+		//When
+		MutableCar result = resultMapper.mapResult(response, MutableCar.class);
+
+		//Then
+		assertThat(result, notNullValue());
+		assertThat(result.getId(), is(id));
 		assertThat(result.getModel(), is("Grat"));
 		assertThat(result.getName(), is("Ford"));
 	}

--- a/src/test/java/org/springframework/data/elasticsearch/entities/ImmutableCar.java
+++ b/src/test/java/org/springframework/data/elasticsearch/entities/ImmutableCar.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.entities;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author Rizwan Idrees
+ * @author Mohsin Husen
+ * @author Artur Konczak
+ */
+@Document(indexName="cars", type="car")
+public final class ImmutableCar {
+
+	@Id
+	private final String id;
+	private final String name;
+	private final String model;
+
+	@JsonCreator
+	public ImmutableCar(
+			@JsonProperty("id") final String id, 
+			@JsonProperty("name") final String name, 
+			@JsonProperty("model") final String model) {
+		super();
+		this.id = id;
+		this.name = name;
+		this.model = model;
+	}
+
+	public String getId() {
+		return id;
+	}
+	
+	public String getName() {
+		return name;
+	}
+
+	public String getModel() {
+		return model;
+	}
+}

--- a/src/test/java/org/springframework/data/elasticsearch/entities/MutableCar.java
+++ b/src/test/java/org/springframework/data/elasticsearch/entities/MutableCar.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.entities;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+
+/**
+ * @author Rizwan Idrees
+ * @author Mohsin Husen
+ * @author Artur Konczak
+ */
+@Document(indexName="cars", type="car")
+public class MutableCar {
+
+	@Id
+	private String id;
+	private String name;
+	private String model;
+
+	public String getId() {
+		return id;
+	}
+	
+	public void setId(String id) {
+		this.id = id;
+	}
+	
+	public String getName() {
+		return name;
+	}
+	
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getModel() {
+		return model;
+	}
+	
+	public void setModel(String model) {
+		this.model = model;
+	}
+}


### PR DESCRIPTION
Our data-model is composed of only immutable objects. The id is not correctly injected in those objects because it needs a setter method at the moment.

The following fix injects the id directly into the field, even when the field is declared as "private final".
