### PR TITLE
DATAES-163 Add support of UUID type as primary key

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchRepositoryFactory.java
@@ -77,7 +77,7 @@ public class ElasticsearchRepositoryFactory extends RepositoryFactorySupport {
 		} else if (metadata.getIdType() == String.class) {
 			return SimpleElasticsearchRepository.class;
 		} else {
-			throw new IllegalArgumentException("Unsuppored ID type " + metadata.getIdType());
+			throw new IllegalArgumentException("Unsupported ID type " + metadata.getIdType());
 		}
 	}
 

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchRepositoryFactory.java
@@ -19,6 +19,7 @@ import static org.springframework.data.querydsl.QueryDslUtils.*;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.util.UUID;
 
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
@@ -41,6 +42,7 @@ import org.springframework.util.Assert;
  * @author Rizwan Idrees
  * @author Mohsin Husen
  * @author Ryan Henszey
+ * @author Gad Akuka
  */
 public class ElasticsearchRepositoryFactory extends RepositoryFactorySupport {
 
@@ -76,6 +78,8 @@ public class ElasticsearchRepositoryFactory extends RepositoryFactorySupport {
 			return NumberKeyedRepository.class;
 		} else if (metadata.getIdType() == String.class) {
 			return SimpleElasticsearchRepository.class;
+		} else if (metadata.getIdType() == UUID.class) {
+			return UUIDElasticsearchRepository.class;
 		} else {
 			throw new IllegalArgumentException("Unsupported ID type " + metadata.getIdType());
 		}

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/UUIDElasticsearchRepository.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/UUIDElasticsearchRepository.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.repository.support;
+
+import java.util.UUID;
+
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+
+/**
+ * Elasticsearch specific repository implementation. Likely to be used as target within
+ * {@link ElasticsearchRepositoryFactory}
+ *
+ * @author Gad Akuka
+ */
+public class UUIDElasticsearchRepository<T> extends AbstractElasticsearchRepository<T, UUID> {
+
+	public UUIDElasticsearchRepository() {
+		super();
+	}
+
+	public UUIDElasticsearchRepository(ElasticsearchEntityInformation<T, UUID> metadata,
+										 ElasticsearchOperations elasticsearchOperations) {
+		super(metadata, elasticsearchOperations);
+	}
+
+	public UUIDElasticsearchRepository(ElasticsearchOperations elasticsearchOperations) {
+		super(elasticsearchOperations);
+	}
+
+	@Override
+	protected String stringIdRepresentation(UUID id) {
+		return (id != null) ? id.toString() : null;
+	}
+}

--- a/src/test/java/org/springframework/data/elasticsearch/SampleEntityUUIDKeyed.java
+++ b/src/test/java/org/springframework/data/elasticsearch/SampleEntityUUIDKeyed.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch;
+
+import java.util.UUID;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Version;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.ScriptedField;
+
+/**
+ * @author Gad Akuka
+ */
+@Document(indexName = "test-index", type = "test-type", indexStoreType = "memory", shards = 1, replicas = 0, refreshInterval = "-1")
+public class SampleEntityUUIDKeyed {
+
+	@Id
+	private UUID id;
+	private String type;
+	private String message;
+	private int rate;
+    @ScriptedField
+    private Long scriptedRate;
+	private boolean available;
+	private String highlightedMessage;
+	@Version
+	private Long version;
+
+	public UUID getId() {
+		return id;
+	}
+
+	public void setId(UUID id) {
+		this.id = id;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+
+	public void setMessage(String message) {
+		this.message = message;
+	}
+
+	public int getRate() {
+		return rate;
+	}
+
+	public void setRate(int rate) {
+		this.rate = rate;
+	}
+
+    public Long getScriptedRate() {
+        return scriptedRate;
+    }
+
+    public void setScriptedRate(Long scriptedRate) {
+        this.scriptedRate = scriptedRate;
+    }
+
+	public boolean isAvailable() {
+		return available;
+	}
+
+	public void setAvailable(boolean available) {
+		this.available = available;
+	}
+
+	public String getHighlightedMessage() {
+		return highlightedMessage;
+	}
+
+	public void setHighlightedMessage(String highlightedMessage) {
+		this.highlightedMessage = highlightedMessage;
+	}
+
+	public Long getVersion() {
+		return version;
+	}
+
+	public void setVersion(Long version) {
+		this.version = version;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof SampleEntityUUIDKeyed)) {
+			return false;
+		}
+		if (this == obj) {
+			return true;
+		}
+		SampleEntityUUIDKeyed rhs = (SampleEntityUUIDKeyed) obj;
+		return new EqualsBuilder().append(this.id, rhs.id).append(this.type, rhs.type).append(this.message, rhs.message)
+				.append(this.rate, rhs.rate).append(this.available, rhs.available).append(this.version, rhs.version).isEquals();
+	}
+
+	@Override
+	public int hashCode() {
+		return new HashCodeBuilder().append(id).append(type).append(message).append(rate).append(available).append(version)
+				.toHashCode();
+	}
+
+	@Override
+	public String toString() {
+		return "SampleEntity{" +
+				"id='" + id + '\'' +
+				", type='" + type + '\'' +
+				", message='" + message + '\'' +
+				", rate=" + rate +
+				", available=" + available +
+				", highlightedMessage='" + highlightedMessage + '\'' +
+				", version=" + version +
+				'}';
+	}
+}

--- a/src/test/java/org/springframework/data/elasticsearch/config/EnableElasticsearchRepositoriesTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/config/EnableElasticsearchRepositoriesTests.java
@@ -18,6 +18,8 @@ package org.springframework.data.elasticsearch.config;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
+import java.util.Arrays;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.BeansException;
@@ -41,6 +43,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Rizwan Idrees
  * @author Mohsin Husen
  * @author Kevin Leturc
+ * @author Gad Akuka
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
@@ -85,8 +88,9 @@ public class EnableElasticsearchRepositoriesTests implements ApplicationContextA
 		String[] beanNamesForType = context.getBeanNamesForType(ElasticsearchRepository.class);
 
 		//then
-		assertThat(beanNamesForType.length, is(1));
-		assertThat(beanNamesForType[0], is("sampleElasticsearchRepository"));
+		assertThat(beanNamesForType.length, is(2));
+		assertTrue(Arrays.asList(beanNamesForType).contains("sampleElasticsearchRepository"));
+		assertTrue(Arrays.asList(beanNamesForType).contains("sampleUUIDKeyedElasticsearchRepository"));
 	}
 
 	@Test

--- a/src/test/java/org/springframework/data/elasticsearch/entities/SampleEntityUUIDKeyed.java
+++ b/src/test/java/org/springframework/data/elasticsearch/entities/SampleEntityUUIDKeyed.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.entities;
+
+import lombok.*;
+
+import java.util.UUID;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Version;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.ScriptedField;
+import org.springframework.data.elasticsearch.core.geo.GeoPoint;
+
+/**
+ * @author Gad Akuka
+ * @author Rizwan Idrees
+ * @author Mohsin Husen
+ */
+
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Document(indexName = "test-index-uuid-keyed", type = "test-type-uuid-keyed", indexStoreType = "memory", shards = 1, replicas = 0, refreshInterval = "-1")
+public class SampleEntityUUIDKeyed {
+
+	@Id
+	private UUID id;
+	private String type;
+	private String message;
+	private int rate;
+	@ScriptedField
+	private Long scriptedRate;
+	private boolean available;
+	private String highlightedMessage;
+
+	private GeoPoint location;
+
+	@Version
+	private Long version;
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		SampleEntityUUIDKeyed that = (SampleEntityUUIDKeyed) o;
+
+		if (available != that.available) return false;
+		if (rate != that.rate) return false;
+		if (highlightedMessage != null ? !highlightedMessage.equals(that.highlightedMessage) : that.highlightedMessage != null)
+			return false;
+		if (id != null ? !id.equals(that.id) : that.id != null) return false;
+		if (location != null ? !location.equals(that.location) : that.location != null) return false;
+		if (message != null ? !message.equals(that.message) : that.message != null) return false;
+		if (type != null ? !type.equals(that.type) : that.type != null) return false;
+		if (version != null ? !version.equals(that.version) : that.version != null) return false;
+
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = id != null ? id.hashCode() : 0;
+		result = 31 * result + (type != null ? type.hashCode() : 0);
+		result = 31 * result + (message != null ? message.hashCode() : 0);
+		result = 31 * result + rate;
+		result = 31 * result + (available ? 1 : 0);
+		result = 31 * result + (highlightedMessage != null ? highlightedMessage.hashCode() : 0);
+		result = 31 * result + (location != null ? location.hashCode() : 0);
+		result = 31 * result + (version != null ? version.hashCode() : 0);
+		return result;
+	}
+}

--- a/src/test/java/org/springframework/data/elasticsearch/repositories/sample/SampleUUIDKeyedElasticsearchRepository.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repositories/sample/SampleUUIDKeyedElasticsearchRepository.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.repositories.sample;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.elasticsearch.entities.SampleEntityUUIDKeyed;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+/**
+ * @author Gad Akuka
+ */
+public interface SampleUUIDKeyedElasticsearchRepository extends ElasticsearchRepository<SampleEntityUUIDKeyed, UUID> {
+
+	long deleteById(UUID id);
+	List<SampleEntityUUIDKeyed> deleteByAvailable(boolean available);
+	List<SampleEntityUUIDKeyed> deleteByMessage(String message);
+	void deleteByType(String type);
+
+}

--- a/src/test/java/org/springframework/data/elasticsearch/repository/support/UUIDElasticsearchRepositoryTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repository/support/UUIDElasticsearchRepositoryTests.java
@@ -1,0 +1,512 @@
+/*
+ * Copyright 2013-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.repository.support;
+
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import org.elasticsearch.common.collect.Lists;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.elasticsearch.core.ElasticsearchTemplate;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
+import org.springframework.data.elasticsearch.core.query.SearchQuery;
+import org.springframework.data.elasticsearch.entities.SampleEntityUUIDKeyed;
+import org.springframework.data.elasticsearch.repositories.sample.SampleUUIDKeyedElasticsearchRepository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Gad Akuka
+ * @author Rizwan Idrees
+ * @author Mohsin Husen
+ */
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("classpath:/simple-repository-test.xml")
+public class UUIDElasticsearchRepositoryTests {
+
+	@Autowired
+	private SampleUUIDKeyedElasticsearchRepository repository;
+
+	@Autowired
+	private ElasticsearchTemplate elasticsearchTemplate;
+
+
+	@Before
+	public void before() {
+		elasticsearchTemplate.deleteIndex(SampleEntityUUIDKeyed.class);
+		elasticsearchTemplate.createIndex(SampleEntityUUIDKeyed.class);
+        elasticsearchTemplate.putMapping(SampleEntityUUIDKeyed.class);
+		elasticsearchTemplate.refresh(SampleEntityUUIDKeyed.class, true);
+	}
+
+	@Test
+	public void shouldDoBulkIndexDocument() {
+		// given
+		UUID documentId1 = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed1 = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed1.setId(documentId1);
+		sampleEntityUUIDKeyed1.setMessage("some message");
+		sampleEntityUUIDKeyed1.setVersion(System.currentTimeMillis());
+
+		UUID documentId2 = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed2 = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed2.setId(documentId2);
+		sampleEntityUUIDKeyed2.setMessage("some message");
+		sampleEntityUUIDKeyed2.setVersion(System.currentTimeMillis());
+
+		// when
+		repository.save(Arrays.asList(sampleEntityUUIDKeyed1, sampleEntityUUIDKeyed2));
+		// then
+		SampleEntityUUIDKeyed entity1FromElasticSearch = repository.findOne(documentId1);
+		assertThat(entity1FromElasticSearch, is(notNullValue()));
+
+		SampleEntityUUIDKeyed entity2FromElasticSearch = repository.findOne(documentId2);
+		assertThat(entity2FromElasticSearch, is(notNullValue()));
+	}
+
+	@Test
+	public void shouldSaveDocument() {
+		// given
+		UUID documentId = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed.setId(documentId);
+		sampleEntityUUIDKeyed.setMessage("some message");
+		sampleEntityUUIDKeyed.setVersion(System.currentTimeMillis());
+		// when
+		repository.save(sampleEntityUUIDKeyed);
+		// then
+		SampleEntityUUIDKeyed entityFromElasticSearch = repository.findOne(documentId);
+		assertThat(entityFromElasticSearch, is(notNullValue()));
+	}
+
+	@Test
+	public void shouldFindDocumentById() {
+		// given
+		UUID documentId = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed.setId(documentId);
+		sampleEntityUUIDKeyed.setMessage("some message");
+		sampleEntityUUIDKeyed.setVersion(System.currentTimeMillis());
+		repository.save(sampleEntityUUIDKeyed);
+		// when
+		SampleEntityUUIDKeyed entityFromElasticSearch = repository.findOne(documentId);
+		// then
+		assertThat(entityFromElasticSearch, is(notNullValue()));
+		assertThat(sampleEntityUUIDKeyed, is((equalTo(sampleEntityUUIDKeyed))));
+	}
+
+	@Test
+	public void shouldReturnCountOfDocuments() {
+		// given
+		UUID documentId = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed.setId(documentId);
+		sampleEntityUUIDKeyed.setMessage("some message");
+		sampleEntityUUIDKeyed.setVersion(System.currentTimeMillis());
+		repository.save(sampleEntityUUIDKeyed);
+		// when
+		Long count = repository.count();
+		// then
+		assertThat(count, is(greaterThanOrEqualTo(1L)));
+	}
+
+	@Test
+	public void shouldFindAllDocuments() {
+		// when
+		Iterable<SampleEntityUUIDKeyed> results = repository.findAll();
+		// then
+		assertThat(results, is(notNullValue()));
+	}
+
+	@Test
+	public void shouldDeleteDocument() {
+		// given
+		UUID documentId = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed.setId(documentId);
+		sampleEntityUUIDKeyed.setMessage("some message");
+		sampleEntityUUIDKeyed.setVersion(System.currentTimeMillis());
+		repository.save(sampleEntityUUIDKeyed);
+		// when
+		repository.delete(documentId);
+		// then
+		SampleEntityUUIDKeyed entityFromElasticSearch = repository.findOne(documentId);
+		assertThat(entityFromElasticSearch, is(nullValue()));
+	}
+
+	@Test
+	public void shouldSearchDocumentsGivenSearchQuery() {
+		// given
+		UUID documentId = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed.setId(documentId);
+		sampleEntityUUIDKeyed.setMessage("some test message");
+		sampleEntityUUIDKeyed.setVersion(System.currentTimeMillis());
+		repository.save(sampleEntityUUIDKeyed);
+
+		SearchQuery query = new NativeSearchQueryBuilder().withQuery(termQuery("message", "test")).build();
+		// when
+		Page<SampleEntityUUIDKeyed> page = repository.search(query);
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getNumberOfElements(), is(greaterThanOrEqualTo(1)));
+	}
+
+	@Test
+	public void shouldSearchDocumentsGivenElasticsearchQuery() {
+		// given
+		UUID documentId = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed.setId(documentId);
+		sampleEntityUUIDKeyed.setMessage("hello world.");
+		sampleEntityUUIDKeyed.setVersion(System.currentTimeMillis());
+		repository.save(sampleEntityUUIDKeyed);
+		// when
+		Page<SampleEntityUUIDKeyed> page = repository.search(termQuery("message", "world"), new PageRequest(0, 50));
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getNumberOfElements(), is(greaterThanOrEqualTo(1)));
+	}
+
+	/*
+	DATAES-82
+	*/
+	@Test
+	public void shouldFindAllByIdQuery() {
+		// given
+		UUID documentId = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed.setId(documentId);
+		sampleEntityUUIDKeyed.setMessage("hello world.");
+		sampleEntityUUIDKeyed.setVersion(System.currentTimeMillis());
+		repository.save(sampleEntityUUIDKeyed);
+
+		UUID documentId2 = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed2 = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed2.setId(documentId2);
+		sampleEntityUUIDKeyed2.setMessage("hello world.");
+		sampleEntityUUIDKeyed2.setVersion(System.currentTimeMillis());
+		repository.save(sampleEntityUUIDKeyed2);
+
+		// when
+		Iterable<SampleEntityUUIDKeyed> sampleEntities = repository.findAll(Arrays.asList(documentId, documentId2));
+
+		// then
+		assertNotNull("sample entities cant be null..", sampleEntities);
+		List<SampleEntityUUIDKeyed> entities = Lists.newArrayList(sampleEntities);
+		assertThat(entities.size(), is(2));
+	}
+
+	@Test
+	public void shouldSaveIterableEntities() {
+		// given
+		UUID documentId = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed1 = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed1.setId(documentId);
+		sampleEntityUUIDKeyed1.setMessage("hello world.");
+		sampleEntityUUIDKeyed1.setVersion(System.currentTimeMillis());
+
+		UUID documentId2 = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed2 = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed2.setId(documentId2);
+		sampleEntityUUIDKeyed2.setMessage("hello world.");
+		sampleEntityUUIDKeyed2.setVersion(System.currentTimeMillis());
+
+		Iterable<SampleEntityUUIDKeyed> sampleEntities = Arrays.asList(sampleEntityUUIDKeyed1, sampleEntityUUIDKeyed2);
+		// when
+		repository.save(sampleEntities);
+		// then
+		Page<SampleEntityUUIDKeyed> entities = repository.search(termQuery("id", documentId), new PageRequest(0, 50));
+		assertNotNull(entities);
+	}
+
+	@Test
+	public void shouldReturnTrueGivenDocumentWithIdExists() {
+		// given
+		UUID documentId = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed.setId(documentId);
+		sampleEntityUUIDKeyed.setMessage("hello world.");
+		sampleEntityUUIDKeyed.setVersion(System.currentTimeMillis());
+		repository.save(sampleEntityUUIDKeyed);
+
+		// when
+		boolean exist = repository.exists(documentId);
+
+		// then
+		assertEquals(exist, true);
+	}
+
+	@Test
+	public void shouldDeleteAll() {
+		// when
+		repository.deleteAll();
+		// then
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
+		Page<SampleEntityUUIDKeyed> sampleEntities = repository.search(searchQuery);
+		assertThat(sampleEntities.getTotalElements(), equalTo(0L));
+	}
+
+	@Test
+	public void shouldDeleteById() {
+		// given
+		UUID documentId = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed.setId(documentId);
+		sampleEntityUUIDKeyed.setMessage("hello world.");
+		sampleEntityUUIDKeyed.setVersion(System.currentTimeMillis());
+		repository.save(sampleEntityUUIDKeyed);
+		// when
+		long result = repository.deleteById(documentId);
+		// then
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("id", documentId)).build();
+		Page<SampleEntityUUIDKeyed> sampleEntities = repository.search(searchQuery);
+		assertThat(sampleEntities.getTotalElements(), equalTo(0L));
+		assertThat(result, equalTo(1L));
+	}
+
+	@Test
+	public void shouldDeleteByMessageAndReturnList() {
+		// given
+		UUID documentId = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed1 = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed1.setId(documentId);
+		sampleEntityUUIDKeyed1.setMessage("hello world 1");
+		sampleEntityUUIDKeyed1.setAvailable(true);
+		sampleEntityUUIDKeyed1.setVersion(System.currentTimeMillis());
+
+		documentId = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed2 = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed2.setId(documentId);
+		sampleEntityUUIDKeyed2.setMessage("hello world 2");
+		sampleEntityUUIDKeyed2.setAvailable(true);
+		sampleEntityUUIDKeyed2.setVersion(System.currentTimeMillis());
+
+		documentId = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed3 = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed3.setId(documentId);
+		sampleEntityUUIDKeyed3.setMessage("hello world 3");
+		sampleEntityUUIDKeyed3.setAvailable(false);
+		sampleEntityUUIDKeyed3.setVersion(System.currentTimeMillis());
+		repository.save(Arrays.asList(sampleEntityUUIDKeyed1, sampleEntityUUIDKeyed2, sampleEntityUUIDKeyed3));
+		// when
+		List<SampleEntityUUIDKeyed> result = repository.deleteByAvailable(true);
+		// then
+		assertThat(result.size(), equalTo(2));
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
+		Page<SampleEntityUUIDKeyed> sampleEntities = repository.search(searchQuery);
+		assertThat(sampleEntities.getTotalElements(), equalTo(1L));
+	}
+
+	@Test
+	public void shouldDeleteByListForMessage() {
+		// given
+		UUID documentId = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed1 = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed1.setId(documentId);
+		sampleEntityUUIDKeyed1.setMessage("hello world 1");
+		sampleEntityUUIDKeyed1.setVersion(System.currentTimeMillis());
+
+		documentId = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed2 = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed2.setId(documentId);
+		sampleEntityUUIDKeyed2.setMessage("hello world 2");
+		sampleEntityUUIDKeyed2.setVersion(System.currentTimeMillis());
+
+		documentId = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed3 = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed3.setId(documentId);
+		sampleEntityUUIDKeyed3.setMessage("hello world 3");
+		sampleEntityUUIDKeyed3.setVersion(System.currentTimeMillis());
+		repository.save(Arrays.asList(sampleEntityUUIDKeyed1, sampleEntityUUIDKeyed2, sampleEntityUUIDKeyed3));
+		// when
+		List<SampleEntityUUIDKeyed> result = repository.deleteByMessage("hello world 3");
+		// then
+		assertThat(result.size(), equalTo(1));
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
+		Page<SampleEntityUUIDKeyed> sampleEntities = repository.search(searchQuery);
+		assertThat(sampleEntities.getTotalElements(), equalTo(2L));
+	}
+
+	@Test
+	public void shouldDeleteByType() {
+		// given
+		UUID documentId = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed1 = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed1.setId(documentId);
+		sampleEntityUUIDKeyed1.setType("book");
+		sampleEntityUUIDKeyed1.setVersion(System.currentTimeMillis());
+
+		documentId = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed2 = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed2.setId(documentId);
+		sampleEntityUUIDKeyed2.setType("article");
+		sampleEntityUUIDKeyed2.setVersion(System.currentTimeMillis());
+
+		documentId = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed3 = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed3.setId(documentId);
+		sampleEntityUUIDKeyed3.setType("image");
+		sampleEntityUUIDKeyed3.setVersion(System.currentTimeMillis());
+		repository.save(Arrays.asList(sampleEntityUUIDKeyed1, sampleEntityUUIDKeyed2, sampleEntityUUIDKeyed3));
+		// when
+		repository.deleteByType("article");
+		// then
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
+		Page<SampleEntityUUIDKeyed> sampleEntities = repository.search(searchQuery);
+		assertThat(sampleEntities.getTotalElements(), equalTo(2L));
+	}
+
+
+
+	@Test
+	public void shouldDeleteEntity() {
+		// given
+		UUID documentId = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed.setId(documentId);
+		sampleEntityUUIDKeyed.setMessage("hello world.");
+		sampleEntityUUIDKeyed.setVersion(System.currentTimeMillis());
+		repository.save(sampleEntityUUIDKeyed);
+		// when
+		repository.delete(sampleEntityUUIDKeyed);
+		// then
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("id", documentId)).build();
+		Page<SampleEntityUUIDKeyed> sampleEntities = repository.search(searchQuery);
+		assertThat(sampleEntities.getTotalElements(), equalTo(0L));
+	}
+
+	@Test
+	public void shouldReturnIterableEntities() {
+		// given
+		UUID documentId1 = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed1 = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed1.setId(documentId1);
+		sampleEntityUUIDKeyed1.setMessage("hello world.");
+		sampleEntityUUIDKeyed1.setVersion(System.currentTimeMillis());
+		repository.save(sampleEntityUUIDKeyed1);
+
+		UUID documentId2 = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed2 = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed2.setId(documentId2);
+		sampleEntityUUIDKeyed2.setMessage("hello world.");
+		sampleEntityUUIDKeyed2.setVersion(System.currentTimeMillis());
+		repository.save(sampleEntityUUIDKeyed2);
+
+		// when
+		Iterable<SampleEntityUUIDKeyed> sampleEntities = repository.search(termQuery("id", documentId1));
+		// then
+		assertNotNull("sample entities cant be null..", sampleEntities);
+	}
+
+	@Test
+	public void shouldDeleteIterableEntities() {
+		// given
+		UUID documentId1 = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed1 = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed1.setId(documentId1);
+		sampleEntityUUIDKeyed1.setMessage("hello world.");
+		sampleEntityUUIDKeyed1.setVersion(System.currentTimeMillis());
+
+		UUID documentId2 = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed2 = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed2.setId(documentId2);
+		sampleEntityUUIDKeyed2.setMessage("hello world.");
+		sampleEntityUUIDKeyed2.setVersion(System.currentTimeMillis());
+		repository.save(sampleEntityUUIDKeyed2);
+
+		Iterable<SampleEntityUUIDKeyed> sampleEntities = Arrays.asList(sampleEntityUUIDKeyed2, sampleEntityUUIDKeyed2);
+		// when
+		repository.delete(sampleEntities);
+		// then
+		assertThat(repository.findOne(documentId1), is(nullValue()));
+		assertThat(repository.findOne(documentId2), is(nullValue()));
+	}
+
+	@Test
+	public void shouldSortByGivenField() {
+		// todo
+		// given
+		UUID documentId = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed.setId(documentId);
+		sampleEntityUUIDKeyed.setMessage("world");
+		repository.save(sampleEntityUUIDKeyed);
+
+		UUID documentId2 = UUID.randomUUID();
+		SampleEntityUUIDKeyed sampleEntityUUIDKeyed2 = new SampleEntityUUIDKeyed();
+		sampleEntityUUIDKeyed2.setId(documentId2);
+		sampleEntityUUIDKeyed2.setMessage("hello");
+		repository.save(sampleEntityUUIDKeyed2);
+		// when
+		Iterable<SampleEntityUUIDKeyed> sampleEntities = repository.findAll(new Sort(new Sort.Order(Sort.Direction.ASC, "message")));
+		// then
+		assertThat(sampleEntities, is(notNullValue()));
+	}
+
+	@Test
+	public void shouldReturnSimilarEntities() {
+		// given
+		String sampleMessage = "So we build a web site or an application and want to add search to it, "
+				+ "and then it hits us: getting search working is hard. We want our search solution to be fast,"
+				+ " we want a painless setup and a completely free search schema, we want to be able to index data simply using JSON over HTTP, "
+				+ "we want our search server to be always available, we want to be able to start with one machine and scale to hundreds, "
+				+ "we want real-time search, we want simple multi-tenancy, and we want a solution that is built for the cloud.";
+
+		List<SampleEntityUUIDKeyed> sampleEntities = createSampleEntitiesWithMessage(sampleMessage, 30);
+		repository.save(sampleEntities);
+
+		// when
+		Page<SampleEntityUUIDKeyed> results = repository.searchSimilar(sampleEntities.get(0), new String[]{"message"}, new PageRequest(0, 5));
+
+		// then
+		assertThat(results.getTotalElements(), is(greaterThanOrEqualTo(1L)));
+	}
+
+	private static List<SampleEntityUUIDKeyed> createSampleEntitiesWithMessage(String message, int numberOfEntities) {
+		List<SampleEntityUUIDKeyed> sampleEntities = new ArrayList<SampleEntityUUIDKeyed>();
+		for (int i = 0; i < numberOfEntities; i++) {
+			UUID documentId = UUID.randomUUID();
+			SampleEntityUUIDKeyed sampleEntityUUIDKeyed = new SampleEntityUUIDKeyed();
+			sampleEntityUUIDKeyed.setId(documentId);
+			sampleEntityUUIDKeyed.setMessage(message);
+			sampleEntityUUIDKeyed.setRate(2);
+			sampleEntityUUIDKeyed.setVersion(System.currentTimeMillis());
+			sampleEntities.add(sampleEntityUUIDKeyed);
+		}
+		return sampleEntities;
+	}
+}


### PR DESCRIPTION
I received this exception when I tried to use UUID as the key for an ElasticSearch Repository:
```
Caused by: java.lang.IllegalArgumentException: Unsuppored ID type class java.util.UUID
	at org.springframework.data.elasticsearch.repository.support.ElasticsearchRepositoryFactory.getRepositoryBaseClass(ElasticsearchRepositoryFactory.java:79) ~[spring-data-elasticsearch-1.3.2.RELEASE.jar:na]
	at org.springframework.data.repository.core.support.RepositoryFactorySupport.getRepositoryInformation(RepositoryFactorySupport.java:238) ~[spring-data-commons-1.11.2.RELEASE.jar:na]
	at org.springframework.data.repository.core.support.RepositoryFactorySupport.getRepository(RepositoryFactorySupport.java:181) ~[spring-data-commons-1.11.2.RELEASE.jar:na]
	at org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport.initAndReturn(RepositoryFactoryBeanSupport.java:251) ~[spring-data-commons-1.11.2.RELEASE.jar:na]
	at org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport.afterPropertiesSet(RepositoryFactoryBeanSupport.java:237) ~[spring-data-commons-1.11.2.RELEASE.jar:na]
	at org.springframework.data.elasticsearch.repository.support.ElasticsearchRepositoryFactoryBean.afterPropertiesSet(ElasticsearchRepositoryFactoryBean.java:55) ~[spring-data-elasticsearch-1.3.2.RELEASE.jar:na]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1637) ~[spring-beans-4.2.4.RELEASE.jar:4.2.4.RELEASE]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1574) ~[spring-beans-4.2.4.RELEASE.jar:4.2.4.RELEASE]
	... 32 common frames omitted
```
So I add support for UUID types in Spring Data Elastic Search