### PR TITLE
DATAES-216 - Adding support to 'indices_boost' when searching against multiple indices

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
@@ -828,6 +828,12 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, Applicati
 				searchRequest.addHighlightedField(highlightField);
 			}
 		}
+		
+		if(searchQuery.getIndicesBoost() != null) {
+		    for(IndexBoost indexBoost : searchQuery.getIndicesBoost()) {
+		        searchRequest.addIndexBoost(indexBoost.getIndexName(), indexBoost.getBoost());
+		    }
+		}
 
 		if (CollectionUtils.isNotEmpty(searchQuery.getAggregations())) {
 			for (AbstractAggregationBuilder aggregationBuilder : searchQuery.getAggregations()) {

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/IndexBoost.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/IndexBoost.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.elasticsearch.core.query;
+
+/**
+ * Defines a IndexBoost to be applied on the "indices_boost" query clause
+ *
+ * @author Thiago Locatelli
+ */
+public class IndexBoost {
+    
+    private String indexName;
+    private float boost;
+    
+    public IndexBoost(String indexName, float boost) {
+        this.indexName = indexName;
+        this.boost = boost;
+    }
+
+    public String getIndexName() {
+        return indexName;
+    }
+
+    public float getBoost() {
+        return boost;
+    }
+    
+    
+
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/NativeSearchQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/NativeSearchQuery.java
@@ -40,6 +40,7 @@ public class NativeSearchQuery extends AbstractQuery implements SearchQuery {
 	private List<FacetRequest> facets;
 	private List<AbstractAggregationBuilder> aggregations;
 	private HighlightBuilder.Field[] highlightFields;
+    private IndexBoost[] indicesBoost;
 
 
 	public NativeSearchQuery(QueryBuilder query) {
@@ -113,4 +114,14 @@ public class NativeSearchQuery extends AbstractQuery implements SearchQuery {
 	public void setAggregations(List<AbstractAggregationBuilder> aggregations) {
 		this.aggregations = aggregations;
 	}
+
+	@Override
+    public IndexBoost[] getIndicesBoost() {
+        return indicesBoost;
+    }
+
+    public void setIndicesBoost(IndexBoost... indicesBoost) {
+        this.indicesBoost = indicesBoost;
+    }
+	
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/NativeSearchQueryBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/NativeSearchQueryBuilder.java
@@ -49,6 +49,7 @@ public class NativeSearchQueryBuilder {
 	private String[] indices;
 	private String[] types;
 	private String[] fields;
+	private IndexBoost[] indicesBoost;
 	private float minScore;
 	private Collection<String> ids;
 	private String route;
@@ -83,6 +84,11 @@ public class NativeSearchQueryBuilder {
 		this.highlightFields = highlightFields;
 		return this;
 	}
+
+    public NativeSearchQueryBuilder withIndicesBoost(IndexBoost... indicesBoost) {
+        this.indicesBoost = indicesBoost;
+        return this;
+    }
 
 	public NativeSearchQueryBuilder withPageable(Pageable pageable) {
 		this.pageable = pageable;
@@ -140,6 +146,10 @@ public class NativeSearchQueryBuilder {
 
 		if (fields != null) {
 			nativeSearchQuery.addFields(fields);
+		}
+		
+		if(indicesBoost != null) {
+		    nativeSearchQuery.setIndicesBoost(indicesBoost);
 		}
 
 		if (CollectionUtils.isNotEmpty(facetRequests)) {

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/SearchQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/SearchQuery.java
@@ -44,4 +44,6 @@ public interface SearchQuery extends Query {
 	List<AbstractAggregationBuilder> getAggregations();
 
 	HighlightBuilder.Field[] getHighlightFields();
+	
+	IndexBoost[] getIndicesBoost();
 }


### PR DESCRIPTION
Elasticsearch java client has the support to add the clause 'indices_boost' to a query. This is useful when searching across multiple indices and, for better performance than using custom score script, a boost can be added to rank up hits from specific indices.

NativeSearchQueryBuilder does not have a "withIndicesBoost" method to allow us to do that. This pull request address this problem by adding the required methods to add such capability to the builder.

