### PR TITLE
DATAES-228 Fix id handling for indexing

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
@@ -101,6 +101,7 @@ import org.springframework.util.Assert;
  * @author Artur Konczak
  * @author Kevin Leturc
  * @author Mason Chan
+ * @author Mark Janssen
  */
 
 public class ElasticsearchTemplate implements ElasticsearchOperations, ApplicationContextAware {
@@ -1012,13 +1013,10 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, Applicati
 			IndexRequestBuilder indexRequestBuilder = null;
 
 			if (query.getObject() != null) {
-				String entityId = null;
-				if (isDocument(query.getObject().getClass())) {
-					entityId = getPersistentEntityId(query.getObject());
-				}
+				String id = isBlank(query.getId()) ? getPersistentEntityId(query.getObject()) : query.getId();
 				// If we have a query id and a document id, do not ask ES to generate one.
-				if (query.getId() != null && entityId != null) {
-					indexRequestBuilder = client.prepareIndex(indexName, type, query.getId());
+				if (id != null) {
+					indexRequestBuilder = client.prepareIndex(indexName, type, id);
 				} else {
 					indexRequestBuilder = client.prepareIndex(indexName, type);
 				}


### PR DESCRIPTION
When an id is set in the IndexQuery object, use it without requiring an
@Document annotation. When it is not, try to resolve it from the object
when it has @Document and @Id annotations.