### PR TITLE
DATAES-220 - added support for searchbox-io/jest client.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,8 @@
         <commonscollections>3.2.1</commonscollections>
         <commonslang>2.6</commonslang>
         <elasticsearch>2.2.0</elasticsearch>
+        <jest>2.0.3-SNAPSHOT</jest>
+        <gson>2.4</gson>
         <springdata.commons>1.13.0.BUILD-SNAPSHOT</springdata.commons>
 
     </properties>
@@ -93,6 +95,26 @@
             <artifactId>cdi-api</artifactId>
             <version>${cdi}</version>
             <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- JEST -->
+        <dependency>
+            <groupId>io.searchbox</groupId>
+            <artifactId>jest</artifactId>
+            <version>${jest}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gson}</version>
             <optional>true</optional>
         </dependency>
 

--- a/src/main/java/org/springframework/data/elasticsearch/core/DefaultJestResultsMapper.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/DefaultJestResultsMapper.java
@@ -1,0 +1,196 @@
+package org.springframework.data.elasticsearch.core;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+
+import org.apache.commons.lang.StringUtils;
+import org.elasticsearch.search.SearchHitField;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.ElasticsearchException;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.core.jest.MultiDocumentResult;
+import org.springframework.data.elasticsearch.core.jest.ScrollSearchResult;
+import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentEntity;
+import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentProperty;
+import org.springframework.data.elasticsearch.core.query.SearchQuery;
+import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.mapping.context.MappingContext;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+import io.searchbox.client.JestResult;
+import io.searchbox.core.DocumentResult;
+import io.searchbox.core.SearchResult;
+
+import static org.apache.commons.lang.StringUtils.isBlank;
+
+/**
+ * Jest implementation of Spring Data Elasticsearch results mapper.
+ *
+ * @author Julien Roy
+ * @author Robert Gruendler
+ */
+public class DefaultJestResultsMapper implements JestResultsMapper {
+
+	private EntityMapper entityMapper;
+	private MappingContext<? extends ElasticsearchPersistentEntity<?>, ElasticsearchPersistentProperty> mappingContext;
+
+	public DefaultJestResultsMapper() {
+		this.entityMapper = new DefaultEntityMapper();
+	}
+
+	public DefaultJestResultsMapper(EntityMapper entityMapper) {
+		this.entityMapper = entityMapper;
+	}
+
+	public DefaultJestResultsMapper(MappingContext<? extends ElasticsearchPersistentEntity<?>, ElasticsearchPersistentProperty> mappingContext) {
+		this.entityMapper = new DefaultEntityMapper();
+		this.mappingContext = mappingContext;
+	}
+
+	public DefaultJestResultsMapper(MappingContext<? extends ElasticsearchPersistentEntity<?>, ElasticsearchPersistentProperty> mappingContext, EntityMapper entityMapper) {
+		this.entityMapper = entityMapper;
+		this.mappingContext = mappingContext;
+	}
+
+	@Override
+	public EntityMapper getEntityMapper() {
+		return this.entityMapper;
+	}
+
+	@Override
+	public <T> T mapResult(DocumentResult response, Class<T> clazz) {
+		T result = mapEntity(response.getJsonObject().get("_source").toString(), clazz);
+		if (result != null) {
+			setPersistentEntityId(result, response.getId(), clazz);
+		}
+		return result;
+	}
+
+	@Override
+    public <T> LinkedList<T> mapResults(MultiDocumentResult multiResponse, Class<T> clazz) {
+
+        LinkedList<T> results = new LinkedList<T>();
+
+        for (MultiDocumentResult.MultiDocumentResultItem item : multiResponse.getItems()) {
+            T result = mapEntity(item.getSource(), clazz);
+            setPersistentEntityId(result, item.getId(), clazz);
+            results.add(result);
+        }
+
+        return results;
+    }
+
+	@Override
+	public <T> Page<T> mapResults(ScrollSearchResult response, Class<T> clazz) {
+		List<T> results = new ArrayList<T>();
+
+		for(JsonElement elem : response.getJsonObject().get("hits").getAsJsonObject().get("hits").getAsJsonArray()) {
+			JsonObject hit = elem.getAsJsonObject();
+
+			if (hit.get("_source") != null) {
+				T result = mapEntity(hit.get("_source").toString(), clazz);
+				setPersistentEntityId(result, hit.get("_id").getAsString(), clazz);
+				results.add(result);
+			} else {
+				//TODO(Fields resutls) : Map Fields results
+				//result = mapEntity(hit.getAsJsonObject().get("fields").getAsJsonObject(), clazz);
+			}
+		}
+
+		//TODO: Add Total And Pageable
+		return new PageImpl<T>(results, null, 0);
+	}
+
+	private <T> T mapEntity(Collection<SearchHitField> values, Class<T> clazz) {
+		return mapEntity(buildJSONFromFields(values), clazz);
+	}
+
+	private <T> T mapEntity(String source, Class<T> clazz) {
+		if (isBlank(source)) {
+			return null;
+		}
+		try {
+			return entityMapper.mapToObject(source, clazz);
+		} catch (IOException e) {
+			throw new ElasticsearchException("failed to map source [ " + source + "] to class " + clazz.getSimpleName(), e);
+		}
+	}
+
+	private String buildJSONFromFields(Collection<SearchHitField> values) {
+		JsonFactory nodeFactory = new JsonFactory();
+		try {
+			ByteArrayOutputStream stream = new ByteArrayOutputStream();
+			JsonGenerator generator = nodeFactory.createGenerator(stream, JsonEncoding.UTF8);
+			generator.writeStartObject();
+			for (SearchHitField value : values) {
+				if (value.getValues().size() > 1) {
+					generator.writeArrayFieldStart(value.getName());
+					for (Object val : value.getValues()) {
+						generator.writeObject(val);
+					}
+					generator.writeEndArray();
+				} else {
+					generator.writeObjectField(value.getName(), value.getValue());
+				}
+			}
+			generator.writeEndObject();
+			generator.flush();
+			return new String(stream.toByteArray(), Charset.forName("UTF-8"));
+		} catch (IOException e) {
+			return null;
+		}
+	}
+
+	private <T> void setPersistentEntityId(T result, String id, Class<T> clazz) {
+		if (mappingContext != null && clazz.isAnnotationPresent(Document.class)) {
+			PersistentProperty<ElasticsearchPersistentProperty> idProperty = mappingContext.getPersistentEntity(clazz).getIdProperty();
+			// Only deal with String because ES generated Ids are strings !
+			if (idProperty != null && idProperty.getType().isAssignableFrom(String.class)) {
+				Method setter = idProperty.getSetter();
+				if (setter != null) {
+					try {
+						setter.invoke(result, id);
+					} catch (Throwable t) {
+						t.printStackTrace();
+					}
+				}
+			}
+		}
+	}
+
+	@Override
+	public <T> Page<T> mapResults(SearchResult response, Class<T> clazz, Pageable pageable, SearchQuery query) {
+
+		List<T> results = new ArrayList<T>();
+		for (SearchResult.Hit<JsonObject, Void> hit : response.getHits(JsonObject.class)) {
+			if (hit != null) {
+				T result = null;
+				if (!StringUtils.isEmpty(hit.source.toString())) {
+					result = mapEntity(hit.source.toString(), clazz);
+					// http://stackoverflow.com/a/16640647/965338
+					setPersistentEntityId(result, hit.source.get(JestResult.ES_METADATA_ID).getAsString(), clazz);
+				} else {
+					//TODO(Fields results) : Map Fields results
+					//result = mapEntity(hit.getAsJsonObject().get("fields").getAsJsonObject(), clazz);
+				}
+				results.add(result);
+			}
+		}
+
+		return new PageImpl<T>(results, pageable, response.getTotal());
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/JestElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/JestElasticsearchTemplate.java
@@ -1,0 +1,1274 @@
+package org.springframework.data.elasticsearch.core;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import org.elasticsearch.action.update.UpdateResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.AliasMetaData;
+import org.elasticsearch.common.collect.MapBuilder;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.highlight.HighlightBuilder;
+import org.elasticsearch.search.sort.SortBuilder;
+import org.elasticsearch.search.sort.SortOrder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.elasticsearch.ElasticsearchException;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Setting;
+import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
+import org.springframework.data.elasticsearch.core.convert.MappingElasticsearchConverter;
+import org.springframework.data.elasticsearch.core.jest.ExtendedSearchResult;
+import org.springframework.data.elasticsearch.core.jest.MultiDocumentResult;
+import org.springframework.data.elasticsearch.core.jest.ScrollSearchResult;
+import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentEntity;
+import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
+import org.springframework.data.elasticsearch.core.query.AliasQuery;
+import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
+import org.springframework.data.elasticsearch.core.query.DeleteQuery;
+import org.springframework.data.elasticsearch.core.query.GetQuery;
+import org.springframework.data.elasticsearch.core.query.IndexBoost;
+import org.springframework.data.elasticsearch.core.query.IndexQuery;
+import org.springframework.data.elasticsearch.core.query.MoreLikeThisQuery;
+import org.springframework.data.elasticsearch.core.query.Query;
+import org.springframework.data.elasticsearch.core.query.ScriptField;
+import org.springframework.data.elasticsearch.core.query.SearchQuery;
+import org.springframework.data.elasticsearch.core.query.StringQuery;
+import org.springframework.data.elasticsearch.core.query.UpdateQuery;
+import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.util.CloseableIterator;
+import org.springframework.util.Assert;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import io.searchbox.action.Action;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestResult;
+import io.searchbox.core.Bulk;
+import io.searchbox.core.BulkResult;
+import io.searchbox.core.ClearScroll;
+import io.searchbox.core.Count;
+import io.searchbox.core.CountResult;
+import io.searchbox.core.Delete;
+import io.searchbox.core.DeleteByQuery;
+import io.searchbox.core.DocumentResult;
+import io.searchbox.core.Get;
+import io.searchbox.core.Index;
+import io.searchbox.core.MultiGet;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import io.searchbox.core.SearchScroll;
+import io.searchbox.core.Update;
+import io.searchbox.indices.CreateIndex;
+import io.searchbox.indices.DeleteIndex;
+import io.searchbox.indices.IndicesExists;
+import io.searchbox.indices.Refresh;
+import io.searchbox.indices.Refresh.Builder;
+import io.searchbox.indices.aliases.AddAliasMapping;
+import io.searchbox.indices.aliases.GetAliases;
+import io.searchbox.indices.aliases.ModifyAliases;
+import io.searchbox.indices.aliases.RemoveAliasMapping;
+import io.searchbox.indices.mapping.GetMapping;
+import io.searchbox.indices.mapping.PutMapping;
+import io.searchbox.indices.settings.GetSettings;
+import io.searchbox.indices.type.TypeExist;
+import io.searchbox.params.Parameters;
+import io.searchbox.params.SearchType;
+
+import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.apache.commons.lang.StringUtils.isNotBlank;
+import static org.elasticsearch.index.VersionType.EXTERNAL;
+import static org.springframework.util.CollectionUtils.isEmpty;
+
+/**
+ * Jest implementation of ElasticsearchOperations.
+ *
+ * @author Roy Julien
+ * @author Robert Gruendler
+ */
+public class JestElasticsearchTemplate implements ElasticsearchOperations, ApplicationContextAware {
+
+	private static final Logger logger = LoggerFactory.getLogger(JestElasticsearchTemplate.class);
+
+	private final JestClient client;
+	private final ElasticsearchConverter elasticsearchConverter;
+	private final JestResultsMapper resultsMapper;
+
+	public JestElasticsearchTemplate(JestClient client) {
+		this(client, null, null);
+	}
+
+	public JestElasticsearchTemplate(JestClient client, JestResultsMapper resultMapper) {
+		this(client, null, resultMapper);
+	}
+
+	public JestElasticsearchTemplate(JestClient client, ElasticsearchConverter elasticsearchConverter, JestResultsMapper resultsMapper) {
+		this.client = client;
+		this.elasticsearchConverter = (elasticsearchConverter == null) ? new MappingElasticsearchConverter(new SimpleElasticsearchMappingContext()) : elasticsearchConverter;
+		this.resultsMapper = (resultsMapper == null) ? new DefaultJestResultsMapper(this.elasticsearchConverter.getMappingContext()) : resultsMapper;
+	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext context) throws BeansException {
+		if (elasticsearchConverter instanceof ApplicationContextAware) {
+			((ApplicationContextAware) elasticsearchConverter).setApplicationContext(context);
+		}
+	}
+
+	@Override
+	public ElasticsearchConverter getElasticsearchConverter() {
+		return elasticsearchConverter;
+	}
+
+	@Override
+	public Client getClient() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public <T> boolean createIndex(Class<T> clazz) {
+		return createIndexIfNotCreated(clazz);
+	}
+
+	@Override
+	public boolean createIndex(String indexName) {
+		JestResult result = execute(new CreateIndex.Builder(indexName).build());
+		return result.isSucceeded();
+	}
+
+	@Override
+	public boolean createIndex(String indexName, Object settings) {
+
+		CreateIndex.Builder createIndexBuilder = new CreateIndex.Builder(indexName);
+
+		if (settings instanceof String) {
+			createIndexBuilder.settings(String.valueOf(settings));
+		} else if (settings instanceof Map) {
+			createIndexBuilder.settings(settings);
+		} else if (settings instanceof XContentBuilder) {
+			createIndexBuilder.settings(settings);
+		}
+
+		return executeWithAcknowledge(createIndexBuilder.build());
+	}
+
+	@Override
+	public <T> boolean createIndex(Class<T> clazz, Object settings) {
+		return createIndex(getPersistentEntityFor(clazz).getIndexName(), settings);
+	}
+
+	@Override
+	public <T> boolean putMapping(Class<T> clazz) {
+		logger.warn("putMapping(Class<T> clazz) not implemented yet in jest client");
+		return false;
+	}
+
+	@Override
+	public boolean putMapping(String indexName, String type, Object mapping) {
+		Assert.notNull(indexName, "No index defined for putMapping()");
+		Assert.notNull(type, "No type defined for putMapping()");
+
+		Object source = null;
+		if (mapping instanceof String) {
+			source = String.valueOf(mapping);
+		} else if (mapping instanceof Map) {
+			source = mapping;
+		} else if (mapping instanceof XContentBuilder) {
+			source = mapping;
+		}
+
+		PutMapping.Builder requestBuilder = new PutMapping.Builder(indexName, type, source);
+
+		return executeWithAcknowledge(requestBuilder.build());
+	}
+
+	@Override
+	public <T> boolean putMapping(Class<T> clazz, Object mapping) {
+		return putMapping(getPersistentEntityFor(clazz).getIndexName(), getPersistentEntityFor(clazz).getIndexType(), mapping);
+	}
+
+	@Override
+	public <T> Map getMapping(Class<T> clazz) {
+		return getMapping(getPersistentEntityFor(clazz).getIndexName(), getPersistentEntityFor(clazz).getIndexType());
+	}
+
+	@Override
+	public Map getMapping(String indexName, String type) {
+		Assert.notNull(indexName, "No index defined for putMapping()");
+		Assert.notNull(type, "No type defined for putMapping()");
+		Map mappings = new HashMap();
+
+		try {
+
+			GetMapping.Builder getMappingBuilder = new GetMapping.Builder();
+			getMappingBuilder.addIndex(indexName).addType(type);
+
+			JestResult result = execute(getMappingBuilder.build());
+
+			JsonObject rawProperties = result.getJsonObject().get(indexName).getAsJsonObject()
+					.get("mappings").getAsJsonObject()
+					.get(type).getAsJsonObject().get("properties").getAsJsonObject();
+
+			Map<String, String> properties = new HashMap<String, String>();
+			for (Map.Entry<String, JsonElement> entry : rawProperties.entrySet()) {
+				properties.put(entry.getKey(), entry.getValue().getAsJsonObject().get("type").getAsString());
+			}
+
+			mappings.put("properties", properties);
+		} catch (Exception e) {
+			throw new ElasticsearchException("Error while getting mapping for indexName : " + indexName + " type : " + type + " " + e.getMessage());
+		}
+		return mappings;
+	}
+
+	@Override
+	public Map getSetting(String indexName) {
+		Assert.notNull(indexName, "No index defined for getSettings");
+
+		GetSettings.Builder getSettingsBuilder = new GetSettings.Builder();
+		getSettingsBuilder.addIndex(indexName);
+
+		JestResult result = execute(getSettingsBuilder.build());
+
+		Set<Map.Entry<String, JsonElement>> entries = result.getJsonObject()
+				.get(indexName).getAsJsonObject()
+				.get("settings").getAsJsonObject()
+				.get("index").getAsJsonObject().entrySet();
+
+		HashMap<String, String> mappings = new HashMap<String, String>();
+		// flatten the settings hash to a "index.property.nestedProperty.etc -> value" map
+		for(Map.Entry<String, JsonElement> entry : entries) {
+
+			StringBuilder builder = new StringBuilder();
+			builder.append("index");
+			String value = null;
+			if (entry.getValue().isJsonPrimitive()) {
+				value = entry.getValue().getAsString();
+				builder.append(".").append(entry.getKey());
+				mappings.put(builder.toString(), value);
+			} else if (entry.getValue().isJsonArray()) {
+				// TODO
+			} else if (entry.getValue().isJsonObject()) {
+				builder.append(".").append(entry.getKey());
+				appendJsonObjectKeyValue((JsonObject) entry.getValue(), builder, mappings);
+			}
+
+			if (value != null) {
+			} else {
+				logger.warn("Unable to get value for setting " + builder.toString());
+			}
+		}
+		return mappings;
+	}
+
+	private void appendJsonObjectKeyValue(JsonObject jsonObject, StringBuilder builder, Map<String, String> mappings) {
+
+		for (Map.Entry<String, JsonElement> entry : jsonObject.entrySet()) {
+			if (entry.getValue().isJsonObject()) {
+				StringBuilder newBuilder = new StringBuilder(builder.toString());
+				newBuilder.append(".").append(entry.getKey());
+				appendJsonObjectKeyValue((JsonObject) entry.getValue(), newBuilder, mappings);
+			} else if (entry.getValue().isJsonArray()) {
+				// TODO
+			} else {
+				String key = builder.toString() + "." + entry.getKey();
+				mappings.put(key, entry.getValue().getAsString());
+			}
+		}
+	}
+
+	@Override
+	public <T> Map getSetting(Class<T> clazz) {
+		return getSetting(getPersistentEntityFor(clazz).getIndexName());
+	}
+
+	@Override
+	public <T> T queryForObject(GetQuery query, Class<T> clazz) {
+		return queryForObject(query, clazz, resultsMapper);
+	}
+
+	@Override
+	public <T> T queryForObject(GetQuery query, Class<T> clazz, GetResultMapper mapper) {
+		return queryForObject(query, clazz, resultsMapper);
+	}
+
+
+	public <T> T queryForObject(GetQuery query, Class<T> clazz, JestGetResultMapper mapper) {
+		return queryForObject(null, query, clazz, mapper);
+	}
+
+	public <T> T queryForObject(String indexName, GetQuery query, Class<T> clazz) {
+		return queryForObject(indexName, query, clazz, resultsMapper);
+	}
+
+	public <T> T queryForObject(String indexName, GetQuery query, Class<T> clazz, JestGetResultMapper mapper) {
+
+		ElasticsearchPersistentEntity<T> persistentEntity = getPersistentEntityFor(clazz);
+		String index = indexName == null ? persistentEntity.getIndexName() : indexName;
+		Get.Builder build = new Get.Builder(index, query.getId()).type(persistentEntity.getIndexType());
+		DocumentResult result = execute(build.build());
+
+		if (result.getResponseCode() == 404) {
+			return null;
+		}
+
+		return mapper.mapResult(result, clazz);
+	}
+
+	@Override
+	public <T> T queryForObject(CriteriaQuery query, Class<T> clazz) {
+		Page<T> page = queryForPage(query, clazz);
+		Assert.isTrue(page.getTotalElements() < 2, "Expected 1 but found " + page.getTotalElements() + " results");
+		return page.getTotalElements() > 0 ? page.getContent().get(0) : null;
+	}
+
+	@Override
+	public <T> T queryForObject(StringQuery query, Class<T> clazz) {
+		Page<T> page = queryForPage(query, clazz);
+		Assert.isTrue(page.getTotalElements() < 2, "Expected 1 but found " + page.getTotalElements() + " results");
+		return page.getTotalElements() > 0 ? page.getContent().get(0) : null;
+	}
+
+	@Override
+	public <T> Page<T> queryForPage(SearchQuery query, Class<T> clazz) {
+		return queryForPage(query, clazz, resultsMapper);
+	}
+
+	@Override
+	public <T> Page<T> queryForPage(SearchQuery query, Class<T> clazz, SearchResultMapper mapper) {
+		return queryForPage(query, clazz, resultsMapper);
+	}
+
+
+	@Override
+	public <T> T query(SearchQuery query, ResultsExtractor<T> resultsExtractor) {
+		// TODO
+		throw new UnsupportedOperationException();
+	}
+
+	public <T> T query(SearchQuery query, JestResultsExtractor<T> resultsExtractor) {
+		SearchResult response = doSearch(prepareSearch(query), query);
+		return resultsExtractor.extract(response);
+	}
+
+	@Override
+	public <T> List<T> queryForList(CriteriaQuery query, Class<T> clazz) {
+		return queryForPage(query, clazz).getContent();
+	}
+
+	@Override
+	public <T> List<T> queryForList(StringQuery query, Class<T> clazz) {
+		return queryForPage(query, clazz).getContent();
+	}
+
+	@Override
+	public <T> List<T> queryForList(SearchQuery query, Class<T> clazz) {
+		return queryForPage(query, clazz).getContent();
+	}
+
+	@Override
+	public <T> List<String> queryForIds(SearchQuery query) {
+		SearchSourceBuilder search = prepareSearch(query).query(query.getQuery()).noFields();
+		if (query.getFilter() != null) {
+			search.postFilter(query.getFilter());
+		}
+
+		SearchResult result = executeSearch(query, search);
+		return extractIds(result);
+	}
+
+	@Override
+	public <T> Page<T> queryForPage(CriteriaQuery criteriaQuery, Class<T> clazz) {
+        QueryBuilder elasticsearchQuery = new CriteriaQueryProcessor().createQueryFromCriteria(criteriaQuery.getCriteria());
+		QueryBuilder elasticsearchFilter = new CriteriaFilterProcessor().createFilterFromCriteria(criteriaQuery.getCriteria());
+
+        SearchSourceBuilder searchRequestBuilder = prepareSearch(criteriaQuery, clazz);
+
+        if (elasticsearchQuery != null) {
+            searchRequestBuilder.query(elasticsearchQuery);
+        } else {
+            searchRequestBuilder.query(QueryBuilders.matchAllQuery());
+        }
+
+        if (criteriaQuery.getMinScore() > 0) {
+            searchRequestBuilder.minScore(criteriaQuery.getMinScore());
+        }
+
+        if (elasticsearchFilter != null)
+            searchRequestBuilder.postFilter(elasticsearchFilter);
+
+		SearchResult response = executeSearch(criteriaQuery, searchRequestBuilder);
+		return resultsMapper.mapResults(response, clazz, criteriaQuery.getPageable(), null);
+	}
+
+	@Override
+	public <T> Page<T> queryForPage(StringQuery query, Class<T> clazz) {
+		return queryForPage(query, clazz, resultsMapper);
+	}
+
+	@Override
+	public <T> Page<T> queryForPage(StringQuery query, Class<T> clazz, SearchResultMapper mapper) {
+		return queryForPage(query, clazz, resultsMapper);
+	}
+
+	public <T> Page<T> queryForPage(SearchQuery query, Class<T> clazz, JestSearchResultMapper mapper) {
+        SearchResult response = doSearch(prepareSearch(query, clazz), query);
+        return mapper.mapResults(response, clazz, query.getPageable(), query);
+	}
+
+	public <T> Page<T> queryForPage(StringQuery query, Class<T> clazz, JestSearchResultMapper mapper) {
+		SearchResult response = executeSearch(null, prepareSearch(query, clazz).query(query.getSource()));
+		return mapper.mapResults(response, clazz, query.getPageable(), null);
+	}
+
+	@Override
+	public <T> CloseableIterator<T> stream(CriteriaQuery query, Class<T> clazz) {
+		final long scrollTimeInMillis = TimeValue.timeValueMinutes(1).millis();
+		final String initScrollId = scan(query, scrollTimeInMillis, false, clazz);
+		return doStream(initScrollId, scrollTimeInMillis, clazz, resultsMapper);
+	}
+
+	@Override
+	public <T> CloseableIterator<T> stream(SearchQuery query, Class<T> clazz) {
+		return stream(query, clazz, resultsMapper);
+	}
+
+	@Override
+	public <T> CloseableIterator<T> stream(SearchQuery query, Class<T> clazz, SearchResultMapper mapper) {
+		return stream(query, clazz, resultsMapper);
+	}
+
+	private <T> CloseableIterator<T> stream(SearchQuery query, Class<T> clazz, JestScrollResultMapper mapper) {
+		final long scrollTimeInMillis = TimeValue.timeValueMinutes(1).millis();
+		final String initScrollId = scan(query, scrollTimeInMillis, false, clazz);
+		return doStream(initScrollId, scrollTimeInMillis, clazz, mapper);
+	}
+
+	private <T> CloseableIterator<T> doStream(final String initScrollId, final long scrollTimeInMillis, final Class<T> clazz, final JestScrollResultMapper mapper) {
+
+		return new CloseableIterator<T>() {
+
+			/** As we couldn't retrieve single result with scroll, store current hits. */
+			private volatile Iterator<T> currentHits;
+
+			/** The scroll id. */
+			private volatile String scrollId = initScrollId;
+
+			/** If stream is finished (ie: cluster returns no results. */
+			private volatile boolean finished;
+
+			@Override
+			public boolean hasNext() {
+				// Test if stream is finished
+				if (finished) {
+					return false;
+				}
+				// Test if it remains hits
+				if (currentHits == null || !currentHits.hasNext()) {
+
+					SearchScroll scroll = new SearchScroll.Builder(scrollId, scrollTimeInMillis+"ms").build();
+					ScrollSearchResult response = new ScrollSearchResult(execute(scroll));
+
+					// Save hits and scroll id
+					currentHits = mapper.mapResults(response, clazz).iterator();
+					finished = !currentHits.hasNext();
+					scrollId = response.getScrollId();
+				}
+				return currentHits.hasNext();
+			}
+
+			@Override
+			public T next() {
+				if (hasNext()) {
+					return currentHits.next();
+				}
+				throw new NoSuchElementException();
+			}
+
+			@Override
+			public void remove() {
+				throw new UnsupportedOperationException("remove");
+			}
+
+			@Override
+			public void close() {
+				try {
+					// Clear scroll on cluster only in case of error (cause elasticsearch auto clear scroll when it's done)
+					if (!finished && scrollId != null && currentHits != null && currentHits.hasNext()) {
+						execute(new ClearScroll.Builder(scrollId).build());
+					}
+				} finally {
+					currentHits = null;
+					scrollId = null;
+				}
+			}
+		};
+	}
+
+	@Override
+	public <T> long count(CriteriaQuery criteriaQuery, Class<T> clazz) {
+        QueryBuilder elasticsearchQuery = new CriteriaQueryProcessor().createQueryFromCriteria(criteriaQuery.getCriteria());
+		QueryBuilder elasticsearchFilter = new CriteriaFilterProcessor().createFilterFromCriteria(criteriaQuery.getCriteria());
+
+        if (elasticsearchFilter == null) {
+            return doCount(prepareCount(criteriaQuery, clazz), elasticsearchQuery);
+        } else {
+            // filter could not be set into CountRequestBuilder, convert request into search request
+            return doCount(prepareSearch(criteriaQuery, clazz), elasticsearchQuery, elasticsearchFilter);
+        }
+	}
+
+	@Override
+	public <T> long count(SearchQuery searchQuery, Class<T> clazz) {
+		QueryBuilder elasticsearchQuery = searchQuery.getQuery();
+		QueryBuilder elasticsearchFilter = searchQuery.getFilter();
+
+		if (elasticsearchFilter == null) {
+			return doCount(prepareCount(searchQuery, clazz), elasticsearchQuery);
+		} else {
+			// filter could not be set into CountRequestBuilder, convert request into search request
+			return doCount(prepareSearch(searchQuery, clazz), elasticsearchQuery, elasticsearchFilter);
+		}
+	}
+
+	@Override
+	public <T> long count(CriteriaQuery query) {
+		return count(query, null);
+	}
+
+	@Override
+	public <T> long count(SearchQuery query) {
+		return count(query, null);
+	}
+
+	private long doCount(Count.Builder countRequestBuilder, QueryBuilder elasticsearchQuery) {
+		if (elasticsearchQuery != null) {
+			countRequestBuilder.query(new SearchSourceBuilder().query(elasticsearchQuery).toString());
+		}
+
+		CountResult result = execute(countRequestBuilder.build());
+		return result.getCount().longValue();
+	}
+
+	private long doCount(SearchSourceBuilder searchRequestBuilder, QueryBuilder elasticsearchQuery, QueryBuilder elasticsearchFilter) {
+		if (elasticsearchQuery != null) {
+			searchRequestBuilder.query(elasticsearchQuery);
+		} else {
+			searchRequestBuilder.query(QueryBuilders.matchAllQuery());
+		}
+		if (elasticsearchFilter != null) {
+			searchRequestBuilder.postFilter(elasticsearchFilter);
+		}
+
+		CountResult result = execute(new Count.Builder().query(searchRequestBuilder.toString()).build());
+		return result.getCount().longValue();
+	}
+
+	private <T> Count.Builder prepareCount(Query query, Class<T> clazz) {
+		String indexName[] = !isEmpty(query.getIndices()) ? query.getIndices().toArray(new String[query.getIndices().size()]) : retrieveIndexNameFromPersistentEntity(clazz);
+		String types[] = !isEmpty(query.getTypes()) ? query.getTypes().toArray(new String[query.getTypes().size()]) : retrieveTypeFromPersistentEntity(clazz);
+
+		Assert.notNull(indexName, "No index defined for Query");
+
+		Count.Builder countRequestBuilder = new Count.Builder().addIndex(Arrays.asList(indexName));
+		if (types != null) {
+			countRequestBuilder.addType(Arrays.asList(types));
+		}
+		return countRequestBuilder;
+	}
+
+	@Override
+	public <T> LinkedList<T> multiGet(SearchQuery searchQuery, Class<T> clazz, MultiGetResultMapper getResultMapper) {
+		return multiGet(searchQuery, clazz, resultsMapper);
+	}
+
+	public <T> LinkedList<T> multiGet(SearchQuery searchQuery, Class<T> clazz, JestMultiGetResultMapper getResultMapper) {
+		return getResultMapper.mapResults(getMultiResponse(searchQuery, clazz), clazz);
+	}
+
+	@Override
+	public <T> LinkedList<T> multiGet(SearchQuery searchQuery, Class<T> clazz) {
+		return resultsMapper.mapResults(getMultiResponse(searchQuery, clazz), clazz);
+	}
+
+	private <T> MultiDocumentResult getMultiResponse(Query searchQuery, Class<T> clazz) {
+
+		String indexName = !isEmpty(searchQuery.getIndices()) ? searchQuery.getIndices().get(0) : getPersistentEntityFor(clazz).getIndexName();
+		String type = !isEmpty(searchQuery.getTypes()) ? searchQuery.getTypes().get(0) : getPersistentEntityFor(clazz).getIndexType();
+
+		Assert.notNull(indexName, "No index defined for Query");
+		Assert.notNull(type, "No type define for Query");
+		Assert.notEmpty(searchQuery.getIds(), "No Id define for Query");
+
+		MultiGet.Builder.ById builder = new MultiGet.Builder.ById(indexName, type).addId(searchQuery.getIds());
+
+		return new MultiDocumentResult(execute(builder.build()));
+	}
+
+	@Override
+	public String index(IndexQuery query) {
+
+		String documentId = execute(prepareIndex(query)).getId();
+
+		// We should call this because we are not going through a mapper.
+		if (query.getObject() != null) {
+			setPersistentEntityId(query.getObject(), documentId);
+		}
+		return documentId;
+	}
+
+	@Override
+	public UpdateResponse update(UpdateQuery updateQuery) {
+		DocumentResult result = execute(prepareUpdate(updateQuery));
+		JsonObject jsonResult = result.getJsonObject();
+		int successful = jsonResult.get("_shards").getAsJsonObject().get("successful").getAsInt();
+		return new UpdateResponse(
+				jsonResult.get("_index").getAsString(),
+				jsonResult.get("_type").getAsString(),
+				jsonResult.get("_id").getAsString(),
+				jsonResult.get("_version").getAsLong(),
+				successful > 0
+		);
+	}
+
+	@Override
+	public void bulkIndex(List<IndexQuery> queries) {
+		Bulk.Builder bulk = new Bulk.Builder();
+
+		for (IndexQuery query : queries) {
+			bulk.addAction(prepareIndex(query));
+		}
+
+		BulkResult bulkResult = new BulkResult(execute(bulk.build()));
+		if (!bulkResult.isSucceeded()) {
+			Map<String, String> failedDocuments = new HashMap<String, String>();
+			for (BulkResult.BulkResultItem item : bulkResult.getFailedItems()) {
+				failedDocuments.put(item.id, item.error);
+			}
+			throw new ElasticsearchException(
+					"Bulk indexing has failures. Use ElasticsearchException.getFailedDocuments() for detailed messages ["
+							+ failedDocuments + "]", failedDocuments
+			);
+		}
+	}
+
+	@Override
+	public void bulkUpdate(List<UpdateQuery> queries) {
+
+		Bulk.Builder bulk = new Bulk.Builder();
+
+		for (UpdateQuery query : queries) {
+			bulk.addAction(prepareUpdate(query));
+		}
+
+		BulkResult bulkResult = new BulkResult(execute(bulk.build()));
+		if (!bulkResult.isSucceeded()) {
+			Map<String, String> failedDocuments = new HashMap<String, String>();
+			for (BulkResult.BulkResultItem item : bulkResult.getFailedItems()) {
+				failedDocuments.put(item.id, item.error);
+			}
+			throw new ElasticsearchException(
+					"Bulk indexing has failures. Use ElasticsearchException.getFailedDocuments() for detailed messages ["
+							+ failedDocuments + "]", failedDocuments
+			);
+		}
+	}
+
+	@Override
+	public String delete(String indexName, String type, String id) {
+		return execute(new Delete.Builder(id).index(indexName).type(type).build()).getId();
+	}
+
+	@Override
+	public <T> void delete(CriteriaQuery criteriaQuery, Class<T> clazz) {
+		QueryBuilder elasticsearchQuery = new CriteriaQueryProcessor().createQueryFromCriteria(criteriaQuery.getCriteria());
+		Assert.notNull(elasticsearchQuery, "Query can not be null.");
+		DeleteQuery deleteQuery = new DeleteQuery();
+		deleteQuery.setQuery(elasticsearchQuery);
+		delete(deleteQuery, clazz);
+	}
+
+	@Override
+	public <T> String delete(Class<T> clazz, String id) {
+		ElasticsearchPersistentEntity persistentEntity = getPersistentEntityFor(clazz);
+		return delete(persistentEntity.getIndexName(), persistentEntity.getIndexType(), id);
+	}
+
+	@Override
+	public <T> void delete(DeleteQuery query, Class<T> clazz) {
+		ElasticsearchPersistentEntity persistentEntity = getPersistentEntityFor(clazz);
+
+		DeleteByQuery deleteQuery = new DeleteByQuery.Builder(query.getQuery().toString()).
+				addIndex(persistentEntity.getIndexName()).
+				addType(persistentEntity.getIndexType()).build();
+
+		execute(deleteQuery);
+	}
+
+	@Override
+	public void delete(DeleteQuery query) {
+		Assert.notNull(query.getIndex(), "No index defined for Query");
+		Assert.notNull(query.getType(), "No type define for Query");
+
+		DeleteByQuery deleteQuery = new DeleteByQuery.Builder(query.getQuery().toString()).
+				addIndex(query.getIndex()).
+				addType(query.getType()).build();
+
+		execute(deleteQuery);
+
+	}
+
+	@Override
+	public <T> boolean deleteIndex(Class<T> clazz) {
+		return deleteIndex(getPersistentEntityFor(clazz).getIndexName());
+	}
+
+	@Override
+	public boolean deleteIndex(String indexName) {
+		Assert.notNull(indexName, "No index defined for delete operation");
+		if (indexExists(indexName)) {
+			return executeWithAcknowledge(new DeleteIndex.Builder(indexName).build());
+		}
+		return false;
+	}
+
+	@Override
+	public <T> boolean indexExists(Class<T> clazz) {
+		return indexExists(getPersistentEntityFor(clazz).getIndexName());
+	}
+
+	@Override
+	public boolean indexExists(String indexName) {
+		return executeWithAcknowledge(new IndicesExists.Builder(indexName).build());
+	}
+
+	@Override
+	public boolean typeExists(String index, String type) {
+		return executeWithAcknowledge(new TypeExist.Builder(index).addType(type).build());
+	}
+
+	@Override
+	public void refresh(String indexName) {
+		Assert.notNull(indexName, "No index defined for refresh()");
+		Refresh refresh = new Builder().addIndex(indexName).build();
+		execute(refresh);
+	}
+
+	@Override
+	public <T> void refresh(Class<T> clazz) {
+		refresh(getPersistentEntityFor(clazz).getIndexName());
+	}
+
+	@Override
+	public String scan(CriteriaQuery criteriaQuery, long scrollTimeInMillis, boolean noFields) {
+		Assert.notNull(criteriaQuery.getIndices(), "No index defined for Query");
+		Assert.notNull(criteriaQuery.getTypes(), "No type define for Query");
+		Assert.notNull(criteriaQuery.getPageable(), "Query.pageable is required for scan & scroll");
+
+		QueryBuilder elasticsearchQuery = new CriteriaQueryProcessor().createQueryFromCriteria(criteriaQuery.getCriteria());
+		QueryBuilder elasticsearchFilter = new CriteriaFilterProcessor().createFilterFromCriteria(criteriaQuery.getCriteria());
+
+		SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(elasticsearchQuery != null ? elasticsearchQuery : QueryBuilders.matchAllQuery());
+
+		if (elasticsearchFilter != null) {
+			searchSourceBuilder.postFilter(elasticsearchFilter);
+		}
+
+		if (!isEmpty(criteriaQuery.getFields())) {
+			searchSourceBuilder.fields(criteriaQuery.getFields());
+		}
+
+		if (noFields) {
+			searchSourceBuilder.noFields();
+		}
+
+		Search.Builder search = new Search.Builder(searchSourceBuilder.toString()).
+				addType(criteriaQuery.getTypes()).
+				addIndex(criteriaQuery.getIndices()).
+				setSearchType(SearchType.SCAN).
+				setParameter(Parameters.SIZE, criteriaQuery.getPageable().getPageSize()).
+				setParameter(Parameters.SCROLL, scrollTimeInMillis+"ms");
+
+		return new ExtendedSearchResult(execute(search.build())).getScrollId();
+	}
+
+	@Override
+	public <T> String scan(CriteriaQuery query, long scrollTimeInMillis, boolean noFields, Class<T> clazz) {
+		setPersistentEntityIndexAndType(query, clazz);
+		return scan(query, scrollTimeInMillis, noFields);
+	}
+
+	@Override
+	public String scan(SearchQuery searchQuery, long scrollTimeInMillis, boolean noFields) {
+		Assert.notNull(searchQuery.getIndices(), "No index defined for Query");
+		Assert.notNull(searchQuery.getTypes(), "No type define for Query");
+		Assert.notNull(searchQuery.getPageable(), "Query.pageable is required for scan & scroll");
+
+		SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(searchQuery.getQuery());
+
+		if (!isEmpty(searchQuery.getFields())) {
+			searchSourceBuilder.fields(searchQuery.getFields());
+		}
+
+		if (noFields) {
+			searchSourceBuilder.noFields();
+		}
+
+		if (searchQuery.getFilter() != null) {
+			searchSourceBuilder.postFilter(searchQuery.getFilter());
+		}
+
+		Search.Builder search = new Search.Builder(searchSourceBuilder.toString()).
+			addType(searchQuery.getTypes()).
+			addIndex(searchQuery.getIndices()).
+			setSearchType(SearchType.SCAN).
+			setParameter(Parameters.SIZE, searchQuery.getPageable().getPageSize()).
+			setParameter(Parameters.SCROLL, scrollTimeInMillis+"ms");
+
+		return new ExtendedSearchResult(execute(search.build())).getScrollId();
+	}
+
+	@Override
+	public <T> String scan(SearchQuery query, long scrollTimeInMillis, boolean noFields, Class<T> clazz) {
+		setPersistentEntityIndexAndType(query, clazz);
+		return scan(query, scrollTimeInMillis, noFields);
+	}
+
+	@Override
+	public <T> Page<T> scroll(String scrollId, long scrollTimeInMillis, Class<T> clazz) {
+		SearchScroll scroll = new SearchScroll.Builder(scrollId, scrollTimeInMillis+"ms").build();
+		ScrollSearchResult response = getScrollSearchResult(execute(scroll));
+		return resultsMapper.mapResults(response, clazz);
+	}
+
+	@Override
+	public <T> Page<T> scroll(String scrollId, long scrollTimeInMillis, SearchResultMapper mapper) {
+		return scroll(scrollId, scrollTimeInMillis, resultsMapper);
+	}
+
+	@VisibleForTesting
+	public ScrollSearchResult getScrollSearchResult(JestResult jestResult) {
+		return new ScrollSearchResult(jestResult);
+	}
+
+	@Override
+	public <T> void clearScroll(String scrollId) {
+		execute(new ClearScroll.Builder(scrollId).build());
+	}
+
+	public <T> Page<T> scroll(String scrollId, long scrollTimeInMillis, JestScrollResultMapper mapper) {
+		SearchScroll scroll = new SearchScroll.Builder(scrollId, scrollTimeInMillis+"ms").build();
+		ScrollSearchResult response = new ScrollSearchResult(execute(scroll));
+		return mapper.mapResults(response, null);
+	}
+
+	@Override
+	public <T> Page<T> moreLikeThis(MoreLikeThisQuery query, Class<T> clazz) {
+		// TODO
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Boolean addAlias(AliasQuery query) {
+		Assert.notNull(query.getIndexName(), "No index defined for Alias");
+		Assert.notNull(query.getAliasName(), "No alias defined");
+
+		AddAliasMapping.Builder aliasAction = new AddAliasMapping.Builder(query.getIndexName(), query.getAliasName());
+		if (query.getFilterBuilder() != null) {
+			//TODO(setFilter on alias)
+//            aliasAction.setFilter(query.getFilterBuilder());
+		} else if (query.getFilter() != null) {
+			aliasAction.setFilter(query.getFilter());
+		} else if (isNotBlank(query.getRouting())) {
+			aliasAction.addRouting(query.getRouting());
+		} else if (isNotBlank(query.getSearchRouting())) {
+			aliasAction.addSearchRouting(query.getSearchRouting());
+		} else if (isNotBlank(query.getIndexRouting())) {
+			aliasAction.addIndexRouting(query.getIndexRouting());
+		}
+		return executeWithAcknowledge(new ModifyAliases.Builder(aliasAction.build()).build());
+	}
+
+	@Override
+	public Boolean removeAlias(AliasQuery query) {
+		Assert.notNull(query.getIndexName(), "No index defined for Alias");
+		Assert.notNull(query.getAliasName(), "No alias defined");
+
+		RemoveAliasMapping removeAlias = new RemoveAliasMapping.Builder(query.getIndexName(), query.getAliasName()).build();
+		return executeWithAcknowledge(new ModifyAliases.Builder(removeAlias).build());
+	}
+
+	@Override
+	public List<AliasMetaData> queryForAlias(String indexName) {
+
+		GetAliases getAliases = new GetAliases.Builder().addIndex(indexName).build();
+		JestResult result = execute(getAliases);
+		if (!result.isSucceeded()) {
+			return Collections.emptyList();
+		}
+
+		Set<Map.Entry<String, JsonElement>> entries = result.getJsonObject().getAsJsonObject(indexName).getAsJsonObject("aliases").entrySet();
+
+		List<AliasMetaData> aliases = new ArrayList<AliasMetaData>(entries.size());
+		for(Map.Entry<String, JsonElement> entry : entries) {
+			aliases.add(AliasMetaData.builder(entry.getKey()).build());
+		}
+		return aliases;
+
+	}
+
+	@VisibleForTesting
+	public <T extends JestResult> T execute(Action<T> action) {
+		try {
+			return client.execute(action);
+		} catch (IOException e) {
+			throw new ElasticsearchException("failed to execute action", e);
+		}
+	}
+
+	private boolean executeWithAcknowledge(Action<?> action) {
+		try {
+			JestResult jestResult = client.execute(action);
+			return jestResult.isSucceeded();
+		} catch (IOException e) {
+			throw new ElasticsearchException("failed to execute action", e);
+		}
+	}
+
+	private <T> SearchSourceBuilder prepareSearch(Query query, Class<T> clazz) {
+		if (query.getIndices().isEmpty()) {
+			query.addIndices(retrieveIndexNameFromPersistentEntity(clazz));
+		}
+		if (query.getTypes().isEmpty()) {
+			query.addTypes(retrieveTypeFromPersistentEntity(clazz));
+		}
+		return prepareSearch(query);
+	}
+
+	private SearchSourceBuilder prepareSearch(Query query) {
+		Assert.notNull(query.getIndices(), "No index defined for Query");
+		Assert.notNull(query.getTypes(), "No type defined for Query");
+
+		SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+
+		int startRecord = 0;
+
+		if (query.getPageable() != null) {
+			startRecord = query.getPageable().getPageNumber() * query.getPageable().getPageSize();
+			searchSourceBuilder.size(query.getPageable().getPageSize());
+		}
+		searchSourceBuilder.from(startRecord);
+
+		if (!query.getFields().isEmpty()) {
+			searchSourceBuilder.fields(query.getFields());
+		}
+
+		if (query.getSort() != null) {
+			for (Sort.Order order : query.getSort()) {
+				searchSourceBuilder.sort(order.getProperty(), order.getDirection() == Sort.Direction.DESC ? SortOrder.DESC : SortOrder.ASC);
+			}
+		}
+
+		if (query.getMinScore() > 0) {
+			searchSourceBuilder.minScore(query.getMinScore());
+		}
+		return searchSourceBuilder;
+	}
+
+
+	private SearchResult doSearch(SearchSourceBuilder searchSourceBuilder, SearchQuery searchQuery) {
+		if (searchQuery.getFilter() != null) {
+			searchSourceBuilder.postFilter(searchQuery.getFilter());
+		}
+
+		if (!isEmpty(searchQuery.getElasticsearchSorts())) {
+			for (SortBuilder sort : searchQuery.getElasticsearchSorts()) {
+				searchSourceBuilder.sort(sort);
+			}
+		}
+
+		if (searchQuery.getHighlightFields() != null) {
+			HighlightBuilder highlighter = searchSourceBuilder.highlighter();
+			for (HighlightBuilder.Field highlightField : searchQuery.getHighlightFields()) {
+				highlighter.field(highlightField);
+			}
+		}
+
+		if (!isEmpty(searchQuery.getAggregations())) {
+			for (AbstractAggregationBuilder aggregationBuilder : searchQuery.getAggregations()) {
+				searchSourceBuilder.aggregation(aggregationBuilder);
+			}
+		}
+		if (!isEmpty(searchQuery.getIndicesBoost())) {
+			for (IndexBoost indexBoost : searchQuery.getIndicesBoost()) {
+				searchSourceBuilder.indexBoost(indexBoost.getIndexName(), indexBoost.getBoost());
+			}
+		}
+
+		if (!searchQuery.getScriptFields().isEmpty()) {
+			searchSourceBuilder.field("_source");
+			for (ScriptField scriptedField : searchQuery.getScriptFields()) {
+				searchSourceBuilder.scriptField(scriptedField.fieldName(), scriptedField.script());
+			}
+		}
+
+		return executeSearch(searchQuery, searchSourceBuilder.query(searchQuery.getQuery()));
+	}
+
+	private SearchResult executeSearch(Query query, SearchSourceBuilder request) {
+
+		Search.Builder search = new Search.Builder(request.toString());
+		if (query != null) {
+			search.
+					addType(query.getTypes()).
+					addIndex(query.getIndices()).
+					setSearchType(SearchType.valueOf(query.getSearchType().name()));
+		}
+
+		return new ExtendedSearchResult(execute(search.build()));
+	}
+
+	private Index prepareIndex(IndexQuery query) {
+		try {
+			String indexName = isBlank(query.getIndexName()) ? retrieveIndexNameFromPersistentEntity(query.getObject()
+					.getClass())[0] : query.getIndexName();
+			String type = isBlank(query.getType()) ? retrieveTypeFromPersistentEntity(query.getObject().getClass())[0]
+					: query.getType();
+
+			Index.Builder indexBuilder;
+
+			if (query.getObject() != null) {
+				String entityId = null;
+				if (isDocument(query.getObject().getClass())) {
+					entityId = getPersistentEntityId(query.getObject());
+				}
+
+				indexBuilder = new Index.Builder(resultsMapper.getEntityMapper().mapToString(query.getObject()));
+
+				// If we have a query id and a document id, do not ask ES to generate one.
+				if (query.getId() != null && entityId != null) {
+					indexBuilder.index(indexName).type(type).id(query.getId());
+				} else {
+					indexBuilder.index(indexName).type(type);
+				}
+			} else if (query.getSource() != null) {
+				indexBuilder = new Index.Builder(query.getSource()).index(indexName).type(type).id(query.getId());
+			} else {
+				throw new ElasticsearchException("object or source is null, failed to index the document [id: " + query.getId() + "]");
+			}
+			if (query.getVersion() != null) {
+				indexBuilder.setParameter(Parameters.VERSION, query.getVersion());
+				indexBuilder.setParameter(Parameters.VERSION_TYPE, EXTERNAL);
+			}
+
+			if (query.getParentId() != null) {
+				indexBuilder.setParameter(Parameters.PARENT, query.getParentId());
+			}
+
+			return indexBuilder.build();
+		} catch (IOException e) {
+			throw new ElasticsearchException("failed to index the document [id: " + query.getId() + "]", e);
+		}
+	}
+
+	private Update prepareUpdate(UpdateQuery query) {
+		String indexName = isNotBlank(query.getIndexName()) ? query.getIndexName() : getPersistentEntityFor(query.getClazz()).getIndexName();
+		String type = isNotBlank(query.getType()) ? query.getType() : getPersistentEntityFor(query.getClazz()).getIndexType();
+		Assert.notNull(indexName, "No index defined for Query");
+		Assert.notNull(type, "No type define for Query");
+		Assert.notNull(query.getId(), "No Id define for Query");
+		Assert.notNull(query.getUpdateRequest(), "No IndexRequest define for Query");
+
+		Map<String, Object> payLoadMap = new HashMap<String, Object>();
+
+		if (query.getUpdateRequest().script() == null) {
+
+			Map<String, Object> sourceAsMap = null;
+
+			if (query.getUpdateRequest().doc().source() != null) {
+				sourceAsMap = query.getUpdateRequest().doc().sourceAsMap();
+			}
+
+			// doc
+			if (query.DoUpsert()) {
+				payLoadMap.put("doc_as_upsert", Boolean.TRUE);
+				payLoadMap.put("doc", sourceAsMap);
+			} else {
+				payLoadMap.put("doc", sourceAsMap);
+			}
+
+		} else {
+			Script script = query.getUpdateRequest().script();
+			payLoadMap.put("script", script.getScript());
+			payLoadMap.put("lang", script.getLang());
+			payLoadMap.put("params", script.getParams());
+		}
+
+		try {
+			String payload = resultsMapper.getEntityMapper().mapToString(payLoadMap);
+			Update.Builder updateBuilder = new Update.Builder(payload).index(indexName).type(type).id(query.getId());
+			return updateBuilder.build();
+
+		} catch (IOException e) {
+			throw new ElasticsearchException("failed to index the document [id: " + query.getId() + "]", e);
+		}
+	}
+
+	private <T> Map getDefaultSettings(ElasticsearchPersistentEntity<T> persistentEntity) {
+		return new MapBuilder<String, String>().put("index.number_of_shards", String.valueOf(persistentEntity.getShards()))
+				.put("index.number_of_replicas", String.valueOf(persistentEntity.getReplicas()))
+				.put("index.refresh_interval", persistentEntity.getRefreshInterval())
+				.put("index.store.type", persistentEntity.getIndexStoreType()).map();
+	}
+
+	private <T> boolean createIndexIfNotCreated(Class<T> clazz) {
+		return indexExists(getPersistentEntityFor(clazz).getIndexName()) || createIndexWithSettings(clazz);
+	}
+
+	private <T> boolean createIndexWithSettings(Class<T> clazz) {
+		if (clazz.isAnnotationPresent(Setting.class)) {
+			String settingPath = clazz.getAnnotation(Setting.class).settingPath();
+			if (isNotBlank(settingPath)) {
+				String settings = readFileFromClasspath(settingPath);
+				if (isNotBlank(settings)) {
+					return createIndex(getPersistentEntityFor(clazz).getIndexName(), settings);
+				}
+			} else {
+				logger.info("settingPath in @Setting has to be defined. Using default instead.");
+			}
+		}
+		return createIndex(getPersistentEntityFor(clazz).getIndexName(), getDefaultSettings(getPersistentEntityFor(clazz)));
+	}
+
+	private boolean isDocument(Class clazz) {
+		return clazz.isAnnotationPresent(Document.class);
+	}
+
+	public ElasticsearchPersistentEntity getPersistentEntityFor(Class clazz) {
+		Assert.isTrue(clazz.isAnnotationPresent(Document.class), "Unable to identify index name. " + clazz.getSimpleName()
+				+ " is not a Document. Make sure the document class is annotated with @Document(indexName=\"foo\")");
+		return elasticsearchConverter.getMappingContext().getPersistentEntity(clazz);
+	}
+
+	private String getPersistentEntityId(Object entity) {
+		PersistentProperty idProperty = getPersistentEntityFor(entity.getClass()).getIdProperty();
+		if (idProperty != null) {
+			Method getter = idProperty.getGetter();
+			if (getter != null) {
+				try {
+					Object id = getter.invoke(entity);
+					if (id != null) {
+						return String.valueOf(id);
+					}
+				} catch (Throwable t) {
+					logger.error(t.getMessage(), t);
+				}
+			}
+		}
+		return null;
+	}
+
+	private void setPersistentEntityIndexAndType(Query query, Class clazz) {
+		if (query.getIndices().isEmpty()) {
+			query.addIndices(retrieveIndexNameFromPersistentEntity(clazz));
+		}
+		if (query.getTypes().isEmpty()) {
+			query.addTypes(retrieveTypeFromPersistentEntity(clazz));
+		}
+	}
+
+	private void setPersistentEntityId(Object entity, String id) {
+		PersistentProperty idProperty = getPersistentEntityFor(entity.getClass()).getIdProperty();
+		// Only deal with String because ES generated Ids are strings !
+		if (idProperty != null && idProperty.getType().isAssignableFrom(String.class)) {
+			Method setter = idProperty.getSetter();
+			if (setter != null) {
+				try {
+					setter.invoke(entity, id);
+				} catch (Throwable t) {
+					t.printStackTrace();
+				}
+			}
+		}
+	}
+
+	private String[] retrieveIndexNameFromPersistentEntity(Class clazz) {
+		if (clazz != null) {
+			return new String[]{getPersistentEntityFor(clazz).getIndexName()};
+		}
+		return null;
+	}
+
+	private String[] retrieveTypeFromPersistentEntity(Class clazz) {
+		if (clazz != null) {
+			return new String[]{getPersistentEntityFor(clazz).getIndexType()};
+		}
+		return null;
+	}
+
+	private List<String> extractIds(SearchResult result) {
+		List<String> ids = new ArrayList<String>();
+		for (SearchResult.Hit<JsonObject, Void> hit : result.getHits(JsonObject.class)) {
+			if (hit != null) {
+				ids.add(hit.source.get(JestResult.ES_METADATA_ID).toString());
+			}
+		}
+		return ids;
+	}
+
+	private static String readFileFromClasspath(String url) {
+		StringBuilder stringBuilder = new StringBuilder();
+
+		BufferedReader bufferedReader = null;
+
+		try {
+			ClassPathResource classPathResource = new ClassPathResource(url);
+			InputStreamReader inputStreamReader = new InputStreamReader(classPathResource.getInputStream());
+			bufferedReader = new BufferedReader(inputStreamReader);
+			String line;
+
+			while ((line = bufferedReader.readLine()) != null) {
+				stringBuilder.append(line);
+			}
+		} catch (Exception e) {
+			logger.debug(String.format("Failed to load file from url: %s: %s", url, e.getMessage()));
+			return null;
+		} finally {
+			if (bufferedReader != null) {
+				try {
+					bufferedReader.close();
+				} catch (IOException e) {
+					logger.debug(String.format("Unable to close buffered reader.. %s", e.getMessage()));
+				}
+			}
+		}
+
+		return stringBuilder.toString();
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/JestGetResultMapper.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/JestGetResultMapper.java
@@ -1,0 +1,13 @@
+package org.springframework.data.elasticsearch.core;
+
+import io.searchbox.core.DocumentResult;
+
+/**
+ * Jest specific get result mapper.
+ *
+ * @author Julien Roy
+ */
+public interface JestGetResultMapper {
+
+	<T> T mapResult(DocumentResult response, Class<T> clazz);
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/JestMultiGetResultMapper.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/JestMultiGetResultMapper.java
@@ -1,0 +1,15 @@
+package org.springframework.data.elasticsearch.core;
+
+import java.util.LinkedList;
+
+import org.springframework.data.elasticsearch.core.jest.MultiDocumentResult;
+
+/**
+ * Jest specific multi get result mapper.
+ *
+ * @author Julien Roy
+ */
+public interface JestMultiGetResultMapper {
+
+	<T> LinkedList<T> mapResults(MultiDocumentResult response, Class<T> clazz);
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/JestResultsExtractor.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/JestResultsExtractor.java
@@ -1,0 +1,14 @@
+package org.springframework.data.elasticsearch.core;
+
+import io.searchbox.core.SearchResult;
+
+/**
+ * Interface results extractor.
+ *
+ * @param <T> Type of extract result.
+ * @author Julien Roy
+ */
+public interface JestResultsExtractor<T> {
+
+	T extract(SearchResult response);
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/JestResultsMapper.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/JestResultsMapper.java
@@ -1,0 +1,11 @@
+package org.springframework.data.elasticsearch.core;
+
+/**
+ * Jest specific result mapper.
+ *
+ * @author Julien Roy
+ */
+public interface JestResultsMapper extends JestSearchResultMapper, JestGetResultMapper, JestMultiGetResultMapper, JestScrollResultMapper {
+
+	EntityMapper getEntityMapper();
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/JestScrollResultMapper.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/JestScrollResultMapper.java
@@ -1,0 +1,14 @@
+package org.springframework.data.elasticsearch.core;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.elasticsearch.core.jest.ScrollSearchResult;
+
+/**
+ * Jest specific scroll result mapper.
+ *
+ * @author Julien Roy
+ */
+public interface JestScrollResultMapper {
+
+	<T> Page<T> mapResults(ScrollSearchResult response, Class<T> clazz);
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/JestSearchResultMapper.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/JestSearchResultMapper.java
@@ -1,0 +1,17 @@
+package org.springframework.data.elasticsearch.core;
+
+import io.searchbox.core.SearchResult;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.query.SearchQuery;
+
+/**
+ * Jest specific result mapper.
+ *
+ * @author Julien Roy
+ */
+public interface JestSearchResultMapper {
+
+    <T> Page<T> mapResults(SearchResult response, Class<T> clazz, Pageable pageable, SearchQuery query);
+
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/jest/ExtendedSearchResult.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/jest/ExtendedSearchResult.java
@@ -1,0 +1,72 @@
+package org.springframework.data.elasticsearch.core.jest;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.List;
+import java.util.Map;
+
+import io.searchbox.core.SearchResult;
+
+/**
+ * Extend SearchResult with useful result methods.
+ * @author Julien Roy
+ */
+public class ExtendedSearchResult extends SearchResult {
+
+	public ExtendedSearchResult(SearchResult searchResult) {
+		super(searchResult);
+	}
+
+	public ExtendedSearchResult(Gson gson) {
+		super(gson);
+	}
+
+	public String getScrollId() {
+		return getJsonObject().get("_scroll_id").getAsString();
+	}
+
+	@Override
+	protected <T, K> Hit<T, K> extractHit(Class<T> sourceType, Class<K> explanationType, JsonElement hitElement, String sourceKey) {
+		Hit<T, K> hit = null;
+
+		if (hitElement.isJsonObject()) {
+			JsonObject hitObject = hitElement.getAsJsonObject();
+
+			JsonElement id = hitObject.get("_id");
+			String index = hitObject.get("_index").getAsString();
+			String type = hitObject.get("_type").getAsString();
+
+			Double score = null;
+			if (hitObject.has("_score") && !hitObject.get("_score").isJsonNull()) {
+				score = hitObject.get("_score").getAsDouble();
+			}
+
+			JsonElement explanation = hitObject.get(EXPLANATION_KEY);
+			Map<String, List<String>> highlight = extractHighlight(hitObject.getAsJsonObject(HIGHLIGHT_KEY));
+			List<String> sort = extractSort(hitObject.getAsJsonArray(SORT_KEY));
+
+			JsonObject source = hitObject.getAsJsonObject(sourceKey);
+			if (source == null) {
+				source = new JsonObject();
+			}
+
+			if (id != null) source.addProperty(ES_METADATA_ID, id.getAsString());
+			hit = new Hit<T, K>(
+					sourceType,
+					source,
+					explanationType,
+					explanation,
+					highlight,
+					sort,
+					index,
+					type,
+					score
+			);
+
+		}
+
+		return hit;
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/jest/MultiDocumentResult.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/jest/MultiDocumentResult.java
@@ -1,0 +1,63 @@
+package org.springframework.data.elasticsearch.core.jest;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import io.searchbox.client.JestResult;
+
+/**
+ * Bulk result of elasticsearch action.
+ * @author Julien Roy
+ */
+public class MultiDocumentResult extends JestResult {
+
+    public MultiDocumentResult(JestResult source) {
+        super(source);
+    }
+
+    /**
+     *
+     * @return empty list if Bulk action failed on HTTP level, otherwise all individual action items in the response
+     */
+    public List<MultiDocumentResultItem> getItems() {
+        List<MultiDocumentResultItem> items = new LinkedList<MultiDocumentResultItem>();
+
+        if (jsonObject != null && jsonObject.has("docs")) {
+            for (JsonElement jsonElement : jsonObject.getAsJsonArray("docs")) {
+                items.add(new MultiDocumentResultItem(jsonElement));
+            }
+        }
+
+        return items;
+    }
+
+    /**
+     * MultiDocument Item.
+     */
+    public static class MultiDocumentResultItem {
+
+        private final JsonObject jsonObject;
+
+        public MultiDocumentResultItem(JsonElement jsonElement) {
+            this.jsonObject = jsonElement.getAsJsonObject();
+        }
+
+        public String getId() {
+            return getAsString(jsonObject.get("_id"));
+        }
+
+        private String getAsString(JsonElement jsonElement) {
+            if (jsonElement == null) {
+                return null;
+            } else {
+                return jsonElement.getAsString();
+            }
+        }
+
+        public String getSource() {
+            return jsonObject.get("_source").toString();
+        }
+    }
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/jest/ScrollSearchResult.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/jest/ScrollSearchResult.java
@@ -1,0 +1,25 @@
+package org.springframework.data.elasticsearch.core.jest;
+
+import com.google.gson.Gson;
+
+import io.searchbox.client.JestResult;
+
+/**
+ * Represent Scroll result.
+ * @author Julien Roy
+ * @author Robert Gruendler
+ */
+public class ScrollSearchResult extends JestResult {
+
+	public ScrollSearchResult(JestResult source) {
+		super(source);
+	}
+
+	public ScrollSearchResult(Gson gson) {
+		super(gson);
+	}
+
+	public String getScrollId() {
+		return getJsonObject().get("_scroll_id").getAsString();
+	}
+}

--- a/src/test/java/org/springframework/data/elasticsearch/core/JestElasticsearchTemplateTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/JestElasticsearchTemplateTests.java
@@ -1,0 +1,2102 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.update.UpdateResponse;
+import org.elasticsearch.index.engine.DocumentMissingException;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.highlight.HighlightBuilder;
+import org.elasticsearch.search.sort.FieldSortBuilder;
+import org.elasticsearch.search.sort.SortOrder;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.elasticsearch.ElasticsearchException;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.core.jest.MultiDocumentResult;
+import org.springframework.data.elasticsearch.core.jest.ScrollSearchResult;
+import org.springframework.data.elasticsearch.core.query.Criteria;
+import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
+import org.springframework.data.elasticsearch.core.query.DeleteQuery;
+import org.springframework.data.elasticsearch.core.query.GetQuery;
+import org.springframework.data.elasticsearch.core.query.IndexQuery;
+import org.springframework.data.elasticsearch.core.query.IndexQueryBuilder;
+import org.springframework.data.elasticsearch.core.query.MoreLikeThisQuery;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
+import org.springframework.data.elasticsearch.core.query.SearchQuery;
+import org.springframework.data.elasticsearch.core.query.StringQuery;
+import org.springframework.data.elasticsearch.core.query.UpdateQuery;
+import org.springframework.data.elasticsearch.core.query.UpdateQueryBuilder;
+import org.springframework.data.elasticsearch.entities.HetroEntity1;
+import org.springframework.data.elasticsearch.entities.HetroEntity2;
+import org.springframework.data.elasticsearch.entities.SampleEntity;
+import org.springframework.data.elasticsearch.entities.SampleMappingEntity;
+import org.springframework.data.util.CloseableIterator;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestClientFactory;
+import io.searchbox.client.JestResult;
+import io.searchbox.client.config.HttpClientConfig;
+import io.searchbox.core.SearchResult;
+
+import static org.apache.commons.lang.RandomStringUtils.randomNumeric;
+import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static org.elasticsearch.index.query.QueryBuilders.wildcardQuery;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.data.elasticsearch.utils.IndexBuilder.buildIndex;
+
+/**
+ * @author Rizwan Idrees
+ * @author Mohsin Husen
+ * @author Franck Marchand
+ * @author Abdul Mohammed
+ * @author Kevin Leturc
+ * @author Mason Chan
+ * @author Robert Gruendler
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("classpath:elasticsearch-jest-template-test.xml")
+public class JestElasticsearchTemplateTests {
+
+	private static final String INDEX_NAME = "test-index";
+	private static final String INDEX_1_NAME = "test-index-1";
+	private static final String INDEX_2_NAME = "test-index-2";
+	private static final String TYPE_NAME = "test-type";
+
+	private JestElasticsearchTemplate elasticsearchTemplate;
+
+	@Before
+	public void before() {
+
+		// Construct a new Jest client according to configuration via factory
+		JestClientFactory factory = new JestClientFactory();
+		factory.setHttpClientConfig(new HttpClientConfig
+				.Builder("http://localhost:9200")
+				.multiThreaded(true)
+				.build());
+		JestClient client = factory.getObject();
+
+		elasticsearchTemplate = new JestElasticsearchTemplate(client);
+
+		elasticsearchTemplate.deleteIndex(SampleEntity.class);
+		elasticsearchTemplate.createIndex(SampleEntity.class);
+		elasticsearchTemplate.deleteIndex(INDEX_1_NAME);
+		elasticsearchTemplate.deleteIndex(INDEX_2_NAME);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldReturnCountForGivenCriteriaQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
+		// when
+		long count = elasticsearchTemplate.count(criteriaQuery, SampleEntity.class);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	@Test
+	public void shouldReturnCountForGivenSearchQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
+		// when
+		long count = elasticsearchTemplate.count(searchQuery, SampleEntity.class);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	@Test
+	public void shouldReturnObjectForGivenId() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+		elasticsearchTemplate.index(indexQuery);
+		// when
+		GetQuery getQuery = new GetQuery();
+		getQuery.setId(documentId);
+		SampleEntity sampleEntity1 = elasticsearchTemplate.queryForObject(getQuery, SampleEntity.class);
+		// then
+		assertNotNull("entity can't be null....", sampleEntity1);
+		assertEquals(sampleEntity, sampleEntity1);
+	}
+
+	@Test
+	public void shouldReturnObjectsForGivenIdsUsingMultiGet() {
+		// given
+		List<IndexQuery> indexQueries = new ArrayList<IndexQuery>();
+		// first document
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		// second document
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		indexQueries = getIndexQueries(Arrays.asList(sampleEntity1, sampleEntity2));
+
+		elasticsearchTemplate.bulkIndex(indexQueries);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		// when
+		SearchQuery query = new NativeSearchQueryBuilder().withIds(Arrays.asList(documentId, documentId2)).build();
+		LinkedList<SampleEntity> sampleEntities = elasticsearchTemplate.multiGet(query, SampleEntity.class);
+		// then
+		assertThat(sampleEntities.size(), is(equalTo(2)));
+		assertEquals(sampleEntities.get(0), sampleEntity1);
+		assertEquals(sampleEntities.get(1), sampleEntity2);
+	}
+
+	@Test
+	public void shouldReturnObjectsForGivenIdsUsingMultiGetWithFields() {
+		// given
+		List<IndexQuery> indexQueries = new ArrayList<IndexQuery>();
+		// first document
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId)
+				.message("some message")
+				.type("type1")
+				.version(System.currentTimeMillis()).build();
+
+		// second document
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2)
+				.message("some message")
+				.type("type2")
+				.version(System.currentTimeMillis()).build();
+
+		indexQueries = getIndexQueries(Arrays.asList(sampleEntity1, sampleEntity2));
+
+		elasticsearchTemplate.bulkIndex(indexQueries);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		// when
+		SearchQuery query = new NativeSearchQueryBuilder()
+				.withIds(Arrays.asList(documentId, documentId2))
+				.withFields("message", "type")
+				.build();
+		LinkedList<SampleEntity> sampleEntities = elasticsearchTemplate.multiGet(query, SampleEntity.class, new JestMultiGetResultMapper() {
+			@Override
+			public <T> LinkedList<T> mapResults(MultiDocumentResult responses, Class<T> clazz) {
+				LinkedList<T> list = new LinkedList<T>();
+				for (MultiDocumentResult.MultiDocumentResultItem response : responses.getItems()) {
+					SampleEntity entity = new SampleEntity();
+					entity.setId(response.getId());
+
+					//TODO: Need to map Fields
+//					entity.setMessage((String) response.getField("message").getValue());
+//					entity.setType((String) response.getField("type").getValue());
+					list.add((T) entity);
+				}
+				return list;
+			}
+		});
+		// then
+		assertThat(sampleEntities.size(), is(equalTo(2)));
+	}
+
+	@Test
+	public void shouldReturnPageForGivenSearchQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
+		// when
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		// then
+		assertThat(sampleEntities, is(notNullValue()));
+		assertThat(sampleEntities.getTotalElements(), greaterThanOrEqualTo(1L));
+	}
+
+	@Test
+	public void shouldDoBulkIndex() {
+		// given
+		List<IndexQuery> indexQueries = new ArrayList<IndexQuery>();
+		// first document
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		// second document
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		indexQueries = getIndexQueries(Arrays.asList(sampleEntity1, sampleEntity2));
+
+		// when
+		elasticsearchTemplate.bulkIndex(indexQueries);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		assertThat(sampleEntities.getTotalElements(), is(equalTo(2L)));
+	}
+
+
+	@Test
+	public void shouldDoBulkUpdate() {
+		//given
+		String documentId = randomNumeric(5);
+		String messageBeforeUpdate = "some test message";
+		String messageAfterUpdate = "test message";
+
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId)
+				.message(messageBeforeUpdate)
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		IndexRequest indexRequest = new IndexRequest();
+		indexRequest.source("message", messageAfterUpdate);
+		UpdateQuery updateQuery = new UpdateQueryBuilder().withId(documentId)
+				.withClass(SampleEntity.class).withIndexRequest(indexRequest).build();
+
+		List<UpdateQuery> queries = new ArrayList<UpdateQuery>();
+		queries.add(updateQuery);
+
+		// when
+		elasticsearchTemplate.bulkUpdate(queries);
+		//then
+		GetQuery getQuery = new GetQuery();
+		getQuery.setId(documentId);
+		SampleEntity indexedEntity = elasticsearchTemplate.queryForObject(getQuery, SampleEntity.class);
+		assertThat(indexedEntity.getMessage(), is(messageAfterUpdate));
+	}
+
+	@Test
+	public void shouldDeleteDocumentForGivenId() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		// when
+		elasticsearchTemplate.delete(INDEX_NAME, TYPE_NAME, documentId);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("id", documentId)).build();
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		assertThat(sampleEntities.getTotalElements(), equalTo(0L));
+	}
+
+	@Test
+	public void shouldDeleteEntityForGivenId() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		// when
+		elasticsearchTemplate.delete(SampleEntity.class, documentId);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("id", documentId)).build();
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		assertThat(sampleEntities.getTotalElements(), equalTo(0L));
+	}
+
+	@Test
+	public void shouldDeleteDocumentForGivenQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		// when
+		DeleteQuery deleteQuery = new DeleteQuery();
+		deleteQuery.setQuery(termQuery("id", documentId));
+		elasticsearchTemplate.delete(deleteQuery, SampleEntity.class);
+		// then
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("id", documentId)).build();
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		assertThat(sampleEntities.getTotalElements(), equalTo(0L));
+	}
+
+	@Test
+	public void shouldFilterSearchResultsForGivenFilter() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
+				.withFilter(QueryBuilders.boolQuery().must(QueryBuilders.termQuery("id", documentId))).build();
+		// when
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		// then
+		assertThat(sampleEntities.getTotalElements(), equalTo(1L));
+	}
+
+	@Test
+	public void shouldSortResultsGivenSortCriteria() {
+		// given
+		List<IndexQuery> indexQueries = new ArrayList<IndexQuery>();
+		// first document
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId)
+				.message("abc")
+				.rate(10)
+				.version(System.currentTimeMillis()).build();
+
+		// second document
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2)
+				.message("xyz")
+				.rate(5)
+				.version(System.currentTimeMillis()).build();
+
+		// third document
+		String documentId3 = randomNumeric(5);
+		SampleEntity sampleEntity3 = SampleEntity.builder().id(documentId3)
+				.message("xyz")
+				.rate(15)
+				.version(System.currentTimeMillis()).build();
+
+		indexQueries = getIndexQueries(Arrays.asList(sampleEntity1, sampleEntity2, sampleEntity3));
+
+		elasticsearchTemplate.bulkIndex(indexQueries);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
+				.withSort(new FieldSortBuilder("rate").ignoreUnmapped(true).order(SortOrder.ASC)).build();
+		// when
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		// then
+		assertThat(sampleEntities.getTotalElements(), equalTo(3L));
+		assertThat(sampleEntities.getContent().get(0).getRate(), is(sampleEntity2.getRate()));
+	}
+
+	@Test
+	public void shouldSortResultsGivenMultipleSortCriteria() {
+		// given
+		List<IndexQuery> indexQueries = new ArrayList<IndexQuery>();
+		// first document
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId)
+				.message("abc")
+				.rate(10)
+				.version(System.currentTimeMillis()).build();
+
+		// second document
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2)
+				.message("xyz")
+				.rate(5)
+				.version(System.currentTimeMillis()).build();
+
+		// third document
+		String documentId3 = randomNumeric(5);
+		SampleEntity sampleEntity3 = SampleEntity.builder().id(documentId3)
+				.message("xyz")
+				.rate(15)
+				.version(System.currentTimeMillis()).build();
+
+		indexQueries = getIndexQueries(Arrays.asList(sampleEntity1, sampleEntity2, sampleEntity3));
+
+		elasticsearchTemplate.bulkIndex(indexQueries);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
+				.withSort(new FieldSortBuilder("rate").ignoreUnmapped(true).order(SortOrder.ASC))
+				.withSort(new FieldSortBuilder("message").ignoreUnmapped(true).order(SortOrder.ASC)).build();
+		// when
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		// then
+		assertThat(sampleEntities.getTotalElements(), equalTo(3L));
+		assertThat(sampleEntities.getContent().get(0).getRate(), is(sampleEntity2.getRate()));
+		assertThat(sampleEntities.getContent().get(1).getMessage(), is(sampleEntity1.getMessage()));
+	}
+
+	@Test
+	public void shouldExecuteStringQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		StringQuery stringQuery = new StringQuery(matchAllQuery().toString());
+		// when
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(stringQuery, SampleEntity.class);
+		// then
+		assertThat(sampleEntities.getTotalElements(), equalTo(1L));
+	}
+
+	@Test
+	public void shouldReturnPageableResultsGivenStringQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		StringQuery stringQuery = new StringQuery(matchAllQuery().toString(), new PageRequest(0, 10));
+		// when
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(stringQuery, SampleEntity.class);
+
+		// then
+		assertThat(sampleEntities.getTotalElements(), is(greaterThanOrEqualTo(1L)));
+	}
+
+	@Test
+	@Ignore("By default, the search request will fail if there is no mapping associated with a field. The ignore_unmapped option allows to ignore fields that have no mapping and not sort by them")
+	public void shouldReturnSortedPageableResultsGivenStringQuery() {
+		// todo
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setMessage("some message");
+		sampleEntity.setVersion(System.currentTimeMillis());
+
+		IndexQuery indexQuery = new IndexQuery();
+		indexQuery.setId(documentId);
+		indexQuery.setObject(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		StringQuery stringQuery = new StringQuery(matchAllQuery().toString(), new PageRequest(0, 10), new Sort(
+				new Sort.Order(Sort.Direction.ASC, "messsage")));
+		// when
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(stringQuery, SampleEntity.class);
+		// then
+		assertThat(sampleEntities.getTotalElements(), is(greaterThanOrEqualTo(1L)));
+	}
+
+	@Test
+	public void shouldReturnObjectMatchingGivenStringQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		StringQuery stringQuery = new StringQuery(termQuery("id", documentId).toString());
+		// when
+		SampleEntity sampleEntity1 = elasticsearchTemplate.queryForObject(stringQuery, SampleEntity.class);
+		// then
+		assertThat(sampleEntity1, is(notNullValue()));
+		assertThat(sampleEntity1.getId(), is(equalTo(documentId)));
+	}
+
+	@Test
+	public void shouldCreateIndexGivenEntityClass() {
+		// when
+		boolean created = elasticsearchTemplate.createIndex(SampleEntity.class);
+		final Map setting = elasticsearchTemplate.getSetting(SampleEntity.class);
+		// then
+		assertThat(created, is(true));
+		assertThat(setting.get("index.number_of_shards"), Matchers.<Object>is("1"));
+		assertThat(setting.get("index.number_of_replicas"), Matchers.<Object>is("0"));
+	}
+
+	@Test
+	public void shouldExecuteGivenCriteriaQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("test message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("message").contains("test"));
+
+		// when
+		SampleEntity sampleEntity1 = elasticsearchTemplate.queryForObject(criteriaQuery, SampleEntity.class);
+		// then
+		assertThat(sampleEntity1, is(notNullValue()));
+	}
+
+	/**
+	 * @see JestElasticsearchTemplateTests#shouldDeleteDocumentBySpecifiedTypeUsingDeleteQuery()
+	 */
+	@Test
+	@Ignore
+	public void shouldDeleteGivenCriteriaQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("test message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("message").contains("test"));
+
+		// when
+		elasticsearchTemplate.delete(criteriaQuery, SampleEntity.class);
+		// then
+		StringQuery stringQuery = new StringQuery(matchAllQuery().toString());
+		List<SampleEntity> sampleEntities = elasticsearchTemplate.queryForList(stringQuery, SampleEntity.class);
+
+		assertThat(sampleEntities.size(), is(0));
+	}
+
+	@Test
+	public void shouldReturnSpecifiedFields() {
+		// given
+		String documentId = randomNumeric(5);
+		String message = "some test message";
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message(message)
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		SearchQuery count = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
+				.withIndices(INDEX_NAME)
+				.withTypes(TYPE_NAME)
+				.build();
+
+		long counter = elasticsearchTemplate.count(count);
+		assertThat(counter, is(equalTo(1L)));
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).withIndices(INDEX_NAME)
+				.withTypes(TYPE_NAME).withFields("message").build();
+		// when
+		Page<String> page = elasticsearchTemplate.queryForPage(searchQuery, String.class, new JestSearchResultMapper() {
+			@Override
+			public <T> Page<T> mapResults(SearchResult response, Class<T> clazz, Pageable pageable, SearchQuery query) {
+				List<String> values = new ArrayList<String>();
+				for (JsonElement hit : response.getJsonObject().get("hits").getAsJsonObject().get("hits").getAsJsonArray()) {
+					values.add(hit.getAsJsonObject().get("fields").getAsJsonObject().get("message").getAsString());
+				}
+				return new PageImpl<T>((List<T>) values);
+			}
+		});
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(equalTo(1L)));
+		assertThat(page.getContent().get(0), is(message));
+	}
+
+	@Test
+	@Ignore("TODO")
+	public void shouldReturnSimilarResultsGivenMoreLikeThisQuery() {
+		// given
+		String sampleMessage = "So we build a web site or an application and want to add search to it, "
+				+ "and then it hits us: getting search working is hard. We want our search solution to be fast,"
+				+ " we want a painless setup and a completely free search schema, we want to be able to index data simply using JSON over HTTP, "
+				+ "we want our search server to be always available, we want to be able to start with one machine and scale to hundreds, "
+				+ "we want real-time search, we want simple multi-tenancy, and we want a solution that is built for the cloud.";
+
+		String documentId1 = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId1).message(sampleMessage)
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+
+		String documentId2 = randomNumeric(5);
+
+		elasticsearchTemplate.index(getIndexQuery(SampleEntity.builder().id(documentId2).message(sampleMessage)
+				.version(System.currentTimeMillis()).build()));
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		MoreLikeThisQuery moreLikeThisQuery = new MoreLikeThisQuery();
+		moreLikeThisQuery.setId(documentId2);
+		moreLikeThisQuery.addFields("message");
+		moreLikeThisQuery.setMinDocFreq(1);
+		// when
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.moreLikeThis(moreLikeThisQuery, SampleEntity.class);
+
+		// then
+		assertThat(sampleEntities.getTotalElements(), is(equalTo(1L)));
+		assertThat(sampleEntities.getContent(), hasItem(sampleEntity));
+	}
+
+	/*
+	DATAES-167
+	 */
+	@Test
+	public void shouldReturnResultsWithScanAndScrollForGivenCriteriaQuery() {
+		//given
+		List<IndexQuery> entities = createSampleEntitiesWithMessage("Test message", 30);
+		// when
+		elasticsearchTemplate.bulkIndex(entities);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
+		criteriaQuery.addIndices(INDEX_NAME);
+		criteriaQuery.addTypes(TYPE_NAME);
+		criteriaQuery.setPageable(new PageRequest(0, 10));
+
+		String scrollId = elasticsearchTemplate.scan(criteriaQuery, 1000, false);
+		List<SampleEntity> sampleEntities = new ArrayList<SampleEntity>();
+		boolean hasRecords = true;
+		while (hasRecords) {
+			Page<SampleEntity> page = elasticsearchTemplate.scroll(scrollId, 5000L, SampleEntity.class);
+			if (page.hasContent()) {
+				sampleEntities.addAll(page.getContent());
+			} else {
+				hasRecords = false;
+			}
+		}
+		assertThat(sampleEntities.size(), is(equalTo(30)));
+	}
+
+	@Test
+	public void shouldReturnResultsWithScanAndScrollForGivenSearchQuery() {
+		//given
+		List<IndexQuery> entities = createSampleEntitiesWithMessage("Test message", 30);
+		// when
+		elasticsearchTemplate.bulkIndex(entities);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).withIndices(INDEX_NAME)
+				.withTypes(TYPE_NAME).withPageable(new PageRequest(0, 10)).build();
+
+		String scrollId = elasticsearchTemplate.scan(searchQuery, 1000, false);
+		List<SampleEntity> sampleEntities = new ArrayList<SampleEntity>();
+		boolean hasRecords = true;
+		while (hasRecords) {
+			Page<SampleEntity> page = elasticsearchTemplate.scroll(scrollId, 5000L, SampleEntity.class);
+			if (page.hasContent()) {
+				sampleEntities.addAll(page.getContent());
+			} else {
+				hasRecords = false;
+			}
+		}
+		elasticsearchTemplate.clearScroll(scrollId);
+		assertThat(sampleEntities.size(), is(equalTo(30)));
+	}
+
+	/*
+	DATAES-167
+	*/
+	@Test
+	public void shouldReturnResultsWithScanAndScrollForSpecifiedFieldsForCriteriaCriteria() {
+		//given
+		List<IndexQuery> entities = createSampleEntitiesWithMessage("Test message", 30);
+		// when
+		elasticsearchTemplate.bulkIndex(entities);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
+		criteriaQuery.addIndices(INDEX_NAME);
+		criteriaQuery.addTypes(TYPE_NAME);
+		criteriaQuery.addFields("message");
+		criteriaQuery.setPageable(new PageRequest(0, 10));
+
+		String scrollId = elasticsearchTemplate.scan(criteriaQuery, 5000, false);
+		List<SampleEntity> sampleEntities = new ArrayList<SampleEntity>();
+		boolean hasRecords = true;
+		while (hasRecords) {
+
+			Page<SampleEntity> page = elasticsearchTemplate.scroll(scrollId, 5000L, new JestScrollResultMapper() {
+
+				@Override
+				public <T> Page<T> mapResults(ScrollSearchResult response, Class<T> clazz) {
+					List<SampleEntity> result = new ArrayList<SampleEntity>();
+
+					JsonArray hits = response.getJsonObject().get("hits").getAsJsonObject().get("hits").getAsJsonArray();
+
+					for(JsonElement hit : hits) {
+						JsonObject objectHit = hit.getAsJsonObject();
+						SampleEntity sampleEntity = new SampleEntity();
+						sampleEntity.setId(objectHit.get("_id").getAsString());
+						result.add(sampleEntity);
+					}
+
+
+					if (result.size() > 0) {
+						return new PageImpl<T>((List<T>) result);
+					}
+					return null;
+				}
+			});
+
+			if (page != null) {
+				sampleEntities.addAll(page.getContent());
+			} else {
+				hasRecords = false;
+			}
+		}
+		assertThat(sampleEntities.size(), is(equalTo(30)));
+	}
+
+	/*
+	DATAES-84
+	*/
+	@Test
+	public void shouldReturnResultsWithScanAndScrollForSpecifiedFieldsForSearchCriteria() {
+		//given
+		List<IndexQuery> entities = createSampleEntitiesWithMessage("Test message", 30);
+		// when
+		elasticsearchTemplate.bulkIndex(entities);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
+				.withIndices(INDEX_NAME)
+				.withTypes(TYPE_NAME)
+				.withFields("message")
+				.withQuery(matchAllQuery())
+				.withPageable(new PageRequest(0, 10))
+				.build();
+
+		String scrollId = elasticsearchTemplate.scan(searchQuery, 10000, false);
+		List<SampleEntity> sampleEntities = new ArrayList<SampleEntity>();
+		boolean hasRecords = true;
+		while (hasRecords) {
+			Page<SampleEntity> page = elasticsearchTemplate.scroll(scrollId, 10000L, new JestScrollResultMapper() {
+
+				@Override
+				public <T> Page<T> mapResults(ScrollSearchResult response, Class<T> clazz) {
+					List<SampleEntity> result = new ArrayList<SampleEntity>();
+
+					JsonArray hits = response.getJsonObject().get("hits").getAsJsonObject().get("hits").getAsJsonArray();
+
+					for(JsonElement hit : hits) {
+						JsonObject objectHit = hit.getAsJsonObject();
+						SampleEntity sampleEntity = new SampleEntity();
+						sampleEntity.setId(objectHit.get("_id").getAsString());
+						result.add(sampleEntity);
+					}
+
+
+					if (result.size() > 0) {
+						return new PageImpl<T>((List<T>) result);
+					}
+					return null;
+				}
+			});
+			if (page != null) {
+				sampleEntities.addAll(page.getContent());
+			} else {
+				hasRecords = false;
+			}
+		}
+		assertThat(sampleEntities.size(), is(equalTo(30)));
+	}
+
+	@Test
+	public void shouldReturnScrollIdInScrollSearchResult() {
+
+		String jsonString = "{ \"_scroll_id\": \"c2Nhbjs2OzM0NDg1ODpzRlBLc0FXNlNyNm5JWUc1\"}";
+		ScrollSearchResult searchResult = new ScrollSearchResult(new Gson());
+		searchResult.setJsonString(jsonString);
+		searchResult.setJsonObject(new JsonParser().parse(jsonString).getAsJsonObject());
+
+		String id = searchResult.getScrollId();
+		assertEquals("c2Nhbjs2OzM0NDg1ODpzRlBLc0FXNlNyNm5JWUc1", id);
+	}
+
+	/*
+	DATAES-167
+	 */
+	@Test
+	public void shouldReturnResultsForScanAndScrollWithCustomResultMapperForGivenCriteriaQuery() {
+		//given
+		List<IndexQuery> entities = createSampleEntitiesWithMessage("Test message", 30);
+		// when
+		elasticsearchTemplate.bulkIndex(entities);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
+		criteriaQuery.addIndices(INDEX_NAME);
+		criteriaQuery.addTypes(TYPE_NAME);
+		criteriaQuery.setPageable(new PageRequest(0, 10));
+
+		String scrollId = elasticsearchTemplate.scan(criteriaQuery, 5000, false);
+		List<SampleEntity> sampleEntities = new ArrayList<SampleEntity>();
+		boolean hasRecords = true;
+		while (hasRecords) {
+			Page<SampleEntity> page = elasticsearchTemplate.scroll(scrollId, 5000L, new JestScrollResultMapper() {
+
+				@Override
+				public <T> Page<T> mapResults(ScrollSearchResult response, Class<T> clazz) {
+					List<SampleEntity> result = new ArrayList<SampleEntity>();
+
+					JsonArray hits = response.getJsonObject().get("hits").getAsJsonObject().get("hits").getAsJsonArray();
+
+					for(JsonElement hit : hits) {
+						JsonObject objectHit = hit.getAsJsonObject();
+						SampleEntity sampleEntity = new SampleEntity();
+						sampleEntity.setId(objectHit.get("_id").getAsString());
+						result.add(sampleEntity);
+					}
+
+
+					if (result.size() > 0) {
+						return new PageImpl<T>((List<T>) result);
+					}
+					return null;
+				}
+			});
+			if (page != null) {
+				sampleEntities.addAll(page.getContent());
+			} else {
+				hasRecords = false;
+			}
+		}
+		assertThat(sampleEntities.size(), is(equalTo(30)));
+	}
+
+	@Test
+	public void shouldReturnResultsForScanAndScrollWithCustomResultMapperForGivenSearchQuery() {
+		//given
+		List<IndexQuery> entities = createSampleEntitiesWithMessage("Test message", 30);
+		// when
+		elasticsearchTemplate.bulkIndex(entities);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).withIndices(INDEX_NAME)
+				.withTypes(TYPE_NAME).withPageable(new PageRequest(0, 10)).build();
+
+		String scrollId = elasticsearchTemplate.scan(searchQuery, 1000, false);
+		List<SampleEntity> sampleEntities = new ArrayList<SampleEntity>();
+		boolean hasRecords = true;
+		while (hasRecords) {
+			Page<SampleEntity> page = elasticsearchTemplate.scroll(scrollId, 5000L, new JestScrollResultMapper() {
+
+				@Override
+				public <T> Page<T> mapResults(ScrollSearchResult response, Class<T> clazz) {
+					List<SampleEntity> result = new ArrayList<SampleEntity>();
+
+					JsonArray hits = response.getJsonObject().get("hits").getAsJsonObject().get("hits").getAsJsonArray();
+
+					for(JsonElement hit : hits) {
+						JsonObject objectHit = hit.getAsJsonObject();
+						SampleEntity sampleEntity = new SampleEntity();
+						sampleEntity.setId(objectHit.get("_id").getAsString());
+						result.add(sampleEntity);
+					}
+
+
+					if (result.size() > 0) {
+						return new PageImpl<T>((List<T>) result);
+					}
+					return null;
+				}
+			});
+			if (page != null) {
+				sampleEntities.addAll(page.getContent());
+			} else {
+				hasRecords = false;
+			}
+		}
+		assertThat(sampleEntities.size(), is(equalTo(30)));
+	}
+
+
+	/**
+	 * DATAES-217
+	 */
+	@Test
+	public void shouldReturnResultsWithScanAndScrollForGivenCriteriaQueryAndClass() {
+		//given
+		List<IndexQuery> entities = createSampleEntitiesWithMessage("Test message", 30);
+		// when
+		elasticsearchTemplate.bulkIndex(entities);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
+		criteriaQuery.setPageable(new PageRequest(0, 10));
+
+		String scrollId = elasticsearchTemplate.scan(criteriaQuery, 1000, false, SampleEntity.class);
+		List<SampleEntity> sampleEntities = new ArrayList<SampleEntity>();
+		boolean hasRecords = true;
+		while (hasRecords) {
+			Page<SampleEntity> page = elasticsearchTemplate.scroll(scrollId, 5000L, SampleEntity.class);
+			if (page.hasContent()) {
+				sampleEntities.addAll(page.getContent());
+			} else {
+				hasRecords = false;
+			}
+		}
+		elasticsearchTemplate.clearScroll(scrollId);
+		assertThat(sampleEntities.size(), is(equalTo(30)));
+
+	}
+
+	/**
+	 * TODO
+	 */
+	@Test
+	public void shouldReturnResultsWithScanAndScrollForGivenSearchQueryAndClass() {
+		//given
+		List<IndexQuery> entities = createSampleEntitiesWithMessage("Test message", 30);
+		// when
+		elasticsearchTemplate.bulkIndex(entities);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
+				.withPageable(new PageRequest(0, 10)).build();
+
+		String scrollId = elasticsearchTemplate.scan(searchQuery, 1000, false, SampleEntity.class);
+		List<SampleEntity> sampleEntities = new ArrayList<SampleEntity>();
+		boolean hasRecords = true;
+		while (hasRecords) {
+			Page<SampleEntity> page = elasticsearchTemplate.scroll(scrollId, 5000L, SampleEntity.class);
+			if (page.hasContent()) {
+				sampleEntities.addAll(page.getContent());
+			} else {
+				hasRecords = false;
+			}
+		}
+		assertThat(sampleEntities.size(), is(equalTo(30)));
+	}
+
+	/*
+	DATAES-167
+	 */
+	@Test
+	public void shouldReturnResultsWithStreamForGivenCriteriaQuery() {
+		//given
+		List<IndexQuery> entities = createSampleEntitiesWithMessage("Test message", 30);
+		// when
+		elasticsearchTemplate.bulkIndex(entities);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
+		criteriaQuery.addIndices(INDEX_NAME);
+		criteriaQuery.addTypes(TYPE_NAME);
+		criteriaQuery.setPageable(new PageRequest(0, 10));
+
+		CloseableIterator<SampleEntity> stream = elasticsearchTemplate.stream(criteriaQuery, SampleEntity.class);
+		List<SampleEntity> sampleEntities = new ArrayList<SampleEntity>();
+		while (stream.hasNext()) {
+			sampleEntities.add(stream.next());
+		}
+		assertThat(sampleEntities.size(), is(equalTo(30)));
+	}
+
+	private static List<IndexQuery> createSampleEntitiesWithMessage(String message, int numberOfEntities) {
+		List<IndexQuery> indexQueries = new ArrayList<IndexQuery>();
+		for (int i = 0; i < numberOfEntities; i++) {
+			String documentId = UUID.randomUUID().toString();
+			SampleEntity sampleEntity = new SampleEntity();
+			sampleEntity.setId(documentId);
+			sampleEntity.setMessage(message);
+			sampleEntity.setRate(2);
+			sampleEntity.setVersion(System.currentTimeMillis());
+			IndexQuery indexQuery = new IndexQuery();
+			indexQuery.setId(documentId);
+			indexQuery.setObject(sampleEntity);
+			indexQueries.add(indexQuery);
+		}
+		return indexQueries;
+	}
+
+	@Test
+	public void shouldReturnListForGivenCriteria() {
+		// given
+		List<IndexQuery> indexQueries = new ArrayList<IndexQuery>();
+		// first document
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId)
+				.message("test message")
+				.version(System.currentTimeMillis()).build();
+
+		// second document
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2)
+				.message("test test")
+				.rate(5)
+				.version(System.currentTimeMillis()).build();
+
+		// third document
+		String documentId3 = randomNumeric(5);
+		SampleEntity sampleEntity3 = SampleEntity.builder().id(documentId3)
+				.message("some message")
+				.rate(15)
+				.version(System.currentTimeMillis()).build();
+
+		indexQueries = getIndexQueries(Arrays.asList(sampleEntity1, sampleEntity2, sampleEntity3));
+
+		// when
+		elasticsearchTemplate.bulkIndex(indexQueries);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// when
+		CriteriaQuery singleCriteriaQuery = new CriteriaQuery(new Criteria("message").contains("test"));
+		CriteriaQuery multipleCriteriaQuery = new CriteriaQuery(new Criteria("message").contains("some").and("message")
+				.contains("message"));
+		List<SampleEntity> sampleEntitiesForSingleCriteria = elasticsearchTemplate.queryForList(singleCriteriaQuery,
+				SampleEntity.class);
+		List<SampleEntity> sampleEntitiesForAndCriteria = elasticsearchTemplate.queryForList(multipleCriteriaQuery,
+				SampleEntity.class);
+		// then
+		assertThat(sampleEntitiesForSingleCriteria.size(), is(2));
+		assertThat(sampleEntitiesForAndCriteria.size(), is(1));
+	}
+
+	@Test
+	public void shouldReturnListForGivenStringQuery() {
+		// given
+		// first document
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId)
+				.message("test message")
+				.version(System.currentTimeMillis()).build();
+
+		// second document
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2)
+				.message("test test")
+				.rate(5)
+				.version(System.currentTimeMillis()).build();
+
+		// third document
+		String documentId3 = randomNumeric(5);
+		SampleEntity sampleEntity3 = SampleEntity.builder().id(documentId3)
+				.message("some message")
+				.rate(15)
+				.version(System.currentTimeMillis()).build();
+
+		List<IndexQuery> indexQueries = getIndexQueries(Arrays.asList(sampleEntity1, sampleEntity2, sampleEntity3));
+
+		// when
+		elasticsearchTemplate.bulkIndex(indexQueries);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// when
+		StringQuery stringQuery = new StringQuery(matchAllQuery().toString());
+		List<SampleEntity> sampleEntities = elasticsearchTemplate.queryForList(stringQuery, SampleEntity.class);
+		// then
+		assertThat(sampleEntities.size(), is(3));
+	}
+
+	@Test
+	@Ignore("TODO")
+	public void shouldPutMappingForGivenEntity() throws Exception {
+		// given
+		Class entity = SampleMappingEntity.class;
+		elasticsearchTemplate.createIndex(entity);
+		// when
+		assertThat(elasticsearchTemplate.putMapping(entity), is(true));
+	}
+
+	@Test
+	public void shouldDeleteIndexForGivenEntity() {
+		// given
+		Class clazz = SampleEntity.class;
+		// when
+		elasticsearchTemplate.deleteIndex(clazz);
+		// then
+		assertThat(elasticsearchTemplate.indexExists(clazz), is(false));
+	}
+
+	@Test
+	public void shouldDoPartialUpdateForExistingDocument() {
+		//given
+		String documentId = randomNumeric(5);
+		String messageBeforeUpdate = "some test message";
+		String messageAfterUpdate = "test message";
+
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId)
+				.message(messageBeforeUpdate)
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		IndexRequest indexRequest = new IndexRequest();
+		indexRequest.source("message", messageAfterUpdate);
+		UpdateQuery updateQuery = new UpdateQueryBuilder().withId(documentId)
+				.withClass(SampleEntity.class).withIndexRequest(indexRequest).build();
+		// when
+		UpdateResponse response = elasticsearchTemplate.update(updateQuery);
+		assertNotNull(response);
+		assertTrue(response.isCreated());
+
+		//then
+		GetQuery getQuery = new GetQuery();
+		getQuery.setId(documentId);
+		SampleEntity indexedEntity = elasticsearchTemplate.queryForObject(getQuery, SampleEntity.class);
+		assertThat(indexedEntity.getMessage(), is(messageAfterUpdate));
+	}
+
+	@Test(expected = DocumentMissingException.class)
+	@Ignore("TODO")
+	public void shouldThrowExceptionIfDocumentDoesNotExistWhileDoingPartialUpdate() {
+		// when
+		IndexRequest indexRequest = new IndexRequest();
+		UpdateQuery updateQuery = new UpdateQueryBuilder().withId(randomNumeric(5))
+				.withClass(SampleEntity.class).withIndexRequest(indexRequest).build();
+		elasticsearchTemplate.update(updateQuery);
+	}
+
+	@Test
+	public void shouldDoUpsertIfDocumentDoesNotExist() {
+		//given
+		String documentId = randomNumeric(5);
+		String message = "test message";
+		IndexRequest indexRequest = new IndexRequest();
+		indexRequest.source("message", message);
+		UpdateQuery updateQuery = new UpdateQueryBuilder().withId(documentId)
+				.withDoUpsert(true).withClass(SampleEntity.class)
+				.withIndexRequest(indexRequest).build();
+		//when
+		elasticsearchTemplate.update(updateQuery);
+		//then
+		GetQuery getQuery = new GetQuery();
+		getQuery.setId(documentId);
+		SampleEntity indexedEntity = elasticsearchTemplate.queryForObject(getQuery, SampleEntity.class);
+		assertThat(indexedEntity.getMessage(), is(message));
+	}
+
+	@Test
+	public void shouldReturnHighlightedFieldsForGivenQueryAndFields() {
+
+		//given
+		String documentId = randomNumeric(5);
+		String actualMessage = "some test message";
+		String highlightedMessage = "some <em>test</em> message";
+
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId)
+				.message(actualMessage)
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder()
+				.withQuery(termQuery("message", "test"))
+				.withHighlightFields(new HighlightBuilder.Field("message"))
+				.build();
+
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class, new JestSearchResultMapper() {
+			@Override
+			public <T> Page<T> mapResults(SearchResult response, Class<T> clazz, Pageable pageable, SearchQuery searchQuery) {
+				List<SampleEntity> chunk = new ArrayList<SampleEntity>();
+				for (SearchResult.Hit<JsonObject, Void> searchHit : response.getHits(JsonObject.class)) {
+					if (response.getHits(JsonObject.class).size() <= 0) {
+						return null;
+					}
+					SampleEntity user = new SampleEntity();
+					user.setId(searchHit.source.get(JestResult.ES_METADATA_ID).getAsString());
+					user.setMessage(searchHit.source.get("message").getAsString());
+					user.setHighlightedMessage(searchHit.highlight.get("message").get(0));
+					chunk.add(user);
+				}
+				if (chunk.size() > 0) {
+					return new PageImpl<T>((List<T>) chunk);
+				}
+				return null;
+			}
+		});
+
+		assertThat(sampleEntities.getContent().get(0).getHighlightedMessage(), is(highlightedMessage));
+	}
+
+	/**
+	 * Delete by query is now a plugin.
+	 * TODO: how can we test this using the in-memory server?
+	 */
+	@Test
+	@Ignore("see https://www.elastic.co/guide/en/elasticsearch/plugins/current/plugins-delete-by-query.html")
+	public void shouldDeleteDocumentBySpecifiedTypeUsingDeleteQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId)
+				.message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("id", documentId)).build();
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		assertThat(sampleEntities.getTotalElements(), equalTo(1L));
+
+		// when
+		DeleteQuery deleteQuery = new DeleteQuery();
+		deleteQuery.setQuery(termQuery("id", documentId));
+		deleteQuery.setIndex(INDEX_NAME);
+		deleteQuery.setType(TYPE_NAME);
+		elasticsearchTemplate.delete(deleteQuery);
+		elasticsearchTemplate.refresh(INDEX_NAME);
+
+		// then
+		searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("id", documentId)).build();
+		sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		assertThat(sampleEntities.getTotalElements(), equalTo(0L));
+	}
+
+	@Test
+	public void shouldIndexDocumentForSpecifiedSource() {
+
+		// given
+		String documentSource = "{\"id\":\"2333343434\",\"type\":null,\"message\":\"some message\",\"rate\":0,\"available\":false,\"highlightedMessage\":null,\"version\":1385208779482}";
+		IndexQuery indexQuery = new IndexQuery();
+		indexQuery.setId("2333343434");
+		indexQuery.setSource(documentSource);
+		indexQuery.setIndexName(INDEX_NAME);
+		indexQuery.setType(TYPE_NAME);
+		// when
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("id", indexQuery.getId()))
+				.withIndices(INDEX_NAME)
+				.withTypes(TYPE_NAME)
+				.build();
+		// then
+		Page<SampleEntity> page = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class, new JestSearchResultMapper() {
+			@Override
+			public <T> Page<T> mapResults(SearchResult response, Class<T> clazz, Pageable pageable, SearchQuery searchQuery) {
+				List<SampleEntity> values = new ArrayList<SampleEntity>();
+				for (SearchResult.Hit<JsonObject, Void> searchHit : response.getHits(JsonObject.class)) {
+					SampleEntity sampleEntity = new SampleEntity();
+					sampleEntity.setId(searchHit.source.get(JestResult.ES_METADATA_ID).getAsString());
+					sampleEntity.setMessage(searchHit.source.get("message").getAsString());
+					values.add(sampleEntity);
+				}
+				return new PageImpl<T>((List<T>) values);
+			}
+		});
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getContent().size(), is(1));
+		assertThat(page.getContent().get(0).getId(), is(indexQuery.getId()));
+	}
+
+	@Test(expected = ElasticsearchException.class)
+	public void shouldThrowElasticsearchExceptionWhenNoDocumentSpecified() {
+		// given
+		IndexQuery indexQuery = new IndexQuery();
+		indexQuery.setId("2333343434");
+		indexQuery.setIndexName(INDEX_NAME);
+		indexQuery.setType(TYPE_NAME);
+
+		//when
+		elasticsearchTemplate.index(indexQuery);
+	}
+
+	@Test
+	public void shouldReturnIds() {
+		//given
+		List<IndexQuery> entities = createSampleEntitiesWithMessage("Test message", 30);
+		// when
+		elasticsearchTemplate.bulkIndex(entities);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		SearchQuery searchQuery = new NativeSearchQueryBuilder()
+				.withQuery(termQuery("message", "message"))
+				.withIndices(INDEX_NAME)
+				.withTypes(TYPE_NAME)
+				.withPageable(new PageRequest(0, 100))
+				.build();
+		// then
+		List<String> ids = elasticsearchTemplate.queryForIds(searchQuery);
+		assertThat(ids, is(notNullValue()));
+		assertThat(ids.size(), is(30));
+	}
+
+	/**
+	 * @see "DATAES-220"
+	 */
+	@Test
+	public void shouldReturnMappingForIndexAndType() {
+
+		List<IndexQuery> entities = createSampleEntitiesWithMessage("Test message", 30);
+		// when
+		elasticsearchTemplate.bulkIndex(entities);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		Map mapping = elasticsearchTemplate.getMapping(INDEX_NAME, TYPE_NAME);
+		assertNotNull(mapping);
+		assertTrue(mapping.containsKey("properties"));
+		Map properties = (Map) mapping.get("properties");
+		assertEquals(5, properties.size());
+	}
+
+	@Test
+	public void shouldReturnDocumentAboveMinimalScoreGivenQuery() {
+		// given
+		List<IndexQuery> indexQueries = new ArrayList<IndexQuery>();
+
+		indexQueries.add(buildIndex(SampleEntity.builder().id("1").message("ab").build()));
+		indexQueries.add(buildIndex(SampleEntity.builder().id("2").message("bc").build()));
+		indexQueries.add(buildIndex(SampleEntity.builder().id("3").message("ac").build()));
+
+		elasticsearchTemplate.bulkIndex(indexQueries);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		// when
+		SearchQuery searchQuery = new NativeSearchQueryBuilder()
+				.withQuery(boolQuery().must(wildcardQuery("message", "*a*")).should(wildcardQuery("message", "*b*")))
+				.withIndices(INDEX_NAME)
+				.withTypes(TYPE_NAME)
+				.withMinScore(0.5F)
+				.build();
+
+		Page<SampleEntity> page = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		// then
+		assertThat(page.getTotalElements(), is(1L));
+		assertThat(page.getContent().get(0).getMessage(), is("ab"));
+	}
+
+
+	@Test
+	public void shouldDoIndexWithoutId() {
+		// given
+		// document
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setMessage("some message");
+		sampleEntity.setVersion(System.currentTimeMillis());
+
+		IndexQuery indexQuery = new IndexQuery();
+		indexQuery.setObject(sampleEntity);
+		// when
+		String documentId = elasticsearchTemplate.index(indexQuery);
+		// then
+		assertThat(sampleEntity.getId(), is(equalTo(documentId)));
+
+		GetQuery getQuery = new GetQuery();
+		getQuery.setId(documentId);
+		SampleEntity result = elasticsearchTemplate.queryForObject(getQuery, SampleEntity.class);
+		assertThat(result.getId(), is(equalTo(documentId)));
+	}
+
+	@Test
+	public void shouldDoBulkIndexWithoutId() {
+		// given
+		List<IndexQuery> indexQueries = new ArrayList<IndexQuery>();
+		// first document
+		SampleEntity sampleEntity1 = new SampleEntity();
+		sampleEntity1.setMessage("some message");
+		sampleEntity1.setVersion(System.currentTimeMillis());
+
+		IndexQuery indexQuery1 = new IndexQuery();
+		indexQuery1.setObject(sampleEntity1);
+		indexQueries.add(indexQuery1);
+
+		// second document
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setMessage("some message");
+		sampleEntity2.setVersion(System.currentTimeMillis());
+
+		IndexQuery indexQuery2 = new IndexQuery();
+		indexQuery2.setObject(sampleEntity2);
+		indexQueries.add(indexQuery2);
+		// when
+		elasticsearchTemplate.bulkIndex(indexQueries);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		assertThat(sampleEntities.getTotalElements(), is(equalTo(2L)));
+
+		assertThat(sampleEntities.getContent().get(0).getId(), is(notNullValue()));
+		assertThat(sampleEntities.getContent().get(1).getId(), is(notNullValue()));
+	}
+
+	@Test
+	public void shouldIndexMapWithIndexNameAndTypeAtRuntime() {
+		//given
+		Map<String, Object> person1 = new HashMap<String, Object>();
+		person1.put("userId", "1");
+		person1.put("email", "smhdiu@gmail.com");
+		person1.put("title", "Mr");
+		person1.put("firstName", "Mohsin");
+		person1.put("lastName", "Husen");
+
+		Map<String, Object> person2 = new HashMap<String, Object>();
+		person2.put("userId", "2");
+		person2.put("email", "akonczak@gmail.com");
+		person2.put("title", "Mr");
+		person2.put("firstName", "Artur");
+		person2.put("lastName", "Konczak");
+
+		IndexQuery indexQuery1 = new IndexQuery();
+		indexQuery1.setId("1");
+		indexQuery1.setObject(person1);
+		indexQuery1.setIndexName(INDEX_NAME);
+		indexQuery1.setType(TYPE_NAME);
+
+		IndexQuery indexQuery2 = new IndexQuery();
+		indexQuery2.setId("2");
+		indexQuery2.setObject(person2);
+		indexQuery2.setIndexName(INDEX_NAME);
+		indexQuery2.setType(TYPE_NAME);
+
+		List<IndexQuery> indexQueries = new ArrayList<IndexQuery>();
+		indexQueries.add(indexQuery1);
+		indexQueries.add(indexQuery2);
+
+		//when
+		elasticsearchTemplate.bulkIndex(indexQueries);
+		elasticsearchTemplate.refresh(INDEX_NAME);
+
+		// then
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withIndices(INDEX_NAME)
+				.withTypes(TYPE_NAME).withQuery(matchAllQuery()).build();
+		Page<Map> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, Map.class, new JestSearchResultMapper() {
+			@Override
+			public <T> Page<T> mapResults(SearchResult response, Class<T> clazz, Pageable pageable, SearchQuery searchQuery) {
+				List<Map> chunk = new ArrayList<Map>();
+				for (SearchResult.Hit<JsonObject, Void> searchHit : response.getHits(JsonObject.class)) {
+					if (response.getHits(JsonObject.class).size() <= 0) {
+						return null;
+					}
+					Map<String, Object> person = new HashMap<String, Object>();
+					person.put("userId", searchHit.source.get("userId").getAsString());
+					person.put("email", searchHit.source.get("email").getAsString());
+					person.put("title", searchHit.source.get("title").getAsString());
+					person.put("firstName", searchHit.source.get("firstName").getAsString());
+					person.put("lastName", searchHit.source.get("lastName").getAsString());
+					chunk.add(person);
+				}
+				if (chunk.size() > 0) {
+					return new PageImpl<T>((List<T>) chunk);
+				}
+				return null;
+			}
+		});
+		assertThat(sampleEntities.getTotalElements(), is(equalTo(2L)));
+		assertThat(sampleEntities.getContent().get(0).get("userId"), is(person1.get("userId")));
+		assertThat(sampleEntities.getContent().get(1).get("userId"), is(person2.get("userId")));
+	}
+
+	@Test
+	public void shouldIndexSampleEntityWithIndexAndTypeAtRuntime() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId)
+				.message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = new IndexQueryBuilder().withId(documentId)
+				.withIndexName(INDEX_NAME).withType(TYPE_NAME)
+				.withObject(sampleEntity).build();
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(INDEX_NAME);
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withIndices(INDEX_NAME)
+				.withTypes(TYPE_NAME).withQuery(matchAllQuery()).build();
+		// when
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		// then
+		assertThat(sampleEntities, is(notNullValue()));
+		assertThat(sampleEntities.getTotalElements(), greaterThanOrEqualTo(1L));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldReturnCountForGivenCriteriaQueryWithGivenIndexUsingCriteriaQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
+		criteriaQuery.addIndices("test-index");
+		// when
+		long count = elasticsearchTemplate.count(criteriaQuery);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-67
+	 */
+	@Test
+	public void shouldReturnCountForGivenSearchQueryWithGivenIndexUsingSearchQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		SearchQuery searchQuery = new NativeSearchQueryBuilder()
+				.withQuery(matchAllQuery())
+				.withIndices("test-index")
+				.build();
+		// when
+		long count = elasticsearchTemplate.count(searchQuery);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldReturnCountForGivenCriteriaQueryWithGivenIndexAndTypeUsingCriteriaQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
+		criteriaQuery.addIndices("test-index");
+		criteriaQuery.addTypes("test-type");
+		// when
+		long count = elasticsearchTemplate.count(criteriaQuery);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-67
+	 */
+	@Test
+	public void shouldReturnCountForGivenSearchQueryWithGivenIndexAndTypeUsingSearchQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		SearchQuery searchQuery = new NativeSearchQueryBuilder()
+				.withQuery(matchAllQuery())
+				.withIndices("test-index")
+				.withTypes("test-type")
+				.build();
+		// when
+		long count = elasticsearchTemplate.count(searchQuery);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldReturnCountForGivenCriteriaQueryWithGivenMultiIndices() {
+		// given
+		cleanUpIndices();
+		String documentId1 = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId1).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery1 = new IndexQueryBuilder().withId(sampleEntity1.getId())
+				.withIndexName("test-index-1")
+				.withObject(sampleEntity1)
+				.build();
+
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2).message("some test message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery2 = new IndexQueryBuilder().withId(sampleEntity2.getId())
+				.withIndexName("test-index-2")
+				.withObject(sampleEntity2)
+				.build();
+
+		elasticsearchTemplate.bulkIndex(Arrays.asList(indexQuery1, indexQuery2));
+		elasticsearchTemplate.refresh("test-index-1");
+		elasticsearchTemplate.refresh("test-index-2");
+
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
+		criteriaQuery.addIndices("test-index-1", "test-index-2");
+		// when
+		long count = elasticsearchTemplate.count(criteriaQuery);
+		// then
+		assertThat(count, is(equalTo(2L)));
+	}
+
+	/*
+	DATAES-67
+	 */
+	@Test
+	public void shouldReturnCountForGivenSearchQueryWithGivenMultiIndices() {
+		// given
+		cleanUpIndices();
+		String documentId1 = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId1).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery1 = new IndexQueryBuilder().withId(sampleEntity1.getId())
+				.withIndexName("test-index-1")
+				.withObject(sampleEntity1)
+				.build();
+
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2).message("some test message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery2 = new IndexQueryBuilder().withId(sampleEntity2.getId())
+				.withIndexName("test-index-2")
+				.withObject(sampleEntity2)
+				.build();
+
+		elasticsearchTemplate.bulkIndex(Arrays.asList(indexQuery1, indexQuery2));
+		elasticsearchTemplate.refresh("test-index-1");
+		elasticsearchTemplate.refresh("test-index-2");
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder()
+				.withQuery(matchAllQuery())
+				.withIndices("test-index-1", "test-index-2")
+				.build();
+		// when
+		long count = elasticsearchTemplate.count(searchQuery);
+		// then
+		assertThat(count, is(equalTo(2L)));
+	}
+
+	private void cleanUpIndices() {
+		elasticsearchTemplate.deleteIndex("test-index-1");
+		elasticsearchTemplate.deleteIndex("test-index-2");
+		elasticsearchTemplate.createIndex("test-index-1");
+		elasticsearchTemplate.createIndex("test-index-2");
+		elasticsearchTemplate.refresh("test-index-1");
+		elasticsearchTemplate.refresh("test-index-2");
+	}
+
+	/*
+	DATAES-71
+	*/
+	@Test
+	public void shouldCreatedIndexWithSpecifiedIndexName() {
+		// given
+		elasticsearchTemplate.deleteIndex("test-index");
+		// when
+		elasticsearchTemplate.createIndex("test-index");
+		// then
+		assertThat(elasticsearchTemplate.indexExists("test-index"), is(true));
+	}
+
+	/*
+	DATAES-72
+	*/
+	@Test
+	public void shouldDeleteIndexForSpecifiedIndexName() {
+		// given
+		elasticsearchTemplate.createIndex(SampleEntity.class);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		// when
+		elasticsearchTemplate.deleteIndex("test-index");
+		// then
+		assertThat(elasticsearchTemplate.indexExists("test-index"), is(false));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldReturnCountForGivenCriteriaQueryWithGivenIndexNameForSpecificIndex() {
+		// given
+		cleanUpIndices();
+		String documentId1 = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId1).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery1 = new IndexQueryBuilder().withId(sampleEntity1.getId())
+				.withIndexName("test-index-1")
+				.withObject(sampleEntity1)
+				.build();
+
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2).message("some test message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery2 = new IndexQueryBuilder().withId(sampleEntity2.getId())
+				.withIndexName("test-index-2")
+				.withObject(sampleEntity2)
+				.build();
+
+		elasticsearchTemplate.bulkIndex(Arrays.asList(indexQuery1, indexQuery2));
+		elasticsearchTemplate.refresh("test-index-1");
+		elasticsearchTemplate.refresh("test-index-2");
+
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
+		criteriaQuery.addIndices("test-index-1");
+		// when
+		long count = elasticsearchTemplate.count(criteriaQuery);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-67
+	*/
+	@Test
+	public void shouldReturnCountForGivenSearchQueryWithGivenIndexNameForSpecificIndex() {
+		// given
+		cleanUpIndices();
+		String documentId1 = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId1).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery1 = new IndexQueryBuilder().withId(sampleEntity1.getId())
+				.withIndexName("test-index-1")
+				.withObject(sampleEntity1)
+				.build();
+
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2).message("some test message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery2 = new IndexQueryBuilder().withId(sampleEntity2.getId())
+				.withIndexName("test-index-2")
+				.withObject(sampleEntity2)
+				.build();
+
+		elasticsearchTemplate.bulkIndex(Arrays.asList(indexQuery1, indexQuery2));
+		elasticsearchTemplate.refresh("test-index-1");
+		elasticsearchTemplate.refresh("test-index-2");
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder()
+				.withQuery(matchAllQuery())
+				.withIndices("test-index-1")
+				.build();
+		// when
+		long count = elasticsearchTemplate.count(searchQuery);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void shouldThrowAnExceptionForGivenCriteriaQueryWhenNoIndexSpecifiedForCountQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
+		// when
+		long count = elasticsearchTemplate.count(criteriaQuery);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-67
+	*/
+	@Test(expected = IllegalArgumentException.class)
+	public void shouldThrowAnExceptionForGivenSearchQueryWhenNoIndexSpecifiedForCountQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		SearchQuery searchQuery = new NativeSearchQueryBuilder()
+				.withQuery(matchAllQuery())
+				.build();
+		// when
+		long count = elasticsearchTemplate.count(searchQuery);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-71
+	*/
+	@Test
+	public void shouldCreateIndexWithGivenSettings() {
+		// given
+		String settings = "{\n" +
+				"        \"index\": {\n" +
+				"            \"number_of_shards\": \"1\",\n" +
+				"            \"number_of_replicas\": \"0\",\n" +
+				"            \"analysis\": {\n" +
+				"                \"analyzer\": {\n" +
+				"                    \"emailAnalyzer\": {\n" +
+				"                        \"type\": \"custom\",\n" +
+				"                        \"tokenizer\": \"uax_url_email\"\n" +
+				"                    }\n" +
+				"                }\n" +
+				"            }\n" +
+				"        }\n" +
+				"}";
+
+		elasticsearchTemplate.deleteIndex("test-index");
+		// when
+		elasticsearchTemplate.createIndex("test-index", settings);
+		// then
+		Map map = elasticsearchTemplate.getSetting("test-index");
+		boolean hasAnalyzer = map.containsKey("index.analysis.analyzer.emailAnalyzer.tokenizer");
+		String emailAnalyzer = (String) map.get("index.analysis.analyzer.emailAnalyzer.tokenizer");
+		assertThat(elasticsearchTemplate.indexExists("test-index"), is(true));
+		assertThat(hasAnalyzer, is(true));
+		assertThat(emailAnalyzer, is("uax_url_email"));
+	}
+
+	/*
+	DATAES-71
+	*/
+	@Test
+	public void shouldCreateGivenSettingsForGivenIndex() {
+		//given
+		//delete , create and apply mapping in before method
+
+		// then
+		Map map = elasticsearchTemplate.getSetting(SampleEntity.class);
+		assertThat(elasticsearchTemplate.indexExists("test-index"), is(true));
+		assertThat(map.containsKey("index.refresh_interval"), is(true));
+		assertThat(map.containsKey("index.number_of_replicas"), is(true));
+		assertThat(map.containsKey("index.number_of_shards"), is(true));
+		assertThat(map.containsKey("index.store.type"), is(true));
+		assertThat((String) map.get("index.refresh_interval"), is("-1"));
+		assertThat((String) map.get("index.number_of_replicas"), is("0"));
+		assertThat((String) map.get("index.number_of_shards"), is("1"));
+		assertThat((String) map.get("index.store.type"), is("fs"));
+	}
+
+	/*
+	DATAES-88
+	*/
+	@Test
+	public void shouldCreateIndexWithGivenClassAndSettings() {
+		//given
+		String settings = "{\n" +
+				"        \"index\": {\n" +
+				"            \"number_of_shards\": \"1\",\n" +
+				"            \"number_of_replicas\": \"0\",\n" +
+				"            \"analysis\": {\n" +
+				"                \"analyzer\": {\n" +
+				"                    \"emailAnalyzer\": {\n" +
+				"                        \"type\": \"custom\",\n" +
+				"                        \"tokenizer\": \"uax_url_email\"\n" +
+				"                    }\n" +
+				"                }\n" +
+				"            }\n" +
+				"        }\n" +
+				"}";
+
+		elasticsearchTemplate.deleteIndex(SampleEntity.class);
+		elasticsearchTemplate.createIndex(SampleEntity.class, settings);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		// then
+		Map map = elasticsearchTemplate.getSetting(SampleEntity.class);
+		assertThat(elasticsearchTemplate.indexExists("test-index"), is(true));
+		assertThat(map.containsKey("index.number_of_replicas"), is(true));
+		assertThat(map.containsKey("index.number_of_shards"), is(true));
+		assertThat((String) map.get("index.number_of_replicas"), is("0"));
+		assertThat((String) map.get("index.number_of_shards"), is("1"));
+	}
+
+	@Test
+	public void shouldTestResultsAcrossMultipleIndices() {
+		// given
+		String documentId1 = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId1).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery1 = new IndexQueryBuilder().withId(sampleEntity1.getId())
+				.withIndexName("test-index-1")
+				.withObject(sampleEntity1)
+				.build();
+
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2).message("some test message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery2 = new IndexQueryBuilder().withId(sampleEntity2.getId())
+				.withIndexName("test-index-2")
+				.withObject(sampleEntity2)
+				.build();
+
+		elasticsearchTemplate.bulkIndex(Arrays.asList(indexQuery1, indexQuery2));
+		elasticsearchTemplate.refresh("test-index-1");
+		elasticsearchTemplate.refresh("test-index-2");
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder()
+				.withQuery(matchAllQuery())
+				.withIndices("test-index-1", "test-index-2")
+				.build();
+		// when
+		List<SampleEntity> sampleEntities = elasticsearchTemplate.queryForList(searchQuery, SampleEntity.class);
+
+		// then
+		assertThat(sampleEntities.size(), is(equalTo(2)));
+	}
+
+	@Test
+	/**
+	 * This is basically a demonstration to show composing entities out of heterogeneous indexes.
+	 */
+	public void shouldComposeObjectsReturnedFromHeterogeneousIndexes() {
+
+		// Given
+
+		HetroEntity1 entity1 = new HetroEntity1(randomNumeric(3), "aFirstName");
+		HetroEntity2 entity2 = new HetroEntity2(randomNumeric(4), "aLastName");
+
+		IndexQuery idxQuery1 = new IndexQueryBuilder().withIndexName(INDEX_1_NAME).withId(entity1.getId()).withObject(entity1).build();
+		IndexQuery idxQuery2 = new IndexQueryBuilder().withIndexName(INDEX_2_NAME).withId(entity2.getId()).withObject(entity2).build();
+
+		elasticsearchTemplate.bulkIndex(Arrays.asList(idxQuery1, idxQuery2));
+		elasticsearchTemplate.refresh(INDEX_1_NAME);
+		elasticsearchTemplate.refresh(INDEX_2_NAME);
+
+		// When
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).withTypes("hetro").withIndices(INDEX_1_NAME, INDEX_2_NAME).build();
+		Page<ResultAggregator> page = elasticsearchTemplate.queryForPage(searchQuery, ResultAggregator.class, new JestSearchResultMapper() {
+			@Override
+			public <T> Page<T> mapResults(SearchResult response, Class<T> clazz, Pageable pageable, SearchQuery searchQuery) {
+				List<ResultAggregator> values = new ArrayList<ResultAggregator>();
+				for (SearchResult.Hit<JsonObject, Void> searchHit : response.getHits(JsonObject.class)) {
+					String id = String.valueOf(searchHit.source.get("id"));
+					String firstName = searchHit.source.get("firstName") != null ? searchHit.source.get("firstName").getAsString() : "";
+					String lastName = searchHit.source.get("lastName") != null ? searchHit.source.get("lastName").getAsString() : "";
+					values.add(new ResultAggregator(id, firstName, lastName));
+				}
+				return new PageImpl<T>((List<T>) values);
+			}
+		});
+
+		assertThat(page.getTotalElements(), is(2l));
+	}
+
+	private IndexQuery getIndexQuery(SampleEntity sampleEntity) {
+		return new IndexQueryBuilder().withId(sampleEntity.getId()).withObject(sampleEntity).build();
+	}
+
+	private List<IndexQuery> getIndexQueries(List<SampleEntity> sampleEntities) {
+		List<IndexQuery> indexQueries = new ArrayList<IndexQuery>();
+		for (SampleEntity sampleEntity : sampleEntities) {
+			indexQueries.add(new IndexQueryBuilder().withId(sampleEntity.getId()).withObject(sampleEntity).build());
+		}
+		return indexQueries;
+	}
+
+	@Document(indexName = INDEX_2_NAME, replicas = 0, shards = 1)
+	class ResultAggregator {
+
+		private String id;
+		private String firstName;
+		private String lastName;
+
+		ResultAggregator(String id, String firstName, String lastName) {
+			this.id = id;
+			this.firstName = firstName;
+			this.lastName = lastName;
+		}
+	}
+}

--- a/src/test/resources/elasticsearch-jest-template-test.xml
+++ b/src/test/resources/elasticsearch-jest-template-test.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+
+    <import resource="jest-infrastructure.xml"/>
+
+
+</beans>

--- a/src/test/resources/jest-infrastructure.xml
+++ b/src/test/resources/jest-infrastructure.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:elasticsearch="http://www.springframework.org/schema/data/elasticsearch"
+       xsi:schemaLocation="http://www.springframework.org/schema/data/elasticsearch http://www.springframework.org/schema/data/elasticsearch/spring-elasticsearch.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <!-- #{T(org.springframework.util.SocketUtils).findAvailableTcpPort(12000)} -->
+    <elasticsearch:node-client id="client" local="true" cluster-name="#{T(java.util.UUID).randomUUID().toString()}" http-enabled="true"
+                               path-data="target/elasticsearchTestData" path-home="src/test/resources/test-home-dir"/>
+
+    <!--<elasticsearch:transport-client id="client" cluster-name="elasticsearch" cluster-nodes="127.0.0.1:9300" />-->
+
+</beans>

--- a/template.mf
+++ b/template.mf
@@ -16,4 +16,6 @@ Import-Template:
  org.slf4j.*;version="${slf4j:[=.=.=,+1.0.0)}",
  org.springframework.*;version="${spring:[=.=.=.=,+1.0.0)}",
  org.springframework.data.*;version="${springdata.commons:[=.=.=.=,+1.0.0)}",
- org.w3c.*;version="0.0.0"
+ org.w3c.*;version="0.0.0",
+ io.searchbox.*;version="${jest:[=.=.=,+1.0.0)}";resolution:=optional,
+ com.google.gson.*;version="${gson:[=.=.=,+1.0.0)}";resolution:=optional


### PR DESCRIPTION
This commit adds support https://github.com/searchbox-io/Jest as
a backing client. Currently not implemented: MoreLikeThis queries.

Needs https://github.com/searchbox-io/Jest/pull/340 to be merged
to compile.

It is based on the work of https://github.com/VanRoy.

See https://jira.spring.io/browse/DATAES-220 for more info.