### PR TITLE
DATAES-234 - Use Set to store qualifiers in CDI extension.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/repository/cdi/ElasticsearchRepositoryExtension.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/cdi/ElasticsearchRepositoryExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import org.springframework.data.repository.cdi.CdiRepositoryBean;
 import org.springframework.data.repository.cdi.CdiRepositoryExtensionSupport;
 
 /**
- * ElasticsearchRepositoryExtension
+ * CDI extension to export Elasticsearch repositories.
  *
  * @author Rizwan Idrees
  * @author Mohsin Husen
@@ -42,14 +42,14 @@ import org.springframework.data.repository.cdi.CdiRepositoryExtensionSupport;
  */
 public class ElasticsearchRepositoryExtension extends CdiRepositoryExtensionSupport {
 
-	private final Map<String, Bean<ElasticsearchOperations>> elasticsearchOperationsMap = new HashMap<String, Bean<ElasticsearchOperations>>();
+	private final Map<Set<Annotation>, Bean<ElasticsearchOperations>> elasticsearchOperationsMap = new HashMap<Set<Annotation>, Bean<ElasticsearchOperations>>();
 
 	@SuppressWarnings("unchecked")
 	<T> void processBean(@Observes ProcessBean<T> processBean) {
 		Bean<T> bean = processBean.getBean();
 		for (Type type : bean.getTypes()) {
 			if (type instanceof Class<?> && ElasticsearchOperations.class.isAssignableFrom((Class<?>) type)) {
-				elasticsearchOperationsMap.put(bean.getQualifiers().toString(), ((Bean<ElasticsearchOperations>) bean));
+				elasticsearchOperationsMap.put(bean.getQualifiers(), ((Bean<ElasticsearchOperations>) bean));
 			}
 		}
 	}
@@ -69,8 +69,7 @@ public class ElasticsearchRepositoryExtension extends CdiRepositoryExtensionSupp
 	private <T> CdiRepositoryBean<T> createRepositoryBean(Class<T> repositoryType, Set<Annotation> qualifiers,
 														  BeanManager beanManager) {
 
-		Bean<ElasticsearchOperations> elasticsearchOperationsBean = this.elasticsearchOperationsMap.get(qualifiers
-				.toString());
+		Bean<ElasticsearchOperations> elasticsearchOperationsBean = this.elasticsearchOperationsMap.get(qualifiers);
 
 		if (elasticsearchOperationsBean == null) {
 			throw new UnsatisfiedResolutionException(String.format("Unable to resolve a bean for '%s' with qualifiers %s.",

--- a/src/test/java/org/springframework/data/elasticsearch/repositories/cdi/CdiRepositoryClient.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repositories/cdi/CdiRepositoryClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,13 @@ import javax.inject.Inject;
 /**
  * @author Mohsin Husen
  * @author Oliver Gierke
+ * @author Mark Paluch
  */
 class CdiRepositoryClient {
 
 	private CdiProductRepository repository;
 	private SamplePersonRepository samplePersonRepository;
-
+	private QualifiedProductRepository qualifiedProductRepository;
 
 	public CdiProductRepository getRepository() {
 		return repository;
@@ -43,5 +44,15 @@ class CdiRepositoryClient {
 	@Inject
 	public void setSamplePersonRepository(SamplePersonRepository samplePersonRepository) {
 		this.samplePersonRepository = samplePersonRepository;
+	}
+
+	public QualifiedProductRepository getQualifiedProductRepository() {
+		return qualifiedProductRepository;
+	}
+   
+	@Inject
+	public void setQualifiedProductRepository(
+			@PersonDB @OtherQualifier QualifiedProductRepository qualifiedProductRepository) {
+		this.qualifiedProductRepository = qualifiedProductRepository;
 	}
 }

--- a/src/test/java/org/springframework/data/elasticsearch/repositories/cdi/CdiRepositoryTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repositories/cdi/CdiRepositoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.springframework.data.elasticsearch.repositories.cdi;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
 import org.apache.webbeans.cditest.CdiTestContainer;
@@ -28,13 +28,14 @@ import org.springframework.data.elasticsearch.entities.Product;
 
 /**
  * @author Mohsin Husen
+ * @author Mark Paluch
  */
-
 public class CdiRepositoryTests {
 
 	private static CdiTestContainer cdiContainer;
 	private CdiProductRepository repository;
 	private SamplePersonRepository personRepository;
+	private QualifiedProductRepository qualifiedProductRepository;
 
 	@BeforeClass
 	public static void init() throws Exception {
@@ -54,6 +55,7 @@ public class CdiRepositoryTests {
 		CdiRepositoryClient client = cdiContainer.getInstance(CdiRepositoryClient.class);
 		repository = client.getRepository();
 		personRepository = client.getSamplePersonRepository();
+		qualifiedProductRepository = client.getQualifiedProductRepository();
 	}
 
 	@Test
@@ -81,6 +83,37 @@ public class CdiRepositoryTests {
 
 		assertEquals(0, repository.count());
 		retrieved = repository.findOne(bean.getId());
+		assertNull(retrieved);
+	}
+
+	/**
+	 * @see DATAES-234
+	 */
+	@Test
+	public void testQualifiedCdiRepository() {
+		assertNotNull(qualifiedProductRepository);
+
+		Product bean = new Product();
+		bean.setId("id-1");
+		bean.setName("cidContainerTest-1");
+
+		qualifiedProductRepository.save(bean);
+
+		assertTrue(qualifiedProductRepository.exists(bean.getId()));
+
+		Product retrieved = qualifiedProductRepository.findOne(bean.getId());
+		assertNotNull(retrieved);
+		assertEquals(bean.getId(), retrieved.getId());
+		assertEquals(bean.getName(), retrieved.getName());
+
+		assertEquals(1, qualifiedProductRepository.count());
+
+		assertTrue(qualifiedProductRepository.exists(bean.getId()));
+
+		qualifiedProductRepository.delete(bean);
+
+		assertEquals(0, qualifiedProductRepository.count());
+		retrieved = qualifiedProductRepository.findOne(bean.getId());
 		assertNull(retrieved);
 	}
 

--- a/src/test/java/org/springframework/data/elasticsearch/repositories/cdi/ElasticsearchTemplateProducer.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repositories/cdi/ElasticsearchTemplateProducer.java
@@ -18,13 +18,11 @@ package org.springframework.data.elasticsearch.repositories.cdi;
 import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
-import javax.xml.parsers.ParserConfigurationException;
-import java.io.IOException;
 
+import org.elasticsearch.client.node.NodeClient;
 import org.springframework.data.elasticsearch.Utils;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.ElasticsearchTemplate;
-import org.xml.sax.SAXException;
 
 /**
  * @author Mohsin Husen
@@ -33,8 +31,20 @@ import org.xml.sax.SAXException;
 class ElasticsearchTemplateProducer {
 
 	@Produces
-	public ElasticsearchOperations createElasticsearchTemplate() throws IOException, ParserConfigurationException, SAXException {
-		return new ElasticsearchTemplate(Utils.getNodeClient());
+	public NodeClient createNodeClient() {
+		return Utils.getNodeClient();
+	}
+
+	@Produces
+	public ElasticsearchOperations createElasticsearchTemplate(NodeClient nodeClient) {
+		return new ElasticsearchTemplate(nodeClient);
+	}
+
+	@Produces
+	@OtherQualifier
+	@PersonDB
+	public ElasticsearchOperations createQualifiedElasticsearchTemplate(NodeClient nodeClient) {
+		return new ElasticsearchTemplate(nodeClient);
 	}
 
 	@PreDestroy

--- a/src/test/java/org/springframework/data/elasticsearch/repositories/cdi/OtherQualifier.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repositories/cdi/OtherQualifier.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.elasticsearch.repositories.cdi;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ * @author Mark Paluch
+ * @see DATAES-234
+ */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })
+@interface OtherQualifier {
+
+}

--- a/src/test/java/org/springframework/data/elasticsearch/repositories/cdi/PersonDB.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repositories/cdi/PersonDB.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.elasticsearch.repositories.cdi;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ * @author Mark Paluch
+ * @see DATAES-234
+ */
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })
+@interface PersonDB {
+
+}

--- a/src/test/java/org/springframework/data/elasticsearch/repositories/cdi/QualifiedProductRepository.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repositories/cdi/QualifiedProductRepository.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.repositories.cdi;
+
+import org.springframework.data.elasticsearch.entities.Product;
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * @author Mark Paluch
+ * @see DATAES-234
+ */
+@PersonDB
+@OtherQualifier
+public interface QualifiedProductRepository extends CrudRepository<Product, String> {
+
+}


### PR DESCRIPTION
Qualifiers are now stored in their original set instead of using the toString representation.