### PR TITLE
DATAES-224 retain newlines when reading mapping/setting files

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
@@ -1149,8 +1149,9 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, Applicati
 			bufferedReader = new BufferedReader(inputStreamReader);
 			String line;
 
+			String lineSeparator = System.getProperty("line.separator");
 			while ((line = bufferedReader.readLine()) != null) {
-				stringBuilder.append(line);
+				stringBuilder.append(line).append(lineSeparator);
 			}
 		} catch (Exception e) {
 			logger.debug(String.format("Failed to load file from url: %s: %s", url, e.getMessage()));

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
@@ -1976,6 +1976,25 @@ public class ElasticsearchTemplateTests {
 		assertThat(setting.get("index.number_of_replicas"), Matchers.<Object>is("1"));
 	}
 
+	@Test
+	public void shouldReadFileFromClasspathRetainingNewlines() {
+		// given
+		String settingsFile = "/settings/test-settings.yml";
+
+		// when
+		String content = ElasticsearchTemplate.readFileFromClasspath(settingsFile);
+
+		// then
+		assertThat(content, is("index:\n" +
+				"  number_of_shards: 1\n" +
+				"  number_of_replicas: 0\n" +
+				"  analysis:\n" +
+				"    analyzer:\n" +
+				"      emailAnalyzer:\n" +
+				"        type: custom\n" +
+				"        tokenizer\": uax_url_email\n"));
+	}
+
 	private IndexQuery getIndexQuery(SampleEntity sampleEntity) {
 		return new IndexQueryBuilder().withId(sampleEntity.getId()).withObject(sampleEntity).build();
 	}

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
@@ -1992,7 +1992,7 @@ public class ElasticsearchTemplateTests {
 				"    analyzer:\n" +
 				"      emailAnalyzer:\n" +
 				"        type: custom\n" +
-				"        tokenizer\": uax_url_email\n"));
+				"        tokenizer: uax_url_email\n"));
 	}
 
 	private IndexQuery getIndexQuery(SampleEntity sampleEntity) {

--- a/src/test/resources/settings/test-settings.yml
+++ b/src/test/resources/settings/test-settings.yml
@@ -1,0 +1,8 @@
+index:
+  number_of_shards: 1
+  number_of_replicas: 0
+  analysis:
+    analyzer:
+      emailAnalyzer:
+        type: custom
+        tokenizer": uax_url_email

--- a/src/test/resources/settings/test-settings.yml
+++ b/src/test/resources/settings/test-settings.yml
@@ -5,4 +5,4 @@ index:
     analyzer:
       emailAnalyzer:
         type: custom
-        tokenizer": uax_url_email
+        tokenizer: uax_url_email


### PR DESCRIPTION
ElasticsearchTemplate.readFileFromClasspath() reads files using BufferedReader.readLine() which skips newline characters. For JSON files this is not a problem but YAML files end up invalid because newlines are relevant.