### PR TITLE
DATAES-420 - Analyzer of main field ignored when using @MultiField annotation

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/annotations/InnerField.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/InnerField.java
@@ -33,11 +33,15 @@ public @interface InnerField {
 
 	boolean index() default true;
 
+	DateFormat format() default DateFormat.none;
+
+	String pattern() default "";
+
 	boolean store() default false;
 
 	boolean fielddata() default false;
 
 	String searchAnalyzer() default "";
 
-	String indexAnalyzer() default "";
+	String analyzer() default "";
 }

--- a/src/test/java/org/springframework/data/elasticsearch/core/facet/ArticleEntity.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/facet/ArticleEntity.java
@@ -42,8 +42,8 @@ public class ArticleEntity {
 	@MultiField(
 			mainField = @Field(type = Text),
 			otherFields = {
-					@InnerField(suffix = "untouched", type = Text, store = true, fielddata = true, indexAnalyzer = "keyword"),
-					@InnerField(suffix = "sort", type = Text, store = true, indexAnalyzer = "keyword")
+					@InnerField(suffix = "untouched", type = Text, store = true, fielddata = true, analyzer = "keyword"),
+					@InnerField(suffix = "sort", type = Text, store = true, analyzer = "keyword")
 			}
 	)
 	private List<String> authors = new ArrayList<>();

--- a/src/test/java/org/springframework/data/elasticsearch/entities/Book.java
+++ b/src/test/java/org/springframework/data/elasticsearch/entities/Book.java
@@ -29,10 +29,13 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.InnerField;
+import org.springframework.data.elasticsearch.annotations.MultiField;
 
 /**
  * @author Rizwan Idrees
  * @author Mohsin Husen
+ * @author Nordine Bittich
  */
 @Setter
 @Getter
@@ -49,4 +52,11 @@ public class Book {
 	private Author author;
 	@Field(type = FieldType.Nested)
 	private Map<Integer, Collection<String>> buckets = new HashMap<>();
+	@MultiField(
+		mainField = @Field(type = FieldType.Text, analyzer = "whitespace"),
+		otherFields = {
+				@InnerField(suffix = "prefix", type = FieldType.Text, analyzer = "stop", searchAnalyzer = "standard")
+		}
+	)
+	private String description;
 }


### PR DESCRIPTION
Replacement for PR #197. It avoids the usage of a consumer and refactors the logic how mappings for  field annotations (`@Field`, `@MultiField` and `@InnerField`) are written.

@akonczak you mind taking a look?

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
