### PR TITLE
DATAES-386 fix NullPointerException in FacetedPageImpl

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/FacetedPageImpl.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/FacetedPageImpl.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.range.Range;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
@@ -42,6 +43,7 @@ import org.springframework.data.elasticsearch.core.facet.result.*;
  * @author Mohsin Husen
  * @author Artur Konczak
  * @author Jonathan Yan
+ * @author Julio Camarero
  */
 @Deprecated
 public abstract class FacetedPageImpl<T> extends PageImpl<T> implements FacetedPage<T>, AggregatedPage<T> {
@@ -86,43 +88,48 @@ public abstract class FacetedPageImpl<T> extends PageImpl<T> implements FacetedP
 	private void processAggregations() {
 		if (facets == null) {
 			facets = new ArrayList<FacetResult>();
-			for (Aggregation agg : getAggregations()) {
-				if (agg instanceof Terms) {
-					List<Term> terms = new ArrayList<Term>();
-					for (Terms.Bucket t : ((Terms) agg).getBuckets()) {
-						terms.add(new Term(t.getKeyAsString(), t.getDocCount()));
-					}
-					addFacet(new TermResult(agg.getName(), terms, terms.size(), ((Terms) agg).getSumOfOtherDocCounts(), 0));
-				}
-				if (agg instanceof Range) {
-					List<? extends Range.Bucket> buckets = ((Range) agg).getBuckets();
-					List<org.springframework.data.elasticsearch.core.facet.result.Range> ranges = new ArrayList<org.springframework.data.elasticsearch.core.facet.result.Range>();
-					for (Range.Bucket b : buckets) {
-						ExtendedStats rStats = (ExtendedStats) b.getAggregations().get(AbstractFacetRequest.INTERNAL_STATS);
-						if (rStats != null) {
-							Sum sum = (Sum) b.getAggregations().get(RangeFacetRequest.RANGE_INTERNAL_SUM);
-							ranges.add(new org.springframework.data.elasticsearch.core.facet.result.Range((Double) b.getFrom(), (Double) b.getTo(), b.getDocCount(), sum != null ? sum.getValue() : rStats.getSum(), rStats.getCount(), rStats.getMin(), rStats.getMax()));
-						} else {
-							ranges.add(new org.springframework.data.elasticsearch.core.facet.result.Range((Double) b.getFrom(), (Double) b.getTo(), b.getDocCount(), 0, 0, 0, 0));
+
+			Aggregations aggregations = getAggregations();
+
+			if (aggregations != null) {
+				for (Aggregation agg : aggregations) {
+					if (agg instanceof Terms) {
+						List<Term> terms = new ArrayList<Term>();
+						for (Terms.Bucket t : ((Terms) agg).getBuckets()) {
+							terms.add(new Term(t.getKeyAsString(), t.getDocCount()));
 						}
+						addFacet(new TermResult(agg.getName(), terms, terms.size(), ((Terms) agg).getSumOfOtherDocCounts(), 0));
 					}
-					addFacet(new RangeResult(agg.getName(), ranges));
-				}
-				if (agg instanceof ExtendedStats) {
-					ExtendedStats stats = (ExtendedStats) agg;
-					addFacet(new StatisticalResult(agg.getName(), stats.getCount(), stats.getMax(), stats.getMin(), stats.getAvg(), stats.getStdDeviation(), stats.getSumOfSquares(), stats.getSum(), stats.getVariance()));
-				}
-				if (agg instanceof Histogram) {
-					List<IntervalUnit> intervals = new ArrayList<IntervalUnit>();
-					for (Histogram.Bucket h : ((Histogram) agg).getBuckets()) {
-						ExtendedStats hStats = (ExtendedStats) h.getAggregations().get(AbstractFacetRequest.INTERNAL_STATS);
-						if (hStats != null) {
-							intervals.add(new IntervalUnit(((DateTime) h.getKey()).getMillis(), h.getDocCount(), h.getDocCount(), hStats.getSum(), hStats.getAvg(), hStats.getMin(), hStats.getMax()));
-						} else {
-							intervals.add(new IntervalUnit(((DateTime) h.getKey()).getMillis(), h.getDocCount(), h.getDocCount(), 0, 0, 0, 0));
+					if (agg instanceof Range) {
+						List<? extends Range.Bucket> buckets = ((Range) agg).getBuckets();
+						List<org.springframework.data.elasticsearch.core.facet.result.Range> ranges = new ArrayList<org.springframework.data.elasticsearch.core.facet.result.Range>();
+						for (Range.Bucket b : buckets) {
+							ExtendedStats rStats = (ExtendedStats) b.getAggregations().get(AbstractFacetRequest.INTERNAL_STATS);
+							if (rStats != null) {
+								Sum sum = (Sum) b.getAggregations().get(RangeFacetRequest.RANGE_INTERNAL_SUM);
+								ranges.add(new org.springframework.data.elasticsearch.core.facet.result.Range((Double) b.getFrom(), (Double) b.getTo(), b.getDocCount(), sum != null ? sum.getValue() : rStats.getSum(), rStats.getCount(), rStats.getMin(), rStats.getMax()));
+							} else {
+								ranges.add(new org.springframework.data.elasticsearch.core.facet.result.Range((Double) b.getFrom(), (Double) b.getTo(), b.getDocCount(), 0, 0, 0, 0));
+							}
 						}
+						addFacet(new RangeResult(agg.getName(), ranges));
 					}
-					addFacet(new HistogramResult(agg.getName(), intervals));
+					if (agg instanceof ExtendedStats) {
+						ExtendedStats stats = (ExtendedStats) agg;
+						addFacet(new StatisticalResult(agg.getName(), stats.getCount(), stats.getMax(), stats.getMin(), stats.getAvg(), stats.getStdDeviation(), stats.getSumOfSquares(), stats.getSum(), stats.getVariance()));
+					}
+					if (agg instanceof Histogram) {
+						List<IntervalUnit> intervals = new ArrayList<IntervalUnit>();
+						for (Histogram.Bucket h : ((Histogram) agg).getBuckets()) {
+							ExtendedStats hStats = (ExtendedStats) h.getAggregations().get(AbstractFacetRequest.INTERNAL_STATS);
+							if (hStats != null) {
+								intervals.add(new IntervalUnit(((DateTime) h.getKey()).getMillis(), h.getDocCount(), h.getDocCount(), hStats.getSum(), hStats.getAvg(), hStats.getMin(), hStats.getMax()));
+							} else {
+								intervals.add(new IntervalUnit(((DateTime) h.getKey()).getMillis(), h.getDocCount(), h.getDocCount(), 0, 0, 0, 0));
+							}
+						}
+						addFacet(new HistogramResult(agg.getName(), intervals));
+					}
 				}
 			}
 		}

--- a/src/test/java/org/springframework/data/elasticsearch/core/aggregation/AggregatedPageTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/aggregation/AggregatedPageTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core.aggregation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.data.elasticsearch.core.aggregation.impl.AggregatedPageImpl;
+
+/**
+ * @author Julio Camarero
+ */
+public class AggregatedPageTests {
+
+	@Test
+	public void shouldProcessAggregations()  {
+		//Given
+
+		List<String> list = new ArrayList<String>();
+
+		AggregatedPage<String> page = new AggregatedPageImpl<String>(list);
+
+		//When
+		boolean hasFacets = page.hasFacets();
+
+		//Then
+		Assert.assertEquals(hasFacets, false);
+	}
+}


### PR DESCRIPTION
This bug can not be reproduced in the latest master since the FacetedPageImpl class has been refactored. It does affect the branch 2.2.x
When calling hasFacets or getFacets in any Page that extends FacetedPage a NullPointerException will be thrown.
The reason is that facets can be null but the logic inside processAggregations method is asuming the variable is always initialized.



- [x]  You have read the Spring Data contribution guidelines.
- [x]   There is a ticket in the bug tracker for the project in our JIRA.
- [x]   You use the code formatters provided here and have them applied to your changes. Don’t submit any formatting related changes.
- [x]   You submit test cases (unit or integration tests) that back your changes.
- [x]   You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

