### PR TITLE
Added putMapping implementations to allow for custom indexName and type

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchOperations.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchOperations.java
@@ -78,6 +78,22 @@ public interface ElasticsearchOperations {
 	 * @param <T>
 	 */
 	<T> boolean putMapping(Class<T> clazz);
+	
+	/**
+	 * Create mapping for a class for the given indexName
+	 *
+	 * @param clazz
+	 * @param <T>
+	 */
+	<T> boolean putMapping(String indexName, Class<T> clazz);
+	
+	/**
+	 * Create mapping for a class for the given indexName and type
+	 *
+	 * @param clazz
+	 * @param <T>
+	 */
+	<T> boolean putMapping(String indexName, String type, Class<T> clazz);
 
 	/**
 	 * Create mapping for a given indexName and type


### PR DESCRIPTION
This new putMapping implementations allow you to use a custom indexName
and/or type and still use the Field annotations for the mapping

Please let me know if you like this idea. Thank you.
