### PR TITLE
fix bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 atlassian-ide-plugin.xml
-
+.github
 ## Ignore svn files
 .svn
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,6 @@
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
             <version>${commonslang}</version>
-            <scope>test</scope>
         </dependency>
 
         <!-- JODA Time -->

--- a/src/main/java/org/springframework/data/elasticsearch/client/TransportClientFactoryBean.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/TransportClientFactoryBean.java
@@ -15,9 +15,6 @@
  */
 package org.springframework.data.elasticsearch.client;
 
-import java.net.InetAddress;
-import java.util.Properties;
-
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
@@ -28,7 +25,10 @@ import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
+import org.apache.commons.lang.StringUtils;
+
+import java.net.InetAddress;
+import java.util.Properties;
 
 /**
  * TransportClientFactoryBean
@@ -42,7 +42,8 @@ import org.springframework.util.StringUtils;
 
 public class TransportClientFactoryBean implements FactoryBean<TransportClient>, InitializingBean, DisposableBean {
 
-	private static final Logger logger = LoggerFactory.getLogger(TransportClientFactoryBean.class);
+	private static final Logger logger = LoggerFactory.getLogger(
+			org.springframework.data.elasticsearch.client.TransportClientFactoryBean.class);
 	private String clusterNodes = "127.0.0.1:9300";
 	private String clusterName = "elasticsearch";
 	private Boolean clientTransportSniff = true;
@@ -94,9 +95,9 @@ public class TransportClientFactoryBean implements FactoryBean<TransportClient>,
 		if (clusterNodesArray != null) {
 			for (String clusterNode : clusterNodesArray) {
 				if (clusterNode != null) {
-					int colonPosition = clusterName.lastIndexOf(COLON);
+					int colonPosition = clusterNode.lastIndexOf(COLON);
 					String hostName = colonPosition != -1 ? clusterNode.substring(0, colonPosition) : clusterNode;
-					String port = colonPosition != -1 ? clusterNode.substring(colonPosition, clusterNode.length()) : "";
+					String port = colonPosition != -1 ? clusterNode.substring(colonPosition + 1, clusterNode.length()) : "";
 					Assert.hasText(hostName, "[Assertion failed] missing host name in 'clusterNodes'");
 					Assert.hasText(port, "[Assertion failed] missing port in 'clusterNodes'");
 					logger.info("adding transport node : " + clusterNode);


### PR DESCRIPTION
TransportClientFactoryBean has 3 bugs in client creation
1. StringUtils.split(clusterNodes, COMMA) , StringUtils should be in the apache package, spring package has a bug, for example: clusterNodes is 127.0.0.1:9300, the result array is null, there should be an array of 1 elements, array element values Is 127.0.0.1:9300
2. clusterName.lastIndexOf(COLON); This code is wrong, it should be clusterNode.lastIndexOf(COLON);
3. clusterNode.substring(colonPosition, clusterNode.length()); should be clusterNode.substring(colonPosition + 1, clusterNode.length());


<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
