### PR TITLE
DATAES-287 - added new date formats for ES>2.0 missing in DateFormat

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/annotations/DateFormat.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/DateFormat.java
@@ -27,5 +27,14 @@ public enum DateFormat {
 	date_time, date_time_no_millis, hour, hour_minute, hour_minute_second, hour_minute_second_fraction,
 	hour_minute_second_millis, ordinal_date, ordinal_date_time, ordinal_date_time_no_millis, time, time_no_millis,
 	t_time, t_time_no_millis, week_date, week_date_time, weekDateTimeNoMillis, week_year, weekyearWeek,
-	weekyearWeekDay, year, year_month, year_month_day
+	weekyearWeekDay, year, year_month, year_month_day,
+	//Added new formats from Elastic v2.4 due to DATAES-287
+	strict_year_month_day, strict_year_month, strict_weekyear_week_day, strict_weekyear_week, strict_weekyear,
+	strict_week_date_time_no_millis, strict_week_date_time, strict_week_date, strict_t_time_no_millis, strict_t_time,
+	strict_time_no_millis, strict_time, strict_ordinal_date_time_no_millis, strict_ordinal_date_time,
+	strict_hour_minute_second_millis, strict_hour_minute_second_fraction, strict_hour_minute_second,
+	strict_hour_minute, strict_hour, strict_date_time_no_millis, strict_date_time,
+	strict_date_hour_minute_second_millis, strict_date_hour_minute_second_fraction, strict_date_hour_minute_second,
+	strict_date_hour_minute, strict_date_hour, strict_date, strict_basic_week_date_time_no_millis,
+	strict_basic_week_date_time, strict_basic_week_date, strict_date_optional_time, epoch_millis, epoch_seconds
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/DefaultEntityMapper.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/DefaultEntityMapper.java
@@ -16,26 +16,10 @@
 package org.springframework.data.elasticsearch.core;
 
 import java.io.IOException;
-import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.*;
-import com.fasterxml.jackson.databind.*;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import org.springframework.data.elasticsearch.annotations.Document;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.data.elasticsearch.core.geo.CustomGeoModule;
-import org.springframework.data.geo.*;
-import java.util.List;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.Version;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 
 
 /**

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchRepositoryFactoryBean.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchRepositoryFactoryBean.java
@@ -36,6 +36,15 @@ public class ElasticsearchRepositoryFactoryBean<T extends Repository<S, ID>, S, 
 	private ElasticsearchOperations operations;
 
 	/**
+	 * Creates a new {@link ElasticsearchRepositoryFactoryBean} for the given repository interface.
+	 * 
+	 * @param repositoryInterface must not be {@literal null}.
+	 */
+	public ElasticsearchRepositoryFactoryBean(Class<? extends T> repositoryInterface) {
+		super(repositoryInterface);
+	}
+
+	/**
 	 * Configures the {@link ElasticsearchOperations} to be used to create Elasticsearch repositories.
 	 *
 	 * @param operations the operations to set

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.data.repository.core.support.RepositoryFactorySupport=org.springframework.data.elasticsearch.repository.support.ElasticsearchRepositoryFactory

--- a/src/main/resources/changelog.txt
+++ b/src/main/resources/changelog.txt
@@ -1,6 +1,12 @@
 Spring Data Elasticsearch Changelog
 ===================================
 
+Changes in version 3.0.0.M1 (2016-11-23)
+----------------------------------------
+* DATAES-307 - Set up 3.0 development.
+* DATAES-306 - Release 3.0 M1 (Kay).
+
+
 Changes in version 2.0.5.RELEASE (2016-11-03)
 ---------------------------------------------
 * DATAES-300 - Release 2.0.5 (Hopper SR5).

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
@@ -2034,16 +2034,17 @@ public class ElasticsearchTemplateTests {
 
 		// when
 		String content = ElasticsearchTemplate.readFileFromClasspath(settingsFile);
-
 		// then
-		assertThat(content, is("index:\n" +
-				"  number_of_shards: 1\n" +
-				"  number_of_replicas: 0\n" +
-				"  analysis:\n" +
-				"    analyzer:\n" +
-				"      emailAnalyzer:\n" +
-				"        type: custom\n" +
-				"        tokenizer: uax_url_email\n"));
+		//fixes Test issue with Windows Carriage return chars in file
+		String lineSeparator = System.getProperty("line.separator");
+		assertThat(content, is("index:" + lineSeparator +
+				"  number_of_shards: 1" + lineSeparator +
+				"  number_of_replicas: 0" + lineSeparator +
+				"  analysis:" + lineSeparator +
+				"    analyzer:" + lineSeparator +
+				"      emailAnalyzer:" + lineSeparator +
+				"        type: custom" + lineSeparator +
+				"        tokenizer: uax_url_email" + lineSeparator));
 	}
 
 	private IndexQuery getIndexQuery(SampleEntity sampleEntity) {

--- a/src/test/java/org/springframework/data/elasticsearch/core/SimpleElasticsearchDateMappingTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/SimpleElasticsearchDateMappingTests.java
@@ -29,10 +29,7 @@ import org.springframework.data.elasticsearch.entities.SampleDateMappingEntity;
  */
 public class SimpleElasticsearchDateMappingTests {
 
-	private static final String EXPECTED_MAPPING = "{\"mapping\":{\"properties\":{\"message\":{\"store\":true," +
-			"\"type\":\"string\",\"index\":\"not_analyzed\",\"analyzer\":\"standard\"},\"customFormatDate\":{\"store\":false,\"type\":\"date\",\"format\":\"dd.MM.yyyy hh:mm\"}," +
-			"\"defaultFormatDate\":{\"store\":false,\"type\":\"date\"},\"basicFormatDate\":{\"store\":false,\"" +
-			"type\":\"date\",\"format\":\"basic_date\"}}}}";
+	private static final String EXPECTED_MAPPING = "{\"mapping\":{\"properties\":{\"message\":{\"store\":true,\"type\":\"string\",\"index\":\"not_analyzed\",\"analyzer\":\"standard\"},\"customFormatDate\":{\"store\":false,\"type\":\"date\",\"format\":\"dd.MM.yyyy hh:mm\"},\"defaultFormatDate\":{\"store\":false,\"type\":\"date\"},\"basicFormatDate\":{\"store\":false,\"type\":\"date\",\"format\":\"basic_date\"},\"epochMillisDate\":{\"store\":false,\"type\":\"date\",\"format\":\"epoch_millis\"}}}}";
 
 	@Test
 	public void testCorrectDateMappings() throws NoSuchFieldException, IntrospectionException, IOException {

--- a/src/test/java/org/springframework/data/elasticsearch/entities/SampleDateMappingEntity.java
+++ b/src/test/java/org/springframework/data/elasticsearch/entities/SampleDateMappingEntity.java
@@ -6,6 +6,7 @@ import static org.springframework.data.elasticsearch.annotations.FieldType.Strin
 
 import java.util.Date;
 
+import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.DateFormat;
 import org.springframework.data.elasticsearch.annotations.Document;
@@ -13,7 +14,14 @@ import org.springframework.data.elasticsearch.annotations.Field;
 
 /**
  * @author Jakub Vavrik
+ *
+ * @See DATAES-287 - updated test entity that worked in ES < 2.0 with post 2.0 date formats
  */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 @Document(indexName = "test-datemapping", type = "mapping", shards = 1, replicas = 0, refreshInterval = "-1")
 public class SampleDateMappingEntity {
 
@@ -32,43 +40,6 @@ public class SampleDateMappingEntity {
 	@Field(type = Date, format = DateFormat.basic_date)
 	private Date basicFormatDate;
 
-	public String getId() {
-		return id;
-	}
-
-	public void setId(String id) {
-		this.id = id;
-	}
-
-	public String getMessage() {
-		return message;
-	}
-
-	public void setMessage(String message) {
-		this.message = message;
-	}
-
-	public Date getCustomFormatDate() {
-		return customFormatDate;
-	}
-
-	public void setCustomFormatDate(Date customFormatDate) {
-		this.customFormatDate = customFormatDate;
-	}
-
-	public Date getDefaultFormatDate() {
-		return defaultFormatDate;
-	}
-
-	public void setDefaultFormatDate(Date defaultFormatDate) {
-		this.defaultFormatDate = defaultFormatDate;
-	}
-
-	public Date getBasicFormatDate() {
-		return basicFormatDate;
-	}
-
-	public void setBasicFormatDate(Date basicFormatDate) {
-		this.basicFormatDate = basicFormatDate;
-	}
+	@Field(type = Date, format = DateFormat.epoch_millis)
+	private Date epochMillisDate;
 }


### PR DESCRIPTION
ES 2.0 changed the way they handle dates and dateFormats.
This pull added missing date formats based on 2.4 doc.

It also added test demonstrating date format mapping issue described in [DATAES-287](https://jira.spring.io/browse/DATAES-287). The test is actually checking the wrong value so it passes while it should not pass if the mapping worked correctly.

The issue with ignored DateFormat is much more complicated - simple workaround can be achieved adding @JsonFormat annotation to particular field as described in [DATAES-287](https://jira.spring.io/browse/DATAES-287).


I have signed and agree to the terms of the SpringSource Individual
Contributor License Agreement.