### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
         <dist.key>DATAES</dist.key>
 
-        <commonscollections>3.2.1</commonscollections>
+        <commonscollections>3.2.2</commonscollections>
         <commonslang>2.6</commonslang>
         <elasticsearch>2.2.0</elasticsearch>
         <springdata.commons>1.12.0.BUILD-SNAPSHOT</springdata.commons>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

Also, consider using Guava in the future.

https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/