### PR TITLE
DATAES-238: ElasticsearchTemplate.prepareUpdate() does not preserve routing parameter which is required for updating child documents

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
@@ -538,6 +538,7 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, Applicati
 		Assert.notNull(query.getId(), "No Id define for Query");
 		Assert.notNull(query.getUpdateRequest(), "No IndexRequest define for Query");
 		UpdateRequestBuilder updateRequestBuilder = client.prepareUpdate(indexName, type, query.getId());
+		updateRequestBuilder.setRouting(query.getUpdateRequest().routing());
 
 		if (query.getUpdateRequest().script() == null) {
 			// doc

--- a/src/test/java/org/springframework/data/elasticsearch/core/DefaultEntityMapperTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/DefaultEntityMapperTests.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
+import java.util.Locale;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -82,11 +83,11 @@ public class DefaultEntityMapperTests {
 		//then
 		assertThat(jsonResult, containsString(pointTemplate("pointA", point)));
 		assertThat(jsonResult, containsString(pointTemplate("pointB", point)));
-		assertThat(jsonResult, containsString(String.format("\"%s\":\"%s\"", "pointC", pointAsString)));
-		assertThat(jsonResult, containsString(String.format("\"%s\":[%.1f,%.1f]", "pointD", pointAsArray[0], pointAsArray[1])));
+		assertThat(jsonResult, containsString(String.format(Locale.ENGLISH, "\"%s\":\"%s\"", "pointC", pointAsString)));
+		assertThat(jsonResult, containsString(String.format(Locale.ENGLISH, "\"%s\":[%.1f,%.1f]", "pointD", pointAsArray[0], pointAsArray[1])));
 	}
 
 	private String pointTemplate(String name, Point point) {
-		return String.format("\"%s\":{\"lat\":%.1f,\"lon\":%.1f}", name, point.getX(), point.getY());
+		return String.format(Locale.ENGLISH, "\"%s\":{\"lat\":%.1f,\"lon\":%.1f}", name, point.getX(), point.getY());
 	}
 }

--- a/src/test/java/org/springframework/data/elasticsearch/repositories/geo/SpringDataGeoRepositoryTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repositories/geo/SpringDataGeoRepositoryTests.java
@@ -29,6 +29,8 @@ import org.springframework.data.geo.Point;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import java.util.Locale;
+
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("classpath:/repository-spring-data-geo-support.xml")
@@ -72,7 +74,7 @@ public class SpringDataGeoRepositoryTests {
 	}
 
 	private String toGeoString(Point point) {
-		return String.format("%.1f,%.1f", point.getX(), point.getY());
+		return String.format(Locale.ENGLISH, "%.1f,%.1f", point.getX(), point.getY());
 	}
 
 	private double[] toGeoArray(Point point) {


### PR DESCRIPTION
When updating a child document in a parent-child document relationship, Elasticsearch requires a routing parameter on the UpdateRequest.

ElasticsearchTemplate.update(), respectively ElasticsearchTemplate.prepareUpdate() does not preserve the routing parameter specified in the the UpdateRequest (wrapped in the UpdateQuery parameter).

The fix is a one-liner in ElasticsearchTemplate.update().