### PR TITLE
DATAES-263 inner hits fetch support

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/annotations/InnerHits.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/InnerHits.java
@@ -1,0 +1,14 @@
+package org.springframework.data.elasticsearch.annotations;
+
+import java.lang.annotation.*;
+
+/**
+ * Created by franck lefebure on 06/04/2016.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+@Documented
+@Inherited
+public @interface InnerHits {
+    String path();
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentEntity.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentEntity.java
@@ -17,6 +17,8 @@ package org.springframework.data.elasticsearch.core.mapping;
 
 import org.springframework.data.mapping.PersistentEntity;
 
+import java.util.Map;
+
 /**
  * ElasticsearchPersistentEntity
  *
@@ -45,6 +47,8 @@ public interface ElasticsearchPersistentEntity<T> extends PersistentEntity<T, El
 	String getParentType();
 
 	ElasticsearchPersistentProperty getParentIdProperty();
+
+	Map<String, ElasticsearchPersistentProperty> getInnerHitsProperties();
 
 	String settingPath();
 

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/SimpleElasticsearchPersistentEntity.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/SimpleElasticsearchPersistentEntity.java
@@ -17,7 +17,9 @@ package org.springframework.data.elasticsearch.core.mapping;
 
 import static org.springframework.util.StringUtils.*;
 
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
@@ -25,6 +27,7 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.expression.BeanFactoryAccessor;
 import org.springframework.context.expression.BeanFactoryResolver;
 import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.InnerHits;
 import org.springframework.data.elasticsearch.annotations.Parent;
 import org.springframework.data.elasticsearch.annotations.Setting;
 import org.springframework.data.mapping.model.BasicPersistentEntity;
@@ -59,6 +62,7 @@ public class SimpleElasticsearchPersistentEntity<T> extends BasicPersistentEntit
 	private ElasticsearchPersistentProperty parentIdProperty;
 	private String settingPath;
 	private boolean createIndexAndMapping;
+	Map<String, ElasticsearchPersistentProperty> innerHitsProperties;
 
 	public SimpleElasticsearchPersistentEntity(TypeInformation<T> typeInformation) {
 		super(typeInformation);
@@ -149,6 +153,11 @@ public class SimpleElasticsearchPersistentEntity<T> extends BasicPersistentEntit
 	}
 
 	@Override
+	public Map<String, ElasticsearchPersistentProperty> getInnerHitsProperties() {
+		return innerHitsProperties;
+	}
+
+	@Override
 	public void addPersistentProperty(ElasticsearchPersistentProperty property) {
 		super.addPersistentProperty(property);
 
@@ -165,6 +174,13 @@ public class SimpleElasticsearchPersistentEntity<T> extends BasicPersistentEntit
 
 		if (property.isVersionProperty()) {
 			Assert.isTrue(property.getType() == Long.class, "Version property should be Long");
+		}
+
+		InnerHits innerHits = property.getField().getAnnotation(InnerHits.class);
+		if (innerHits != null) {
+			if (innerHitsProperties == null) innerHitsProperties = new HashMap<String, ElasticsearchPersistentProperty>();
+			Assert.isTrue(!innerHitsProperties.containsKey(innerHits.path()), "Only one filed can be mapped with the same innerHi path");
+			innerHitsProperties.put(innerHits.path(), property);
 		}
 	}
 }

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateInnerHitsTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateInnerHitsTests.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core;
+
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.support.QueryInnerHitBuilder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.elasticsearch.core.query.IndexQuery;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQuery;
+import org.springframework.data.elasticsearch.entities.Book;
+import org.springframework.data.elasticsearch.entities.ParentEntity;
+import org.springframework.data.elasticsearch.entities.ParentEntity.ChildEntity;
+import org.springframework.data.elasticsearch.entities.Person;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.commons.lang.RandomStringUtils.randomNumeric;
+import static org.elasticsearch.index.query.QueryBuilders.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Franck Lefebure
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("classpath:elasticsearch-template-test.xml")
+public class ElasticsearchTemplateInnerHitsTests {
+
+	@Autowired
+	private ElasticsearchTemplate elasticsearchTemplate;
+
+	@Before
+	public void before() {
+		clean();
+		elasticsearchTemplate.createIndex(ParentEntity.class);
+		elasticsearchTemplate.createIndex(ChildEntity.class);
+		elasticsearchTemplate.putMapping(ChildEntity.class);
+		elasticsearchTemplate.createIndex(Book.class);
+		elasticsearchTemplate.putMapping(Book.class);
+		elasticsearchTemplate.createIndex(Person.class);
+		elasticsearchTemplate.putMapping(Person.class);
+	}
+
+	@After
+	public void clean() {
+		elasticsearchTemplate.deleteIndex(ChildEntity.class);
+		elasticsearchTemplate.deleteIndex(ParentEntity.class);
+		elasticsearchTemplate.deleteIndex(Book.class);
+		elasticsearchTemplate.deleteIndex(Person.class);
+	}
+
+	private ParentEntity index(String parentId, String name) {
+		ParentEntity parent = new ParentEntity(parentId, name);
+		IndexQuery index = new IndexQuery();
+		index.setId(parent.getId());
+		index.setObject(parent);
+		elasticsearchTemplate.index(index);
+
+		return parent;
+	}
+
+	private ChildEntity index(String childId, String parentId, String name) {
+		ChildEntity child = new ChildEntity(childId, parentId, name);
+		IndexQuery index = new IndexQuery();
+		index.setId(child.getId());
+		index.setObject(child);
+		index.setParentId(child.getParentId());
+		elasticsearchTemplate.index(index);
+
+		return child;
+	}
+
+	@Test
+	public void shouldHaveInnerHitsChildren() {
+		// index two parents
+		ParentEntity parent1 = index("parent1", "First Parent");
+		ParentEntity parent2 = index("parent2", "Second Parent");
+
+		// index a child for each parent
+		String child1name = "First";
+		index("child1", parent1.getId(), child1name);
+		index("child2", parent2.getId(), "Second");
+
+		elasticsearchTemplate.refresh(ParentEntity.class);
+		elasticsearchTemplate.refresh(ChildEntity.class);
+
+		// find all parents that have the first child
+		QueryBuilder query = hasChildQuery(ParentEntity.CHILD_TYPE, QueryBuilders.termQuery("name", child1name.toLowerCase())).innerHit(new QueryInnerHitBuilder());
+		List<ParentEntity> parents = elasticsearchTemplate.queryForList(new NativeSearchQuery(query), ParentEntity.class);
+
+		assertEquals(1, parents.size());
+		assertNotNull(parents.get(0).getChildren());
+		assertEquals("First", parents.get(0).getChildren().get(0).getName());
+
+	}
+
+	@Test
+	public void shouldHaveInnerHitsParent() {
+		// index two parents
+		ParentEntity parent1 = index("parent1", "firstparent");
+		ParentEntity parent2 = index("parent2", "secondparent");
+
+		// index a child for each parent
+		String child1name = "First";
+		index("child1", parent1.getId(), child1name);
+		index("child2", parent2.getId(), "Second");
+
+		elasticsearchTemplate.refresh(ParentEntity.class);
+		elasticsearchTemplate.refresh(ChildEntity.class);
+
+		// find all parents that have the first child
+		QueryBuilder query = hasParentQuery(ParentEntity.PARENT_TYPE, QueryBuilders.termQuery("name", "firstparent")).innerHit(new QueryInnerHitBuilder());
+		List<ChildEntity> children = elasticsearchTemplate.queryForList(new NativeSearchQuery(query), ChildEntity.class);
+
+		assertEquals(1, children.size());
+		assertNotNull(children.get(0).getParent());
+		assertEquals("firstparent", children.get(0).getParent().getName());
+
+	}
+
+	@Test
+	public void shouldHaveInnerHitNested() {
+
+		final Book book1 = new Book();
+		final Book book2 = new Book();
+
+		book1.setId(randomNumeric(5));
+		book1.setName("testbook1");
+
+		book2.setId(randomNumeric(5));
+		book2.setName("testbook2");
+
+		final Person person1 = new Person();
+		person1.setName("doe");
+		person1.setId(randomNumeric(5));
+		person1.setBooks(new ArrayList<Book>());
+		person1.getBooks().add(book1);
+		person1.getBooks().add(book2);
+		IndexQuery index = new IndexQuery();
+		index.setId(person1.getId());
+		index.setObject(person1);
+		elasticsearchTemplate.index(index);
+		elasticsearchTemplate.refresh(Person.class);
+		QueryBuilder query = nestedQuery("books", QueryBuilders.termQuery("books.name", "testbook1")).innerHit(new QueryInnerHitBuilder());
+		List<Person> persons = elasticsearchTemplate.queryForList(new NativeSearchQuery(query), Person.class);
+
+		assertEquals(1, persons.size());
+		assertNotNull(persons.get(0).getTargetedBooks());
+		assertEquals("testbook1", persons.get(0).getTargetedBooks().get(0).getName());
+
+	}
+}

--- a/src/test/java/org/springframework/data/elasticsearch/entities/ParentEntity.java
+++ b/src/test/java/org/springframework/data/elasticsearch/entities/ParentEntity.java
@@ -15,9 +15,12 @@
  */
 package org.springframework.data.elasticsearch.entities;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.*;
+
+import java.util.List;
 
 /**
  * ParentEntity
@@ -45,6 +48,19 @@ public class ParentEntity {
 		this.name = name;
 	}
 
+	@JsonIgnore
+	@InnerHits(path = "child-entity")
+	private List<ChildEntity> children;
+
+	public List<ChildEntity> getChildren() {
+		return children;
+	}
+
+	@JsonIgnore
+	public void setChildren(List<ChildEntity> children) {
+		this.children = children;
+	}
+
 	public String getId() {
 		return id;
 	}
@@ -68,6 +84,18 @@ public class ParentEntity {
 		private String parentId;
 		@Field(type = FieldType.String, index = FieldIndex.analyzed, store = true)
 		private String name;
+
+		@JsonIgnore
+		@InnerHits(path = "parent-entity")
+		private ParentEntity parent;
+		@JsonIgnore
+		public ParentEntity getParent() {
+			return parent;
+		}
+		@JsonIgnore
+		public void setParent(ParentEntity parent) {
+			this.parent = parent;
+		}
 
 		public ChildEntity() {
 		}

--- a/src/test/java/org/springframework/data/elasticsearch/entities/Person.java
+++ b/src/test/java/org/springframework/data/elasticsearch/entities/Person.java
@@ -18,10 +18,12 @@ package org.springframework.data.elasticsearch.entities;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.InnerHits;
 
 /**
  * @author Rizwan Idrees
@@ -42,6 +44,18 @@ public class Person {
 
 	@Field(type = FieldType.Nested, includeInParent = true)
 	private List<Book> books;
+
+	@JsonIgnore
+	@InnerHits(path = "books")
+	private List<Book> targetedBooks;
+	@JsonIgnore
+	public List<Book> getTargetedBooks() {
+		return targetedBooks;
+	}
+	@JsonIgnore
+	public void setTargetedBooks(List<Book> targetedBooks) {
+		this.targetedBooks = targetedBooks;
+	}
 
 	public String getId() {
 		return id;


### PR DESCRIPTION
Hi,
This pull request in linked with Jira   https://jira.spring.io/browse/DATAES-263
The purpose of this PR is to enhance ES inner hits support in Spring Data ES repositories

You can annotate a property with the  @InnerHits annotation :

```
@InnerHits(path = "books")
private List<Book> targetedBooks;
@InnerHits(path = "parent-entity")
private ParentEntity parent;
@InnerHits(path = "child-entity")
private List<ChildEntity> children;
```

For parent/child relations, path must match the relative parent or child mapping type
For nested objects, path must match the query nested collection name

Regarding the collections, only Set<> and List<> are supported.

To populate the annotated relations, the queries must include an innerHits structure
eg for a nested :

```
QueryBuilder query = nestedQuery("books", QueryBuilders.termQuery("books.name", "testbook1")).innerHit(new QueryInnerHitBuilder());
List<Person> persons = elasticsearchTemplate.queryForList(new NativeSearchQuery(query), Person.class);
```

Check testU here : [ElasticsearchTemplateInnerHitsTests.java](https://github.com/flefebure/spring-data-elasticsearch/blob/inner_hits/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateInnerHitsTests.java)

Franck
