### PR TITLE
[DATAES-270] Add new methods for query response scrolling to the Elas…

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/repository/ElasticsearchRepository.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/ElasticsearchRepository.java
@@ -20,8 +20,10 @@ import java.io.Serializable;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
 import org.springframework.data.elasticsearch.core.query.SearchQuery;
 import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.data.util.CloseableIterator;
 
 /**
  * @param <T>
@@ -41,6 +43,10 @@ public interface ElasticsearchRepository<T, ID extends Serializable> extends Ela
 	Page<T> search(SearchQuery searchQuery);
 
 	Page<T> searchSimilar(T entity, String[] fields, Pageable pageable);
+
+	CloseableIterator<T> stream(SearchQuery searchQuery);
+
+	CloseableIterator<T> stream(CriteriaQuery searchQuery);
 
 	void refresh();
 

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/AbstractElasticsearchRepository.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/AbstractElasticsearchRepository.java
@@ -33,6 +33,7 @@ import org.springframework.data.domain.*;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.query.*;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.data.util.CloseableIterator;
 import org.springframework.util.Assert;
 
 /**
@@ -286,6 +287,16 @@ public abstract class AbstractElasticsearchRepository<T, ID extends Serializable
 			}
 		}
 		return entityClass;
+	}
+
+	@Override
+	public CloseableIterator<T> stream(CriteriaQuery searchQuery) {
+		return elasticsearchOperations.stream(searchQuery, getEntityClass());
+	}
+
+	@Override
+	public CloseableIterator<T> stream(SearchQuery searchQuery) {
+		return elasticsearchOperations.stream(searchQuery, getEntityClass());
 	}
 
 	private boolean isEntityClassSet() {


### PR DESCRIPTION
Add new methods for query response scrolling to the ElasticsearchRepository, so no need to directly access the ElasticsearchTemplate for the client code
