### PR TITLE
[DATAES-264] Make available the entity class of the repository

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/repository/ElasticsearchRepository.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/ElasticsearchRepository.java
@@ -43,4 +43,6 @@ public interface ElasticsearchRepository<T, ID extends Serializable> extends Ela
 	Page<T> searchSimilar(T entity, String[] fields, Pageable pageable);
 
 	void refresh();
+
+	Class<T> getEntityClass();
 }

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/AbstractElasticsearchRepository.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/AbstractElasticsearchRepository.java
@@ -276,6 +276,7 @@ public abstract class AbstractElasticsearchRepository<T, ID extends Serializable
 		return resolveReturnedClassFromGenericType(clazz.getSuperclass());
 	}
 
+	@Override
 	public Class<T> getEntityClass() {
 		if (!isEntityClassSet()) {
 			try {


### PR DESCRIPTION
ElasticsearchRepository doesn't have a Class<T> getEntityClass() method declared, so it's much harder to write generic client code, which deals with repositories.
As the AbstractElasticsearchRepository already have this method, as public, it's a 2 liner code change