### PR TITLE
DATAES-407 - Support for HighLevelRestClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <commonscollections>3.2.1</commonscollections>
         <commonslang>2.6</commonslang>
-        <elasticsearch>6.2.2</elasticsearch>
+        <elasticsearch>6.3.0</elasticsearch>
         <log4j>2.9.1</log4j>
         <springdata.commons>2.1.0.BUILD-SNAPSHOT</springdata.commons>
         <java-module-name>spring.data.elasticsearch</java-module-name>
@@ -78,6 +78,18 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+		    <groupId>org.elasticsearch.client</groupId>
+		    <artifactId>elasticsearch-rest-high-level-client</artifactId>
+		    <version>${elasticsearch}</version>
+		    <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+		</dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -169,7 +181,7 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok}</version>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
 
     </dependencies>

--- a/src/main/java/org/springframework/data/elasticsearch/client/RestClientFactoryBean.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/RestClientFactoryBean.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.client;
+
+import static org.apache.commons.lang.StringUtils.*;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.net.URL;
+import java.util.ArrayList;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
+
+/**
+ * RestClientFactoryBean
+ * 
+ * @author Don Wellington
+ */
+@Slf4j
+public class RestClientFactoryBean implements FactoryBean<RestHighLevelClient>, InitializingBean, DisposableBean {
+
+	private RestHighLevelClient client;
+	private String hosts = "http://localhost:9200";
+	static final String COMMA = ",";
+
+	@Override
+	public void destroy() throws Exception {
+		try {
+			log.info("Closing elasticSearch  client");
+			if (client != null) {
+				client.close();
+			}
+		} catch (final Exception e) {
+			log.error("Error closing ElasticSearch client: ", e);
+		}
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		buildClient();
+	}
+
+	@Override
+	public RestHighLevelClient getObject() throws Exception {
+		return client;
+	}
+
+	@Override
+	public Class<?> getObjectType() {
+		return RestHighLevelClient.class;
+	}
+
+	@Override
+	public boolean isSingleton() {
+		return false;
+	}
+
+	protected void buildClient() throws Exception {
+
+		Assert.hasText(hosts, "[Assertion Failed] At least one host must be set.");
+		ArrayList<HttpHost> httpHosts = new ArrayList<HttpHost>();
+		for (String host : split(hosts, COMMA)) {
+			URL hostUrl = new URL(host);
+			httpHosts.add(new HttpHost(hostUrl.getHost(), hostUrl.getPort(), hostUrl.getProtocol()));
+		}
+		client = new RestHighLevelClient(RestClient.builder(httpHosts.toArray(new HttpHost[httpHosts.size()])));
+	}
+
+	public void setHosts(String hosts) {
+		this.hosts = hosts;
+	}
+
+	public String getHosts() {
+		return this.hosts;
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/config/ElasticsearchNamespaceHandler.java
+++ b/src/main/java/org/springframework/data/elasticsearch/config/ElasticsearchNamespaceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,8 @@ import org.springframework.data.repository.config.RepositoryConfigurationExtensi
  *
  * @author Rizwan Idrees
  * @author Mohsin Husen
+ * @author Don Wellington
  */
-
 public class ElasticsearchNamespaceHandler extends NamespaceHandlerSupport {
 
 	@Override
@@ -37,5 +37,6 @@ public class ElasticsearchNamespaceHandler extends NamespaceHandlerSupport {
 		registerBeanDefinitionParser("repositories", parser);
 		registerBeanDefinitionParser("node-client", new NodeClientBeanDefinitionParser());
 		registerBeanDefinitionParser("transport-client", new TransportClientBeanDefinitionParser());
+		registerBeanDefinitionParser("rest-client", new RestClientBeanDefinitionParser());
 	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/config/RestClientBeanDefinitionParser.java
+++ b/src/main/java/org/springframework/data/elasticsearch/config/RestClientBeanDefinitionParser.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.config;
+
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.data.elasticsearch.client.RestClientFactoryBean;
+import org.w3c.dom.Element;
+
+/**
+ * @author Don Wellington
+ */
+public class RestClientBeanDefinitionParser extends AbstractBeanDefinitionParser {
+
+	@Override
+	protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.rootBeanDefinition(RestClientFactoryBean.class);
+		setConfigurations(element, builder);
+		return getSourcedBeanDefinition(builder, element, parserContext);
+	}
+
+	private void setConfigurations(Element element, BeanDefinitionBuilder builder) {
+		builder.addPropertyValue("hosts", element.getAttribute("hosts"));
+	}
+
+	private AbstractBeanDefinition getSourcedBeanDefinition(BeanDefinitionBuilder builder, Element source,
+			ParserContext context) {
+		AbstractBeanDefinition definition = builder.getBeanDefinition();
+		definition.setSource(context.extractSource(source));
+		return definition;
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchOperations.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,11 +42,6 @@ public interface ElasticsearchOperations {
 	 * @return Converter in use
 	 */
 	ElasticsearchConverter getElasticsearchConverter();
-
-	/**
-	 * @return elasticsearch client
-	 */
-	Client getClient();
 
 	/**
 	 * Create an index for a class

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
@@ -15,63 +15,79 @@
  */
 package org.springframework.data.elasticsearch.core;
 
-import static org.elasticsearch.client.Requests.*;
-import static org.elasticsearch.index.VersionType.*;
-import static org.elasticsearch.index.query.QueryBuilders.*;
-import static org.springframework.data.elasticsearch.core.MappingBuilder.*;
-import static org.springframework.util.CollectionUtils.*;
+import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.apache.commons.lang.StringUtils.isNotBlank;
+import static org.elasticsearch.client.Requests.refreshRequest;
+import static org.elasticsearch.index.VersionType.EXTERNAL;
+import static org.elasticsearch.index.query.QueryBuilders.moreLikeThisQuery;
+import static org.elasticsearch.index.query.QueryBuilders.wrapperQuery;
+import static org.springframework.data.elasticsearch.core.MappingBuilder.buildMapping;
+import static org.springframework.util.CollectionUtils.isEmpty;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
+import java.util.*;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.util.EntityUtils;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
 import org.elasticsearch.action.admin.indices.alias.get.GetAliasesRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequestBuilder;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
 import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.get.MultiGetRequest;
 import org.elasticsearch.action.get.MultiGetRequestBuilder;
 import org.elasticsearch.action.get.MultiGetResponse;
+import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.search.ClearScrollRequest;
+import org.elasticsearch.action.search.ClearScrollResponse;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.search.SearchScrollRequestBuilder;
+import org.elasticsearch.action.search.SearchScrollRequest;
+import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateRequestBuilder;
 import org.elasticsearch.action.update.UpdateResponse;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Requests;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.DeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.MoreLikeThisQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
 import org.elasticsearch.search.sort.FieldSortBuilder;
-import org.elasticsearch.search.sort.ScoreSortBuilder;
 import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
@@ -92,33 +108,23 @@ import org.springframework.data.elasticsearch.annotations.Mapping;
 import org.springframework.data.elasticsearch.annotations.Setting;
 import org.springframework.data.elasticsearch.core.aggregation.AggregatedPage;
 import org.springframework.data.elasticsearch.core.aggregation.impl.AggregatedPageImpl;
+import org.springframework.data.elasticsearch.core.client.support.AliasData;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
 import org.springframework.data.elasticsearch.core.convert.MappingElasticsearchConverter;
 import org.springframework.data.elasticsearch.core.facet.FacetRequest;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentEntity;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentProperty;
 import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
-import org.springframework.data.elasticsearch.core.query.AliasQuery;
-import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
-import org.springframework.data.elasticsearch.core.query.DeleteQuery;
-import org.springframework.data.elasticsearch.core.query.FetchSourceFilter;
-import org.springframework.data.elasticsearch.core.query.GetQuery;
-import org.springframework.data.elasticsearch.core.query.IndexBoost;
-import org.springframework.data.elasticsearch.core.query.IndexQuery;
-import org.springframework.data.elasticsearch.core.query.MoreLikeThisQuery;
-import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
-import org.springframework.data.elasticsearch.core.query.Query;
-import org.springframework.data.elasticsearch.core.query.ScriptField;
-import org.springframework.data.elasticsearch.core.query.SearchQuery;
-import org.springframework.data.elasticsearch.core.query.SourceFilter;
-import org.springframework.data.elasticsearch.core.query.StringQuery;
-import org.springframework.data.elasticsearch.core.query.UpdateQuery;
+import org.springframework.data.elasticsearch.core.query.*;
 import org.springframework.data.util.CloseableIterator;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
- * ElasticsearchTemplate
+ * ElasticsearchRestTemplate
  *
  * @author Rizwan Idrees
  * @author Mohsin Husen
@@ -134,41 +140,40 @@ import org.springframework.util.StringUtils;
  * @author Alen Turkovic
  * @author Sascha Woo
  * @author Ted Liang
+ * @author Don Wellington
  */
-public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<Client>, ApplicationContextAware {
+public class ElasticsearchRestTemplate
+		implements ElasticsearchOperations, EsClient<RestHighLevelClient>, ApplicationContextAware {
 
-	private static final Logger QUERY_LOGGER = LoggerFactory.getLogger("org.springframework.data.elasticsearch.core.QUERY");
-	private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchTemplate.class);
-	private static final String FIELD_SCORE = "_score";
-
-	private Client client;
+	private static final Logger logger = LoggerFactory.getLogger(ElasticsearchRestTemplate.class);
+	private RestHighLevelClient client;
 	private ElasticsearchConverter elasticsearchConverter;
 	private ResultsMapper resultsMapper;
 	private String searchTimeout;
 
-	public ElasticsearchTemplate(Client client) {
+	public ElasticsearchRestTemplate(RestHighLevelClient client) {
 		this(client, new MappingElasticsearchConverter(new SimpleElasticsearchMappingContext()));
 	}
 
-	public ElasticsearchTemplate(Client client, EntityMapper entityMapper) {
+	public ElasticsearchRestTemplate(RestHighLevelClient client, EntityMapper entityMapper) {
 		this(client, new MappingElasticsearchConverter(new SimpleElasticsearchMappingContext()), entityMapper);
 	}
 
-	public ElasticsearchTemplate(Client client, ElasticsearchConverter elasticsearchConverter,
+	public ElasticsearchRestTemplate(RestHighLevelClient client, ElasticsearchConverter elasticsearchConverter,
 			EntityMapper entityMapper) {
 		this(client, elasticsearchConverter,
 				new DefaultResultMapper(elasticsearchConverter.getMappingContext(), entityMapper));
 	}
 
-	public ElasticsearchTemplate(Client client, ResultsMapper resultsMapper) {
+	public ElasticsearchRestTemplate(RestHighLevelClient client, ResultsMapper resultsMapper) {
 		this(client, new MappingElasticsearchConverter(new SimpleElasticsearchMappingContext()), resultsMapper);
 	}
 
-	public ElasticsearchTemplate(Client client, ElasticsearchConverter elasticsearchConverter) {
+	public ElasticsearchRestTemplate(RestHighLevelClient client, ElasticsearchConverter elasticsearchConverter) {
 		this(client, elasticsearchConverter, new DefaultResultMapper(elasticsearchConverter.getMappingContext()));
 	}
 
-	public ElasticsearchTemplate(Client client, ElasticsearchConverter elasticsearchConverter,
+	public ElasticsearchRestTemplate(RestHighLevelClient client, ElasticsearchConverter elasticsearchConverter,
 			ResultsMapper resultsMapper) {
 
 		Assert.notNull(client, "Client must not be null!");
@@ -181,7 +186,7 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 	}
 
 	@Override
-	public Client getClient() {
+	public RestHighLevelClient getClient() {
 		return client;
 	}
 
@@ -197,20 +202,24 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 	@Override
 	public boolean createIndex(String indexName) {
 		Assert.notNull(indexName, "No index defined for Query");
-		return client.admin().indices().create(Requests.createIndexRequest(indexName)).actionGet().isAcknowledged();
+		try {
+			return client.indices().create(Requests.createIndexRequest(indexName)).isAcknowledged();
+		} catch (Exception e) {
+			throw new ElasticsearchException("Failed to create index " + indexName, e);
+		}
 	}
 
 	@Override
 	public <T> boolean putMapping(Class<T> clazz) {
 		if (clazz.isAnnotationPresent(Mapping.class)) {
 			String mappingPath = clazz.getAnnotation(Mapping.class).mappingPath();
-			if (!StringUtils.isEmpty(mappingPath)) {
+			if (isNotBlank(mappingPath)) {
 				String mappings = readFileFromClasspath(mappingPath);
-				if (!StringUtils.isEmpty(mappings)) {
+				if (isNotBlank(mappings)) {
 					return putMapping(clazz, mappings);
 				}
 			} else {
-				LOGGER.info("mappingPath in @Mapping has to be defined. Building mappings using @Field");
+				logger.info("mappingPath in @Mapping has to be defined. Building mappings using @Field");
 			}
 		}
 		ElasticsearchPersistentEntity<T> persistentEntity = getPersistentEntityFor(clazz);
@@ -219,8 +228,8 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 
 			ElasticsearchPersistentProperty property = persistentEntity.getRequiredIdProperty();
 
-			xContentBuilder = buildMapping(clazz, persistentEntity.getIndexType(),
-					property.getFieldName(), persistentEntity.getParentType());
+			xContentBuilder = buildMapping(clazz, persistentEntity.getIndexType(), property.getFieldName(),
+					persistentEntity.getParentType());
 		} catch (Exception e) {
 			throw new ElasticsearchException("Failed to build mapping for " + clazz.getSimpleName(), e);
 		}
@@ -237,15 +246,19 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 	public boolean putMapping(String indexName, String type, Object mapping) {
 		Assert.notNull(indexName, "No index defined for putMapping()");
 		Assert.notNull(type, "No type defined for putMapping()");
-		PutMappingRequestBuilder requestBuilder = client.admin().indices().preparePutMapping(indexName).setType(type);
+		PutMappingRequest request = new PutMappingRequest(indexName).type(type);
 		if (mapping instanceof String) {
-			requestBuilder.setSource(String.valueOf(mapping), XContentType.JSON);
+			request.source(String.valueOf(mapping), XContentType.JSON);
 		} else if (mapping instanceof Map) {
-			requestBuilder.setSource((Map) mapping);
+			request.source((Map) mapping);
 		} else if (mapping instanceof XContentBuilder) {
-			requestBuilder.setSource((XContentBuilder) mapping);
+			request.source((XContentBuilder) mapping);
 		}
-		return requestBuilder.execute().actionGet().isAcknowledged();
+		try {
+			return client.indices().putMapping(request).isAcknowledged();
+		} catch (IOException e) {
+			throw new ElasticsearchException("Failed to put mapping for " + indexName, e);
+		}
 	}
 
 	@Override
@@ -253,12 +266,13 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 		Assert.notNull(indexName, "No index defined for putMapping()");
 		Assert.notNull(type, "No type defined for putMapping()");
 		Map mappings = null;
+		RestClient restClient = client.getLowLevelClient();
 		try {
-			mappings = client.admin().indices().getMappings(new GetMappingsRequest().indices(indexName).types(type))
-					.actionGet().getMappings().get(indexName).get(type).getSourceAsMap();
+			Response response = restClient.performRequest("GET", "/" + indexName + "/_mapping/" + type);
+			mappings = convertMappingResponse(EntityUtils.toString(response.getEntity()));
 		} catch (Exception e) {
 			throw new ElasticsearchException(
-					"Error while getting mapping for indexName : " + indexName + " type : " + type + " " + e.getMessage());
+					"Error while getting mapping for indexName : " + indexName + " type : " + type + " ", e);
 		}
 		return mappings;
 	}
@@ -266,6 +280,23 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 	@Override
 	public <T> Map getMapping(Class<T> clazz) {
 		return getMapping(getPersistentEntityFor(clazz).getIndexName(), getPersistentEntityFor(clazz).getIndexType());
+	}
+
+	private Map<String, Object> convertMappingResponse(String mappingResponse) {
+		ObjectMapper mapper = new ObjectMapper();
+
+		try {
+			Map result = null;
+			JsonNode node = mapper.readTree(mappingResponse);
+
+			node = node.findValue("settings");
+			result = mapper.readValue(mapper.writeValueAsString(node), HashMap.class);
+
+			return result;
+		} catch (IOException e) {
+			throw new ElasticsearchException("Could not map alias response : " + mappingResponse, e);
+		}
+
 	}
 
 	@Override
@@ -281,12 +312,16 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 	@Override
 	public <T> T queryForObject(GetQuery query, Class<T> clazz, GetResultMapper mapper) {
 		ElasticsearchPersistentEntity<T> persistentEntity = getPersistentEntityFor(clazz);
-		GetResponse response = client
-				.prepareGet(persistentEntity.getIndexName(), persistentEntity.getIndexType(), query.getId()).execute()
-				.actionGet();
-
-		T entity = mapper.mapResult(response, clazz);
-		return entity;
+		GetRequest request = new GetRequest(persistentEntity.getIndexName(), persistentEntity.getIndexType(),
+				query.getId());
+		GetResponse response;
+		try {
+			response = client.get(request);
+			T entity = mapper.mapResult(response, clazz);
+			return entity;
+		} catch (IOException e) {
+			throw new ElasticsearchException("Error while getting for request: " + request.toString(), e);
+		}
 	}
 
 	@Override
@@ -316,7 +351,7 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 
 	@Override
 	public <T> T query(SearchQuery query, ResultsExtractor<T> resultsExtractor) {
-		SearchResponse response = doSearch(prepareSearch(query), query);
+		SearchResponse response = doSearch(prepareSearch(query, Optional.ofNullable(query.getQuery())), query);
 		return resultsExtractor.extract(response);
 	}
 
@@ -337,11 +372,17 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 
 	@Override
 	public <T> List<String> queryForIds(SearchQuery query) {
-		SearchRequestBuilder request = prepareSearch(query).setQuery(query.getQuery());
+		SearchRequest request = prepareSearch(query, Optional.ofNullable(query.getQuery()));
+		request.source().query(query.getQuery());
 		if (query.getFilter() != null) {
-			request.setPostFilter(query.getFilter());
+			request.source().postFilter(query.getFilter());
 		}
-		SearchResponse response = getSearchResponse(request);
+		SearchResponse response;
+		try {
+			response = client.search(request);
+		} catch (IOException e) {
+			throw new ElasticsearchException("Error for search request: " + request.toString(), e);
+		}
 		return extractIds(response);
 	}
 
@@ -350,22 +391,30 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 		QueryBuilder elasticsearchQuery = new CriteriaQueryProcessor().createQueryFromCriteria(criteriaQuery.getCriteria());
 		QueryBuilder elasticsearchFilter = new CriteriaFilterProcessor()
 				.createFilterFromCriteria(criteriaQuery.getCriteria());
-		SearchRequestBuilder searchRequestBuilder = prepareSearch(criteriaQuery, clazz);
+		SearchRequest request = prepareSearch(criteriaQuery, clazz);
 
 		if (elasticsearchQuery != null) {
-			searchRequestBuilder.setQuery(elasticsearchQuery);
+			request.source().query(elasticsearchQuery);
 		} else {
-			searchRequestBuilder.setQuery(QueryBuilders.matchAllQuery());
+			request.source().query(QueryBuilders.matchAllQuery());
 		}
 
 		if (criteriaQuery.getMinScore() > 0) {
-			searchRequestBuilder.setMinScore(criteriaQuery.getMinScore());
+			request.source().minScore(criteriaQuery.getMinScore());
 		}
 
 		if (elasticsearchFilter != null)
-			searchRequestBuilder.setPostFilter(elasticsearchFilter);
+			request.source().postFilter(elasticsearchFilter);
+		if (logger.isDebugEnabled()) {
+			logger.debug("doSearch query:\n" + request.toString());
+		}
 
-		SearchResponse response = getSearchResponse(searchRequestBuilder);
+		SearchResponse response;
+		try {
+			response = client.search(request);
+		} catch (IOException e) {
+			throw new ElasticsearchException("Error for search request: " + request.toString(), e);
+		}
 		return resultsMapper.mapResults(response, clazz, criteriaQuery.getPageable());
 	}
 
@@ -376,14 +425,22 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 
 	@Override
 	public <T> Page<T> queryForPage(StringQuery query, Class<T> clazz, SearchResultMapper mapper) {
-		SearchResponse response = getSearchResponse(prepareSearch(query, clazz).setQuery(wrapperQuery(query.getSource())));
+		SearchRequest request = prepareSearch(query, clazz);
+		request.source().query((wrapperQuery(query.getSource())));
+		SearchResponse response;
+		try {
+			response = client.search(request);
+		} catch (IOException e) {
+			throw new ElasticsearchException("Error for search request: " + request.toString(), e);
+		}
 		return mapper.mapResults(response, clazz, query.getPageable());
 	}
 
 	@Override
 	public <T> CloseableIterator<T> stream(CriteriaQuery query, Class<T> clazz) {
 		final long scrollTimeInMillis = TimeValue.timeValueMinutes(1).millis();
-		return doStream(scrollTimeInMillis, (ScrolledPage<T>) startScroll(scrollTimeInMillis, query, clazz), clazz, resultsMapper);
+		return doStream(scrollTimeInMillis, (ScrolledPage<T>) startScroll(scrollTimeInMillis, query, clazz), clazz,
+				resultsMapper);
 	}
 
 	@Override
@@ -394,10 +451,12 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 	@Override
 	public <T> CloseableIterator<T> stream(SearchQuery query, final Class<T> clazz, final SearchResultMapper mapper) {
 		final long scrollTimeInMillis = TimeValue.timeValueMinutes(1).millis();
-		return doStream(scrollTimeInMillis, (ScrolledPage<T>) startScroll(scrollTimeInMillis, query, clazz, mapper), clazz, mapper);
+		return doStream(scrollTimeInMillis, (ScrolledPage<T>) startScroll(scrollTimeInMillis, query, clazz, mapper), clazz,
+				mapper);
 	}
 
-	private <T> CloseableIterator<T> doStream(final long scrollTimeInMillis, final ScrolledPage<T> page, final Class<T> clazz, final SearchResultMapper mapper) {
+	private <T> CloseableIterator<T> doStream(final long scrollTimeInMillis, final ScrolledPage<T> page,
+			final Class<T> clazz, final SearchResultMapper mapper) {
 		return new CloseableIterator<T>() {
 
 			/** As we couldn't retrieve single result with scroll, store current hits. */
@@ -492,28 +551,39 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 		return count(query, null);
 	}
 
-	private long doCount(SearchRequestBuilder countRequestBuilder, QueryBuilder elasticsearchQuery) {
-
+	private long doCount(SearchRequest countRequest, QueryBuilder elasticsearchQuery) {
+		SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
 		if (elasticsearchQuery != null) {
-			countRequestBuilder.setQuery(elasticsearchQuery);
+			sourceBuilder.query(elasticsearchQuery);
 		}
-		return countRequestBuilder.execute().actionGet().getHits().getTotalHits();
+		countRequest.source(sourceBuilder);
+
+		try {
+			return client.search(countRequest).getHits().getTotalHits();
+		} catch (IOException e) {
+			throw new ElasticsearchException("Error while searching for request: " + countRequest.toString(), e);
+		}
 	}
 
-	private long doCount(SearchRequestBuilder searchRequestBuilder, QueryBuilder elasticsearchQuery,
-			QueryBuilder elasticsearchFilter) {
+	private long doCount(SearchRequest searchRequest, QueryBuilder elasticsearchQuery, QueryBuilder elasticsearchFilter) {
 		if (elasticsearchQuery != null) {
-			searchRequestBuilder.setQuery(elasticsearchQuery);
+			searchRequest.source().query(elasticsearchQuery);
 		} else {
-			searchRequestBuilder.setQuery(QueryBuilders.matchAllQuery());
+			searchRequest.source().query(QueryBuilders.matchAllQuery());
 		}
 		if (elasticsearchFilter != null) {
-			searchRequestBuilder.setPostFilter(elasticsearchFilter);
+			searchRequest.source().postFilter(elasticsearchFilter);
 		}
-		return searchRequestBuilder.execute().actionGet().getHits().getTotalHits();
+		SearchResponse response;
+		try {
+			response = client.search(searchRequest);
+		} catch (IOException e) {
+			throw new ElasticsearchException("Error for search request: " + searchRequest.toString(), e);
+		}
+		return response.getHits().getTotalHits();
 	}
 
-	private <T> SearchRequestBuilder prepareCount(Query query, Class<T> clazz) {
+	private <T> SearchRequest prepareCount(Query query, Class<T> clazz) {
 		String indexName[] = !isEmpty(query.getIndices())
 				? query.getIndices().toArray(new String[query.getIndices().size()])
 				: retrieveIndexNameFromPersistentEntity(clazz);
@@ -522,12 +592,11 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 
 		Assert.notNull(indexName, "No index defined for Query");
 
-		SearchRequestBuilder countRequestBuilder = client.prepareSearch(indexName);
+		SearchRequest countRequestBuilder = new SearchRequest(indexName);
 
 		if (types != null) {
-			countRequestBuilder.setTypes(types);
+			countRequestBuilder.types(types);
 		}
-		countRequestBuilder.setSize(0);
 		return countRequestBuilder;
 	}
 
@@ -547,7 +616,7 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 		Assert.notNull(type, "No type define for Query");
 		Assert.notEmpty(searchQuery.getIds(), "No Id define for Query");
 
-		MultiGetRequestBuilder builder = client.prepareMultiGet();
+		MultiGetRequest request = new MultiGetRequest();
 
 		if (searchQuery.getFields() != null && !searchQuery.getFields().isEmpty()) {
 			searchQuery.addSourceFilter(new FetchSourceFilter(toArray(searchQuery.getFields()), null));
@@ -561,9 +630,13 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 				item = item.routing(searchQuery.getRoute());
 			}
 
-			builder.add(item);
+			request.add(item);
 		}
-		return builder.execute().actionGet();
+		try {
+			return client.multiGet(request);
+		} catch (IOException e) {
+			throw new ElasticsearchException("Error while multiget for request: " + request.toString(), e);
+		}
 	}
 
 	@Override
@@ -573,7 +646,13 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 
 	@Override
 	public String index(IndexQuery query) {
-		String documentId = prepareIndex(query).execute().actionGet().getId();
+		String documentId;
+		IndexRequest request = prepareIndex(query);
+		try {
+			documentId = client.index(request).getId();
+		} catch (IOException e) {
+			throw new ElasticsearchException("Error while index for request: " + request.toString(), e);
+		}
 		// We should call this because we are not going through a mapper.
 		if (query.getObject() != null) {
 			setPersistentEntityId(query.getObject(), documentId);
@@ -583,52 +662,65 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 
 	@Override
 	public UpdateResponse update(UpdateQuery query) {
-		return this.prepareUpdate(query).execute().actionGet();
+		UpdateRequest request = prepareUpdate(query);
+		try {
+			return client.update(request);
+		} catch (IOException e) {
+			throw new ElasticsearchException("Error while update for request: " + request.toString(), e);
+		}
 	}
 
-	private UpdateRequestBuilder prepareUpdate(UpdateQuery query) {
-		String indexName = !StringUtils.isEmpty(query.getIndexName()) ? query.getIndexName()
+	private UpdateRequest prepareUpdate(UpdateQuery query) {
+		String indexName = isNotBlank(query.getIndexName()) ? query.getIndexName()
 				: getPersistentEntityFor(query.getClazz()).getIndexName();
-		String type = !StringUtils.isEmpty(query.getType()) ? query.getType()
+		String type = isNotBlank(query.getType()) ? query.getType()
 				: getPersistentEntityFor(query.getClazz()).getIndexType();
 		Assert.notNull(indexName, "No index defined for Query");
 		Assert.notNull(type, "No type define for Query");
 		Assert.notNull(query.getId(), "No Id define for Query");
 		Assert.notNull(query.getUpdateRequest(), "No IndexRequest define for Query");
-		UpdateRequestBuilder updateRequestBuilder = client.prepareUpdate(indexName, type, query.getId());
-		updateRequestBuilder.setRouting(query.getUpdateRequest().routing());
+		UpdateRequest updateRequest = new UpdateRequest(indexName, type, query.getId());
+		updateRequest.routing(query.getUpdateRequest().routing());
 
 		if (query.getUpdateRequest().script() == null) {
 			// doc
 			if (query.DoUpsert()) {
-				updateRequestBuilder.setDocAsUpsert(true).setDoc(query.getUpdateRequest().doc());
+				updateRequest.docAsUpsert(true).doc(query.getUpdateRequest().doc());
 			} else {
-				updateRequestBuilder.setDoc(query.getUpdateRequest().doc());
+				updateRequest.doc(query.getUpdateRequest().doc());
 			}
 		} else {
 			// or script
-			updateRequestBuilder.setScript(query.getUpdateRequest().script());
+			updateRequest.script(query.getUpdateRequest().script());
 		}
 
-		return updateRequestBuilder;
+		return updateRequest;
 	}
 
 	@Override
 	public void bulkIndex(List<IndexQuery> queries) {
-		BulkRequestBuilder bulkRequest = client.prepareBulk();
+		BulkRequest bulkRequest = new BulkRequest();
 		for (IndexQuery query : queries) {
 			bulkRequest.add(prepareIndex(query));
 		}
-		checkForBulkUpdateFailure(bulkRequest.execute().actionGet());
+		try {
+			checkForBulkUpdateFailure(client.bulk(bulkRequest));
+		} catch (IOException e) {
+			throw new ElasticsearchException("Error while bulk for request: " + bulkRequest.toString(), e);
+		}
 	}
 
 	@Override
 	public void bulkUpdate(List<UpdateQuery> queries) {
-		BulkRequestBuilder bulkRequest = client.prepareBulk();
+		BulkRequest bulkRequest = new BulkRequest();
 		for (UpdateQuery query : queries) {
 			bulkRequest.add(prepareUpdate(query));
 		}
-		checkForBulkUpdateFailure(bulkRequest.execute().actionGet());
+		try {
+			checkForBulkUpdateFailure(client.bulk(bulkRequest));
+		} catch (IOException e) {
+			throw new ElasticsearchException("Error while bulk for request: " + bulkRequest.toString(), e);
+		}
 	}
 
 	private void checkForBulkUpdateFailure(BulkResponse bulkResponse) {
@@ -652,13 +744,25 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 
 	@Override
 	public boolean indexExists(String indexName) {
-		return client.admin().indices().exists(indicesExistsRequest(indexName)).actionGet().isExists();
+		GetIndexRequest request = new GetIndexRequest();
+		request.indices(indexName);
+		try {
+			return client.indices().exists(request);
+		} catch (IOException e) {
+			throw new ElasticsearchException("Error while for indexExists request: " + request.toString(), e);
+		}
 	}
 
 	@Override
 	public boolean typeExists(String index, String type) {
-		return client.admin().cluster().prepareState().execute().actionGet().getState().metaData().index(index)
-				.getMappings().containsKey(type);
+		RestClient restClient = client.getLowLevelClient();
+		try {
+			Response response = restClient.performRequest("HEAD", index + "/_mapping/" + type);
+			return (response.getStatusLine().getStatusCode() == 200);
+		} catch (Exception e) {
+			throw new ElasticsearchException("Error while checking type exists for index: " + index + " type : " + type + " ",
+					e);
+		}
 	}
 
 	@Override
@@ -670,14 +774,24 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 	public boolean deleteIndex(String indexName) {
 		Assert.notNull(indexName, "No index defined for delete operation");
 		if (indexExists(indexName)) {
-			return client.admin().indices().delete(new DeleteIndexRequest(indexName)).actionGet().isAcknowledged();
+			DeleteIndexRequest request = new DeleteIndexRequest(indexName);
+			try {
+				return client.indices().delete(request).isAcknowledged();
+			} catch (IOException e) {
+				throw new ElasticsearchException("Error while deleting index request: " + request.toString(), e);
+			}
 		}
 		return false;
 	}
 
 	@Override
 	public String delete(String indexName, String type, String id) {
-		return client.prepareDelete(indexName, type, id).execute().actionGet().getId();
+		DeleteRequest request = new DeleteRequest(indexName, type, id);
+		try {
+			return client.delete(request).getId();
+		} catch (IOException e) {
+			throw new ElasticsearchException("Error while deleting item request: " + request.toString(), e);
+		}
 	}
 
 	@Override
@@ -689,9 +803,9 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 	@Override
 	public <T> void delete(DeleteQuery deleteQuery, Class<T> clazz) {
 
-		String indexName = !StringUtils.isEmpty(deleteQuery.getIndex()) ? deleteQuery.getIndex()
+		String indexName = isNotBlank(deleteQuery.getIndex()) ? deleteQuery.getIndex()
 				: getPersistentEntityFor(clazz).getIndexName();
-		String typeName = !StringUtils.isEmpty(deleteQuery.getType()) ? deleteQuery.getType()
+		String typeName = isNotBlank(deleteQuery.getType()) ? deleteQuery.getType()
 				: getPersistentEntityFor(clazz).getIndexType();
 		Integer pageSize = deleteQuery.getPageSize() != null ? deleteQuery.getPageSize() : 1000;
 		Long scrollTimeInMillis = deleteQuery.getScrollTimeInMillis() != null ? deleteQuery.getScrollTimeInMillis()
@@ -716,20 +830,27 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 		};
 
 		Page<String> scrolledResult = startScroll(scrollTimeInMillis, searchQuery, String.class, onlyIdResultMapper);
-		BulkRequestBuilder bulkRequestBuilder = client.prepareBulk();
+		BulkRequest request = new BulkRequest();
 		List<String> ids = new ArrayList<String>();
 
 		do {
 			ids.addAll(scrolledResult.getContent());
-			scrolledResult = continueScroll(((ScrolledPage<T>)scrolledResult).getScrollId(), scrollTimeInMillis, String.class, onlyIdResultMapper);
-		} while(scrolledResult.getContent().size() != 0);
+			scrolledResult = continueScroll(((ScrolledPage<T>) scrolledResult).getScrollId(), scrollTimeInMillis,
+					String.class, onlyIdResultMapper);
+		} while (scrolledResult.getContent().size() != 0);
 
 		for (String id : ids) {
-			bulkRequestBuilder.add(client.prepareDelete(indexName, typeName, id));
+			request.add(new DeleteRequest(indexName, typeName, id));
 		}
 
-		if (bulkRequestBuilder.numberOfActions() > 0) {
-			bulkRequestBuilder.execute().actionGet();
+		if (request.numberOfActions() > 0) {
+			BulkResponse response;
+			try {
+				response = client.bulk(request);
+				checkForBulkUpdateFailure(response);
+			} catch (IOException e) {
+				throw new ElasticsearchException("Error while deleting bulk: " + request.toString(), e);
+			}
 		}
 
 		clearScroll(((ScrolledPage<T>) scrolledResult).getScrollId());
@@ -751,29 +872,29 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 		delete(deleteQuery, clazz);
 	}
 
-	private <T> SearchRequestBuilder prepareScroll(Query query, long scrollTimeInMillis, Class<T> clazz) {
+	private <T> SearchRequest prepareScroll(Query query, long scrollTimeInMillis, Class<T> clazz) {
 		setPersistentEntityIndexAndType(query, clazz);
 		return prepareScroll(query, scrollTimeInMillis);
 	}
 
-	private SearchRequestBuilder prepareScroll(Query query, long scrollTimeInMillis) {
-		SearchRequestBuilder requestBuilder = client.prepareSearch(toArray(query.getIndices()))
-				.setTypes(toArray(query.getTypes()))
-				.setScroll(TimeValue.timeValueMillis(scrollTimeInMillis))
-				.setFrom(0)
-				.setVersion(true);
+	private SearchRequest prepareScroll(Query query, long scrollTimeInMillis) {
+		SearchRequest request = new SearchRequest(toArray(query.getIndices()));
+		SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+		request.types(toArray(query.getTypes()));
+		request.scroll(TimeValue.timeValueMillis(scrollTimeInMillis));
 
-		if(query.getPageable().isPaged()){
-			requestBuilder.setSize(query.getPageable().getPageSize());
+		if (query.getPageable().isPaged()) {
+			searchSourceBuilder.size(query.getPageable().getPageSize());
 		}
 
 		if (!isEmpty(query.getFields())) {
-			requestBuilder.setFetchSource(toArray(query.getFields()), null);
+			searchSourceBuilder.fetchSource(toArray(query.getFields()), null);
 		}
-		return requestBuilder;
+		request.source(searchSourceBuilder);
+		return request;
 	}
 
-	private SearchResponse doScroll(SearchRequestBuilder requestBuilder, CriteriaQuery criteriaQuery) {
+	private SearchResponse doScroll(SearchRequest request, CriteriaQuery criteriaQuery) {
 		Assert.notNull(criteriaQuery.getIndices(), "No index defined for Query");
 		Assert.notNull(criteriaQuery.getTypes(), "No type define for Query");
 		Assert.notNull(criteriaQuery.getPageable(), "Query.pageable is required for scan & scroll");
@@ -783,28 +904,38 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 				.createFilterFromCriteria(criteriaQuery.getCriteria());
 
 		if (elasticsearchQuery != null) {
-			requestBuilder.setQuery(elasticsearchQuery);
+			request.source().query(elasticsearchQuery);
 		} else {
-			requestBuilder.setQuery(QueryBuilders.matchAllQuery());
+			request.source().query(QueryBuilders.matchAllQuery());
 		}
 
 		if (elasticsearchFilter != null) {
-			requestBuilder.setPostFilter(elasticsearchFilter);
+			request.source().postFilter(elasticsearchFilter);
 		}
+		request.source().version(true);
 
-		return getSearchResponse(requestBuilder);
+		try {
+			return client.search(request);
+		} catch (IOException e) {
+			throw new ElasticsearchException("Error for search request with scroll: " + request.toString(), e);
+		}
 	}
 
-	private SearchResponse doScroll(SearchRequestBuilder requestBuilder, SearchQuery searchQuery) {
+	private SearchResponse doScroll(SearchRequest request, SearchQuery searchQuery) {
 		Assert.notNull(searchQuery.getIndices(), "No index defined for Query");
 		Assert.notNull(searchQuery.getTypes(), "No type define for Query");
 		Assert.notNull(searchQuery.getPageable(), "Query.pageable is required for scan & scroll");
 
 		if (searchQuery.getFilter() != null) {
-			requestBuilder.setPostFilter(searchQuery.getFilter());
+			request.source().postFilter(searchQuery.getFilter());
 		}
+		request.source().version(true);
 
-		return getSearchResponse(requestBuilder.setQuery(searchQuery.getQuery()));
+		try {
+			return client.search(request);
+		} catch (IOException e) {
+			throw new ElasticsearchException("Error for search request with scroll: " + request.toString(), e);
+		}
 	}
 
 	public <T> Page<T> startScroll(long scrollTimeInMillis, SearchQuery searchQuery, Class<T> clazz) {
@@ -817,46 +948,68 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 		return resultsMapper.mapResults(response, clazz, null);
 	}
 
-	public <T> Page<T> startScroll(long scrollTimeInMillis, SearchQuery searchQuery, Class<T> clazz, SearchResultMapper mapper) {
+	public <T> Page<T> startScroll(long scrollTimeInMillis, SearchQuery searchQuery, Class<T> clazz,
+			SearchResultMapper mapper) {
 		SearchResponse response = doScroll(prepareScroll(searchQuery, scrollTimeInMillis, clazz), searchQuery);
 		return mapper.mapResults(response, clazz, null);
 	}
 
-	public <T> Page<T> startScroll(long scrollTimeInMillis, CriteriaQuery criteriaQuery, Class<T> clazz, SearchResultMapper mapper) {
+	public <T> Page<T> startScroll(long scrollTimeInMillis, CriteriaQuery criteriaQuery, Class<T> clazz,
+			SearchResultMapper mapper) {
 		SearchResponse response = doScroll(prepareScroll(criteriaQuery, scrollTimeInMillis, clazz), criteriaQuery);
 		return mapper.mapResults(response, clazz, null);
 	}
 
 	public <T> Page<T> continueScroll(@Nullable String scrollId, long scrollTimeInMillis, Class<T> clazz) {
-		SearchResponse response = getSearchResponse(client.prepareSearchScroll(scrollId)
-				.setScroll(TimeValue.timeValueMillis(scrollTimeInMillis)).execute());
+		SearchScrollRequest request = new SearchScrollRequest(scrollId);
+		request.scroll(TimeValue.timeValueMillis(scrollTimeInMillis));
+		SearchResponse response;
+		try {
+			response = client.searchScroll(request);
+		} catch (IOException e) {
+			throw new ElasticsearchException("Error for search request with scroll: " + request.toString(), e);
+		}
 		return resultsMapper.mapResults(response, clazz, Pageable.unpaged());
 	}
 
-	public <T> Page<T> continueScroll(@Nullable String scrollId, long scrollTimeInMillis, Class<T> clazz, SearchResultMapper mapper) {
-		SearchResponse response = getSearchResponse(client.prepareSearchScroll(scrollId)
-				.setScroll(TimeValue.timeValueMillis(scrollTimeInMillis)).execute());
+	public <T> Page<T> continueScroll(@Nullable String scrollId, long scrollTimeInMillis, Class<T> clazz,
+			SearchResultMapper mapper) {
+		SearchScrollRequest request = new SearchScrollRequest(scrollId);
+		request.scroll(TimeValue.timeValueMillis(scrollTimeInMillis));
+		SearchResponse response;
+		try {
+			response = client.searchScroll(request);
+		} catch (IOException e) {
+			throw new ElasticsearchException("Error for search request with scroll: " + request.toString(), e);
+		}
 		return mapper.mapResults(response, clazz, Pageable.unpaged());
 	}
 
 	@Override
 	public void clearScroll(String scrollId) {
-		client.prepareClearScroll().addScrollId(scrollId).execute().actionGet();
+		ClearScrollRequest request = new ClearScrollRequest();
+		request.addScrollId(scrollId);
+		try {
+			// TODO: Something useful with the response.
+			ClearScrollResponse response = client.clearScroll(request);
+		} catch (IOException e) {
+			throw new ElasticsearchException("Error for search request with scroll: " + request.toString(), e);
+		}
 	}
 
 	@Override
 	public <T> Page<T> moreLikeThis(MoreLikeThisQuery query, Class<T> clazz) {
 
 		ElasticsearchPersistentEntity persistentEntity = getPersistentEntityFor(clazz);
-		String indexName = !StringUtils.isEmpty(query.getIndexName()) ? query.getIndexName() : persistentEntity.getIndexName();
-		String type = !StringUtils.isEmpty(query.getType()) ? query.getType() : persistentEntity.getIndexType();
+		String indexName = isNotBlank(query.getIndexName()) ? query.getIndexName() : persistentEntity.getIndexName();
+		String type = isNotBlank(query.getType()) ? query.getType() : persistentEntity.getIndexType();
 
 		Assert.notNull(indexName, "No 'indexName' defined for MoreLikeThisQuery");
 		Assert.notNull(type, "No 'type' defined for MoreLikeThisQuery");
 		Assert.notNull(query.getId(), "No document id defined for MoreLikeThisQuery");
 
-
-		MoreLikeThisQueryBuilder moreLikeThisQueryBuilder = moreLikeThisQuery(toArray(new MoreLikeThisQueryBuilder.Item(indexName, type, query.getId())));
+		MoreLikeThisQueryBuilder moreLikeThisQueryBuilder = moreLikeThisQuery(
+				toArray(new MoreLikeThisQueryBuilder.Item(indexName, type, query.getId())));
 
 		if (query.getMinTermFreq() != null) {
 			moreLikeThisQueryBuilder.minTermFreq(query.getMinTermFreq());
@@ -886,14 +1039,14 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 		return queryForPage(new NativeSearchQueryBuilder().withQuery(moreLikeThisQueryBuilder).build(), clazz);
 	}
 
-	private SearchResponse doSearch(SearchRequestBuilder searchRequest, SearchQuery searchQuery) {
+	private SearchResponse doSearch(SearchRequest searchRequest, SearchQuery searchQuery) {
 		if (searchQuery.getFilter() != null) {
-			searchRequest.setPostFilter(searchQuery.getFilter());
+			searchRequest.source().postFilter(searchQuery.getFilter());
 		}
 
 		if (!isEmpty(searchQuery.getElasticsearchSorts())) {
 			for (SortBuilder sort : searchQuery.getElasticsearchSorts()) {
-				searchRequest.addSort(sort);
+				searchRequest.source().sort(sort);
 			}
 		}
 
@@ -901,7 +1054,7 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 			// _source should be return all the time
 			// searchRequest.addStoredField("_source");
 			for (ScriptField scriptedField : searchQuery.getScriptFields()) {
-				searchRequest.addScriptField(scriptedField.fieldName(), scriptedField.script());
+				searchRequest.source().scriptField(scriptedField.fieldName(), scriptedField.script());
 			}
 		}
 
@@ -910,36 +1063,32 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 			for (HighlightBuilder.Field highlightField : searchQuery.getHighlightFields()) {
 				highlightBuilder.field(highlightField);
 			}
-			searchRequest.highlighter(highlightBuilder);
+			searchRequest.source().highlighter(highlightBuilder);
 		}
 
 		if (!isEmpty(searchQuery.getIndicesBoost())) {
 			for (IndexBoost indexBoost : searchQuery.getIndicesBoost()) {
-				searchRequest.addIndexBoost(indexBoost.getIndexName(), indexBoost.getBoost());
+				searchRequest.source().indexBoost(indexBoost.getIndexName(), indexBoost.getBoost());
 			}
 		}
 
 		if (!isEmpty(searchQuery.getAggregations())) {
 			for (AbstractAggregationBuilder aggregationBuilder : searchQuery.getAggregations()) {
-				searchRequest.addAggregation(aggregationBuilder);
+				searchRequest.source().aggregation(aggregationBuilder);
 			}
 		}
 
 		if (!isEmpty(searchQuery.getFacets())) {
 			for (FacetRequest aggregatedFacet : searchQuery.getFacets()) {
-				searchRequest.addAggregation(aggregatedFacet.getFacet());
+				searchRequest.source().aggregation(aggregatedFacet.getFacet());
 			}
 		}
-		return getSearchResponse(searchRequest.setQuery(searchQuery.getQuery()));
-	}
 
-	private SearchResponse getSearchResponse(SearchRequestBuilder requestBuilder) {
-		
-		if (QUERY_LOGGER.isDebugEnabled()) {
-			QUERY_LOGGER.debug(requestBuilder.toString());
+		try {
+			return client.search(searchRequest);
+		} catch (IOException e) {
+			throw new ElasticsearchException("Error for search request with scroll: " + searchRequest.toString(), e);
 		}
-		
-		return getSearchResponse(requestBuilder.execute());
 	}
 
 	private SearchResponse getSearchResponse(ActionFuture<SearchResponse> response) {
@@ -953,13 +1102,13 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 	private <T> boolean createIndexWithSettings(Class<T> clazz) {
 		if (clazz.isAnnotationPresent(Setting.class)) {
 			String settingPath = clazz.getAnnotation(Setting.class).settingPath();
-			if (!StringUtils.isEmpty(settingPath)) {
+			if (isNotBlank(settingPath)) {
 				String settings = readFileFromClasspath(settingPath);
-				if (!StringUtils.isEmpty(settings)) {
+				if (isNotBlank(settings)) {
 					return createIndex(getPersistentEntityFor(clazz).getIndexName(), settings);
 				}
 			} else {
-				LOGGER.info("settingPath in @Setting has to be defined. Using default instead.");
+				logger.info("settingPath in @Setting has to be defined. Using default instead.");
 			}
 		}
 		return createIndex(getPersistentEntityFor(clazz).getIndexName(), getDefaultSettings(getPersistentEntityFor(clazz)));
@@ -967,15 +1116,19 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 
 	@Override
 	public boolean createIndex(String indexName, Object settings) {
-		CreateIndexRequestBuilder createIndexRequestBuilder = client.admin().indices().prepareCreate(indexName);
+		CreateIndexRequest request = new CreateIndexRequest(indexName);
 		if (settings instanceof String) {
-			createIndexRequestBuilder.setSettings(String.valueOf(settings), Requests.INDEX_CONTENT_TYPE);
+			request.settings(String.valueOf(settings), Requests.INDEX_CONTENT_TYPE);
 		} else if (settings instanceof Map) {
-			createIndexRequestBuilder.setSettings((Map) settings);
+			request.settings((Map) settings);
 		} else if (settings instanceof XContentBuilder) {
-			createIndexRequestBuilder.setSettings((XContentBuilder) settings);
+			request.settings((XContentBuilder) settings);
 		}
-		return createIndexRequestBuilder.execute().actionGet().isAcknowledged();
+		try {
+			return client.indices().create(request).isAcknowledged();
+		} catch (IOException e) {
+			throw new ElasticsearchException("Error for creating index: " + request.toString(), e);
+		}
 	}
 
 	@Override
@@ -999,118 +1152,143 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 		return getSetting(getPersistentEntityFor(clazz).getIndexName());
 	}
 
-	@Override
+	@Override // TODO change interface to return Settings.
 	public Map getSetting(String indexName) {
 		Assert.notNull(indexName, "No index defined for getSettings");
-		Settings settings = client.admin().indices().getSettings(new GetSettingsRequest()).actionGet()
-				.getIndexToSettings().get(indexName);
-		return settings.keySet().stream().collect(Collectors.toMap((key)->key, (key)->settings.get(key)));
+		ObjectMapper objMapper = new ObjectMapper();
+		Map settings = null;
+		RestClient restClient = client.getLowLevelClient();
+		try {
+			Response response = restClient.performRequest("GET", "/" + indexName + "/_settings");
+			settings = convertSettingResponse(EntityUtils.toString(response.getEntity()), indexName);
+
+		} catch (Exception e) {
+			throw new ElasticsearchException("Error while getting settings for indexName : " + indexName, e);
+		}
+		return settings;
 	}
 
-	private <T> SearchRequestBuilder prepareSearch(Query query, Class<T> clazz) {
+	private Map<String, String> convertSettingResponse(String settingResponse, String indexName) {
+		ObjectMapper mapper = new ObjectMapper();
+
+		try {
+			Settings settings = Settings.fromXContent(XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY,
+					DeprecationHandler.THROW_UNSUPPORTED_OPERATION, settingResponse));
+			String prefix = indexName + ".settings.";
+			// Backwards compatibility. TODO Change to return Settings object.
+			Map<String, String> result = new HashMap<String, String>();
+			Set<String> keySet = settings.keySet();
+			for (String key : keySet) {
+				result.put(StringUtils.substringAfter(key, prefix), settings.get(key));
+			}
+			return result;
+		} catch (IOException e) {
+			throw new ElasticsearchException("Could not map alias response : " + settingResponse, e);
+		}
+
+	}
+
+	private <T> SearchRequest prepareSearch(Query query, Class<T> clazz) {
 		setPersistentEntityIndexAndType(query, clazz);
-		return prepareSearch(query);
+		return prepareSearch(query, Optional.empty());
 	}
 
-	private SearchRequestBuilder prepareSearch(Query query) {
+	private <T> SearchRequest prepareSearch(SearchQuery query, Class<T> clazz) {
+		setPersistentEntityIndexAndType(query, clazz);
+		return prepareSearch(query, Optional.ofNullable(query.getQuery()));
+	}
+
+	private SearchRequest prepareSearch(Query query, Optional<QueryBuilder> builder) {
 		Assert.notNull(query.getIndices(), "No index defined for Query");
 		Assert.notNull(query.getTypes(), "No type defined for Query");
 
 		int startRecord = 0;
-		SearchRequestBuilder searchRequestBuilder = client.prepareSearch(toArray(query.getIndices()))
-				.setSearchType(query.getSearchType())
-				.setTypes(toArray(query.getTypes()))
-				.setVersion(true)
-				.setTrackScores(query.getTrackScores());
+		SearchRequest request = new SearchRequest(toArray(query.getIndices()));
+		SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+		request.types(toArray(query.getTypes()));
+		sourceBuilder.version(true);
+		sourceBuilder.trackScores(query.getTrackScores());
+
+		if (builder.isPresent()) {
+			sourceBuilder.query(builder.get());
+		}
 
 		if (query.getSourceFilter() != null) {
 			SourceFilter sourceFilter = query.getSourceFilter();
-			searchRequestBuilder.setFetchSource(sourceFilter.getIncludes(), sourceFilter.getExcludes());
+			sourceBuilder.fetchSource(sourceFilter.getIncludes(), sourceFilter.getExcludes());
 		}
 
 		if (query.getPageable().isPaged()) {
 			startRecord = query.getPageable().getPageNumber() * query.getPageable().getPageSize();
-			searchRequestBuilder.setSize(query.getPageable().getPageSize());
+			sourceBuilder.size(query.getPageable().getPageSize());
 		}
-		searchRequestBuilder.setFrom(startRecord);
+		sourceBuilder.from(startRecord);
 
 		if (!query.getFields().isEmpty()) {
-			searchRequestBuilder.setFetchSource(toArray(query.getFields()), null);
+			sourceBuilder.fetchSource(toArray(query.getFields()), null);
 		}
 
 		if (query.getIndicesOptions() != null) {
-			searchRequestBuilder.setIndicesOptions(query.getIndicesOptions());
+			request.indicesOptions(query.getIndicesOptions());
 		}
 
 		if (query.getSort() != null) {
 			for (Sort.Order order : query.getSort()) {
-				SortOrder sortOrder = order.getDirection().isDescending() ? SortOrder.DESC : SortOrder.ASC;
-
-				if (FIELD_SCORE.equals(order.getProperty())) {
-					ScoreSortBuilder sort = SortBuilders //
-							.scoreSort() //
-							.order(sortOrder);
-
-					searchRequestBuilder.addSort(sort);
-				} else {
-					FieldSortBuilder sort = SortBuilders //
-							.fieldSort(order.getProperty()) //
-							.order(sortOrder);
-
-					if (order.getNullHandling() == Sort.NullHandling.NULLS_FIRST) {
-						sort.missing("_first");
-					} else if (order.getNullHandling() == Sort.NullHandling.NULLS_LAST) {
-						sort.missing("_last");
-					}
-
-					searchRequestBuilder.addSort(sort);
+				FieldSortBuilder sort = SortBuilders.fieldSort(order.getProperty())
+						.order(order.getDirection().isDescending() ? SortOrder.DESC : SortOrder.ASC);
+				if (order.getNullHandling() == Sort.NullHandling.NULLS_FIRST) {
+					sort.missing("_first");
+				} else if (order.getNullHandling() == Sort.NullHandling.NULLS_LAST) {
+					sort.missing("_last");
 				}
+				sourceBuilder.sort(sort);
 			}
 		}
 
 		if (query.getMinScore() > 0) {
-			searchRequestBuilder.setMinScore(query.getMinScore());
+			sourceBuilder.minScore(query.getMinScore());
 		}
-		return searchRequestBuilder;
+		request.source(sourceBuilder);
+		return request;
 	}
 
-	private IndexRequestBuilder prepareIndex(IndexQuery query) {
+	private IndexRequest prepareIndex(IndexQuery query) {
 		try {
-			String indexName = StringUtils.isEmpty(query.getIndexName())
+			String indexName = isBlank(query.getIndexName())
 					? retrieveIndexNameFromPersistentEntity(query.getObject().getClass())[0]
 					: query.getIndexName();
-			String type = StringUtils.isEmpty(query.getType()) ? retrieveTypeFromPersistentEntity(query.getObject().getClass())[0]
+			String type = isBlank(query.getType()) ? retrieveTypeFromPersistentEntity(query.getObject().getClass())[0]
 					: query.getType();
 
-			IndexRequestBuilder indexRequestBuilder = null;
+			IndexRequest indexRequest = null;
 
 			if (query.getObject() != null) {
-				String id = StringUtils.isEmpty(query.getId()) ? getPersistentEntityId(query.getObject()) : query.getId();
+				String id = isBlank(query.getId()) ? getPersistentEntityId(query.getObject()) : query.getId();
 				// If we have a query id and a document id, do not ask ES to generate one.
 				if (id != null) {
-					indexRequestBuilder = client.prepareIndex(indexName, type, id);
+					indexRequest = new IndexRequest(indexName, type, id);
 				} else {
-					indexRequestBuilder = client.prepareIndex(indexName, type);
+					indexRequest = new IndexRequest(indexName, type);
 				}
-				indexRequestBuilder.setSource(resultsMapper.getEntityMapper().mapToString(query.getObject()),
+				indexRequest.source(resultsMapper.getEntityMapper().mapToString(query.getObject()),
 						Requests.INDEX_CONTENT_TYPE);
 			} else if (query.getSource() != null) {
-				indexRequestBuilder = client.prepareIndex(indexName, type, query.getId()).setSource(query.getSource(),
+				indexRequest = new IndexRequest(indexName, type, query.getId()).source(query.getSource(),
 						Requests.INDEX_CONTENT_TYPE);
 			} else {
 				throw new ElasticsearchException(
 						"object or source is null, failed to index the document [id: " + query.getId() + "]");
 			}
 			if (query.getVersion() != null) {
-				indexRequestBuilder.setVersion(query.getVersion());
-				indexRequestBuilder.setVersionType(EXTERNAL);
+				indexRequest.version(query.getVersion());
+				indexRequest.versionType(EXTERNAL);
 			}
 
 			if (query.getParentId() != null) {
-				indexRequestBuilder.setParent(query.getParentId());
+				indexRequest.parent(query.getParentId());
 			}
 
-			return indexRequestBuilder;
+			return indexRequest;
 		} catch (IOException e) {
 			throw new ElasticsearchException("failed to index the document [id: " + query.getId() + "]", e);
 		}
@@ -1119,7 +1297,12 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 	@Override
 	public void refresh(String indexName) {
 		Assert.notNull(indexName, "No index defined for refresh()");
-		client.admin().indices().refresh(refreshRequest(indexName)).actionGet();
+		try {
+			// TODO: Do something with the response.
+			client.indices().refresh(refreshRequest(indexName));
+		} catch (IOException e) {
+			throw new ElasticsearchException("failed to refresh index: " + indexName, e);
+		}
 	}
 
 	@Override
@@ -1138,28 +1321,87 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 			aliasAction.filter(query.getFilterBuilder());
 		} else if (query.getFilter() != null) {
 			aliasAction.filter(query.getFilter());
-		} else if (!StringUtils.isEmpty(query.getRouting())) {
+		} else if (isNotBlank(query.getRouting())) {
 			aliasAction.routing(query.getRouting());
-		} else if (!StringUtils.isEmpty(query.getSearchRouting())) {
+		} else if (isNotBlank(query.getSearchRouting())) {
 			aliasAction.searchRouting(query.getSearchRouting());
-		} else if (!StringUtils.isEmpty(query.getIndexRouting())) {
+		} else if (isNotBlank(query.getIndexRouting())) {
 			aliasAction.indexRouting(query.getIndexRouting());
 		}
-		return client.admin().indices().prepareAliases().addAliasAction(aliasAction).execute().actionGet().isAcknowledged();
+
+		IndicesAliasesRequest request = new IndicesAliasesRequest();
+		request.addAliasAction(aliasAction);
+		try {
+			return client.indices().updateAliases(request).isAcknowledged();
+		} catch (IOException e) {
+			throw new ElasticsearchException("failed to update aliases with request: " + request, e);
+		}
 	}
 
 	@Override
 	public Boolean removeAlias(AliasQuery query) {
 		Assert.notNull(query.getIndexName(), "No index defined for Alias");
 		Assert.notNull(query.getAliasName(), "No alias defined");
-		return client.admin().indices().prepareAliases().removeAlias(query.getIndexName(), query.getAliasName()).execute()
-				.actionGet().isAcknowledged();
+		IndicesAliasesRequest request = new IndicesAliasesRequest();
+		AliasActions aliasAction = new AliasActions(AliasActions.Type.REMOVE);
+		request.addAliasAction(aliasAction);
+		try {
+			return client.indices().updateAliases(request).isAcknowledged();
+		} catch (IOException e) {
+			throw new ElasticsearchException("failed to update aliases with request: " + request, e);
+		}
 	}
 
 	@Override
 	public List<AliasMetaData> queryForAlias(String indexName) {
-		return client.admin().indices().getAliases(new GetAliasesRequest().indices(indexName)).actionGet().getAliases()
-				.get(indexName);
+		List<AliasMetaData> aliases = null;
+		RestClient restClient = client.getLowLevelClient();
+		Response response;
+		String aliasResponse;
+
+		try {
+			response = restClient.performRequest("GET", "/" + indexName + "/_alias/*");
+			aliasResponse = EntityUtils.toString(response.getEntity());
+		} catch (Exception e) {
+			throw new ElasticsearchException("Error while getting mapping for indexName : " + indexName, e);
+		}
+
+		return convertAliasResponse(aliasResponse);
+	}
+
+	/**
+	 * It takes two steps to create a List<AliasMetadata> from the elasticsearch http response because the aliases field
+	 * is actually a Map by alias name, but the alias name is on the AliasMetadata.
+	 * 
+	 * @param aliasResponse
+	 * @return
+	 */
+	List<AliasMetaData> convertAliasResponse(String aliasResponse) {
+		ObjectMapper mapper = new ObjectMapper();
+
+		try {
+			JsonNode node = mapper.readTree(aliasResponse);
+
+			Iterator<String> names = node.fieldNames();
+			String name = names.next();
+			node = node.findValue("aliases");
+
+			Map<String, AliasData> aliasData = mapper.readValue(mapper.writeValueAsString(node),
+					new TypeReference<Map<String, AliasData>>() {});
+
+			Iterable<Map.Entry<String, AliasData>> aliasIter = aliasData.entrySet();
+			List<AliasMetaData> aliasMetaDataList = new ArrayList<AliasMetaData>();
+
+			for (Map.Entry<String, AliasData> aliasentry : aliasIter) {
+				AliasData data = aliasentry.getValue();
+				aliasMetaDataList.add(AliasMetaData.newAliasMetaDataBuilder(aliasentry.getKey()).filter(data.getFilter())
+						.routing(data.getRouting()).searchRouting(data.getSearch_routing()).indexRouting(data.getIndex_routing())
+						.build());
+			}
+			return aliasMetaDataList;
+		} catch (IOException e) {
+			throw new ElasticsearchException("Could not map alias response : " + aliasResponse, e);
+		}
 	}
 
 	@Override
@@ -1262,14 +1504,14 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 				stringBuilder.append(line).append(lineSeparator);
 			}
 		} catch (Exception e) {
-			LOGGER.debug(String.format("Failed to load file from url: %s: %s", url, e.getMessage()));
+			logger.debug(String.format("Failed to load file from url: %s: %s", url, e.getMessage()));
 			return null;
 		} finally {
 			if (bufferedReader != null)
 				try {
 					bufferedReader.close();
 				} catch (IOException e) {
-					LOGGER.debug(String.format("Unable to close buffered reader.. %s", e.getMessage()));
+					logger.debug(String.format("Unable to close buffered reader.. %s", e.getMessage()));
 				}
 		}
 
@@ -1277,7 +1519,16 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 	}
 
 	public SearchResponse suggest(SuggestBuilder suggestion, String... indices) {
-		return client.prepareSearch(indices).suggest(suggestion).get();
+		SearchRequest searchRequest = new SearchRequest(indices);
+		SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+		sourceBuilder.suggest(suggestion);
+		searchRequest.source(sourceBuilder);
+
+		try {
+			return client.search(searchRequest);
+		} catch (IOException e) {
+			throw new ElasticsearchException("Could not execute search request : " + searchRequest.toString(), e);
+		}
 	}
 
 	public SearchResponse suggest(SuggestBuilder suggestion, Class clazz) {

--- a/src/main/java/org/springframework/data/elasticsearch/core/EsClient.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/EsClient.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core;
+
+/**
+ * EsClient interface. Specify what client an ElasticSearchTemplate will return from getClient().
+ * 
+ * @author Don Wellington
+ * @param <C>
+ */
+public interface EsClient<C> {
+	C getClient();
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/client/support/AliasData.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/client/support/AliasData.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core.client.support;
+
+import lombok.Data;
+import lombok.Getter;
+
+import org.elasticsearch.cluster.metadata.AliasMetaData;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown=true)
+@Data
+public class AliasData {
+	String filter = null;
+	String routing = null;
+	String search_routing = null;
+	String index_routing= null;
+}

--- a/src/main/resources/META-INF/spring.schemas
+++ b/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/data/elasticsearch/spring-elasticsearch-1.0.xsd=org/springframework/data/elasticsearch/config/spring-elasticsearch-1.0.xsd
+http\://www.springframework.org/schema/data/elasticsearch/spring-elasticsearch-1.1.xsd=org/springframework/data/elasticsearch/config/spring-elasticsearch-1.1.xsd
 http\://www.springframework.org/schema/data/elasticsearch/spring-elasticsearch.xsd=org/springframework/data/elasticsearch/config/spring-elasticsearch-1.0.xsd
+http\://www.springframework.org/schema/data/elasticsearch/spring-elasticsearch.xsd=org/springframework/data/elasticsearch/config/spring-elasticsearch-1.1.xsd

--- a/src/main/resources/org/springframework/data/elasticsearch/config/spring-elasticsearch-1.1.xsd
+++ b/src/main/resources/org/springframework/data/elasticsearch/config/spring-elasticsearch-1.1.xsd
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsd:schema xmlns="http://www.springframework.org/schema/data/elasticsearch"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:beans="http://www.springframework.org/schema/beans"
+            xmlns:tool="http://www.springframework.org/schema/tool"
+            xmlns:repository="http://www.springframework.org/schema/data/repository"
+            targetNamespace="http://www.springframework.org/schema/data/elasticsearch"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified">
+
+    <xsd:import namespace="http://www.springframework.org/schema/beans"/>
+    <xsd:import namespace="http://www.springframework.org/schema/tool"/>
+    <xsd:import namespace="http://www.springframework.org/schema/data/repository"
+                schemaLocation="http://www.springframework.org/schema/data/repository/spring-repository.xsd"/>
+
+    <xsd:element name="repositories">
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="repository:repositories">
+                    <xsd:attributeGroup ref="repository:repository-attributes"/>
+                    <xsd:attribute name="elasticsearch-template-ref" type="elasticsearchTemplateRef"
+                                   default="elasticsearchTemplate"/>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+
+    <xsd:simpleType name="elasticsearchTemplateRef">
+        <xsd:annotation>
+            <xsd:appinfo>
+                <tool:annotation kind="ref">
+                    <tool:assignable-to type="org.springframework.data.elasticsearch.core.ElasticsearchTemplate"/>
+                </tool:annotation>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:union memberTypes="xsd:string"/>
+    </xsd:simpleType>
+
+    <xsd:element name="node-client">
+        <xsd:annotation>
+            <xsd:documentation/>
+            <xsd:appinfo>
+                <tool:assignable-to type="org.elasticsearch.client.Client"/>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="beans:identifiedType">
+                    <xsd:attribute name="local" type="xsd:boolean" default="false">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                                <![CDATA[local here means local on the JVM (well, actually class loader) level, meaning that two local servers started within the same JVM will discover themselves and form a cluster]]>
+                            </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:attribute>
+                    <xsd:attribute name="cluster-name" type="xsd:string" default="elasticsearch">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                                <![CDATA[Name of the cluster in which this instance of node client will connect to]]>
+                            </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:attribute>
+                    <xsd:attribute name="http-enabled" type="xsd:boolean" default="true">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                                <![CDATA[ to enable or disable http port ]]>
+                            </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:attribute>
+                    <xsd:attribute name="path-data" type="xsd:string" default="">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                                <![CDATA[ path to the data folder for node client ]]>
+                            </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:attribute>
+                    <xsd:attribute name="path-home" type="xsd:string" default="">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                                <![CDATA[ path to the home folder for node client ]]>
+                            </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:attribute>
+                    <xsd:attribute name="path-configuration" type="xsd:string" default="">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                                <![CDATA[ path to configuration file for node client ]]>
+                            </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:attribute>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="transport-client">
+        <xsd:annotation>
+            <xsd:documentation/>
+            <xsd:appinfo>
+                <tool:assignable-to type="org.elasticsearch.client.Client"/>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="beans:identifiedType">
+                    <xsd:attribute name="cluster-nodes" type="xsd:string" default="127.0.0.1:9300">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                                <![CDATA[The comma delimited list of host:port entries to use for elasticsearch cluster.]]>
+                            </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:attribute>
+                    <xsd:attribute name="cluster-name" type="xsd:string" default="elasticsearch">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                                <![CDATA[Name of the cluster in which this instance of node client will connect to]]>
+                            </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:attribute>
+                    <xsd:attribute name="client-transport-sniff" type="xsd:boolean" default="true">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                                <![CDATA[The client allows to sniff the rest of the cluster, and add those into its list of machines to use.]]>
+                            </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:attribute>
+                    <xsd:attribute name="client-transport-ignore-cluster-name" type="xsd:boolean" default="false">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                                <![CDATA[Set to true to ignore cluster name validation of connected nodes. (since 0.19.4)]]>
+                            </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:attribute>
+                    <xsd:attribute name="client-transport-ping-timeout" type="xsd:string" default="5s">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                                <![CDATA[The time to wait for a ping response from a node. Defaults to 5s.]]>
+                            </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:attribute>
+                    <xsd:attribute name="client-transport-nodes-sampler-interval" type="xsd:string" default="5s">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                                <![CDATA[How often to sample / ping the nodes listed and connected. Defaults to 5s.]]>
+                            </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:attribute>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="rest-client">
+    	 <xsd:annotation>
+            <xsd:documentation/>
+            <xsd:appinfo>
+                <tool:assignable-to type="org.elasticsearch.client.RestHighLevelClient"/>
+            </xsd:appinfo>
+        </xsd:annotation>
+       	<xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="beans:identifiedType">
+                    <xsd:attribute name="hosts" type="xsd:string" default="http://127.0.0.1:9200">
+                        <xsd:annotation>
+                            <xsd:documentation>
+                                <![CDATA[The comma delimited list of host:port entries to use for elasticsearch cluster.]]>
+                            </xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:attribute>
+               	</xsd:extension>
+			</xsd:complexContent>
+		</xsd:complexType>
+    </xsd:element>
+</xsd:schema>

--- a/src/test/java/org/springframework/data/elasticsearch/config/ElasticsearchNamespaceHandlerTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/config/ElasticsearchNamespaceHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.data.elasticsearch.client.RestClientFactoryBean;
 import org.springframework.data.elasticsearch.client.TransportClientFactoryBean;
 import org.springframework.data.elasticsearch.repositories.sample.SampleElasticsearchRepository;
 import org.springframework.test.context.ContextConfiguration;
@@ -31,6 +32,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Rizwan Idrees
  * @author Mohsin Husen
+ * @author Don Wellington
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -51,5 +53,11 @@ public class ElasticsearchNamespaceHandlerTests {
 		assertThat(context.getBean(TransportClientFactoryBean.class), is(notNullValue()));
 		assertThat(context.getBean(SampleElasticsearchRepository.class),
 				is(instanceOf(SampleElasticsearchRepository.class)));
+	}
+	
+	@Test
+	public void shouldCreateRestClient() {
+		assertThat(context.getBean(RestClientFactoryBean.class), is(notNullValue()));
+		assertThat(context.getBean(RestClientFactoryBean.class), is(instanceOf(RestClientFactoryBean.class)));
 	}
 }

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplateTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplateTests.java
@@ -1,0 +1,2085 @@
+/*
+ * Copyright 2014-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpHost;
+import org.elasticsearch.action.get.MultiGetItemResponse;
+import org.elasticsearch.action.get.MultiGetResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.index.engine.DocumentMissingException;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptType;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
+import org.elasticsearch.search.fetch.subphase.highlight.HighlightField;
+import org.elasticsearch.search.sort.FieldSortBuilder;
+import org.elasticsearch.search.sort.SortBuilders;
+import org.elasticsearch.search.sort.SortOrder;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.elasticsearch.ElasticsearchException;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.core.aggregation.AggregatedPage;
+import org.springframework.data.elasticsearch.core.aggregation.impl.AggregatedPageImpl;
+import org.springframework.data.elasticsearch.core.query.*;
+import org.springframework.data.elasticsearch.entities.HetroEntity1;
+import org.springframework.data.elasticsearch.entities.HetroEntity2;
+import org.springframework.data.elasticsearch.entities.SampleEntity;
+import org.springframework.data.elasticsearch.entities.SampleMappingEntity;
+import org.springframework.data.elasticsearch.entities.UseServerConfigurationEntity;
+import org.springframework.data.util.CloseableIterator;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import static org.apache.commons.lang.RandomStringUtils.*;
+import static org.elasticsearch.index.query.QueryBuilders.*;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.springframework.data.elasticsearch.utils.IndexBuilder.*;
+
+/**
+ * @author Rizwan Idrees
+ * @author Mohsin Husen
+ * @author Franck Marchand
+ * @author Abdul Mohammed
+ * @author Kevin Leturc
+ * @author Mason Chan
+ * @author Chris White
+ * @author Ilkang Na
+ * @author Alen Turkovic
+ * @author Sascha Woo
+ * @author Don Wellington
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("classpath:elasticsearch-rest-template-test.xml")
+public class ElasticsearchRestTemplateTests {
+
+	private static final String INDEX_NAME = "test-index-sample";
+	private static final String INDEX_1_NAME = "test-index-1";
+	private static final String INDEX_2_NAME = "test-index-2";
+	private static final String TYPE_NAME = "test-type";
+
+	@Autowired 
+	private ElasticsearchRestTemplate elasticsearchTemplate;
+
+	@Before
+	public void before() {
+		elasticsearchTemplate.deleteIndex(SampleEntity.class);
+		elasticsearchTemplate.createIndex(SampleEntity.class);
+		elasticsearchTemplate.putMapping(SampleEntity.class);
+		elasticsearchTemplate.deleteIndex(INDEX_1_NAME);
+		elasticsearchTemplate.deleteIndex(INDEX_2_NAME);
+		elasticsearchTemplate.deleteIndex(UseServerConfigurationEntity.class);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldReturnCountForGivenCriteriaQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
+		// when
+		long count = elasticsearchTemplate.count(criteriaQuery, SampleEntity.class);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	@Test
+	public void shouldReturnCountForGivenSearchQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
+		// when
+		long count = elasticsearchTemplate.count(searchQuery, SampleEntity.class);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	@Test
+	public void shouldReturnObjectForGivenId() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+		elasticsearchTemplate.index(indexQuery);
+		// when
+		GetQuery getQuery = new GetQuery();
+		getQuery.setId(documentId);
+		SampleEntity sampleEntity1 = elasticsearchTemplate.queryForObject(getQuery, SampleEntity.class);
+		// then
+		assertNotNull("entity can't be null....", sampleEntity1);
+		assertEquals(sampleEntity, sampleEntity1);
+	}
+
+	@Test
+	public void shouldReturnObjectsForGivenIdsUsingMultiGet() {
+		// given
+		List<IndexQuery> indexQueries = new ArrayList<>();
+		// first document
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		// second document
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		indexQueries = getIndexQueries(Arrays.asList(sampleEntity1, sampleEntity2));
+
+		elasticsearchTemplate.bulkIndex(indexQueries);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		// when
+		SearchQuery query = new NativeSearchQueryBuilder().withIds(Arrays.asList(documentId, documentId2)).build();
+		LinkedList<SampleEntity> sampleEntities = elasticsearchTemplate.multiGet(query, SampleEntity.class);
+		// then
+		assertThat(sampleEntities.size(), is(equalTo(2)));
+		assertEquals(sampleEntities.get(0), sampleEntity1);
+		assertEquals(sampleEntities.get(1), sampleEntity2);
+	}
+
+	@Test
+	public void shouldReturnObjectsForGivenIdsUsingMultiGetWithFields() {
+		// given
+		List<IndexQuery> indexQueries = new ArrayList<>();
+		// first document
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId).message("some message").type("type1")
+				.version(System.currentTimeMillis()).build();
+
+		// second document
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2).message("some message").type("type2")
+				.version(System.currentTimeMillis()).build();
+
+		indexQueries = getIndexQueries(Arrays.asList(sampleEntity1, sampleEntity2));
+
+		elasticsearchTemplate.bulkIndex(indexQueries);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		// when
+		SearchQuery query = new NativeSearchQueryBuilder().withIds(Arrays.asList(documentId, documentId2))
+				.withFields("message", "type").build();
+		LinkedList<SampleEntity> sampleEntities = elasticsearchTemplate.multiGet(query, SampleEntity.class,
+				new MultiGetResultMapper() {
+					@Override
+					public <T> LinkedList<T> mapResults(MultiGetResponse responses, Class<T> clazz) {
+						LinkedList<T> list = new LinkedList<>();
+						for (MultiGetItemResponse response : responses.getResponses()) {
+							SampleEntity entity = new SampleEntity();
+							entity.setId(response.getResponse().getId());
+							entity.setMessage((String) response.getResponse().getSource().get("message"));
+							entity.setType((String) response.getResponse().getSource().get("type"));
+							list.add((T) entity);
+						}
+						return list;
+					}
+				});
+		// then
+		assertThat(sampleEntities.size(), is(equalTo(2)));
+	}
+
+	@Test
+	public void shouldReturnPageForGivenSearchQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
+		// when
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		// then
+		assertThat(sampleEntities, is(notNullValue()));
+		assertThat(sampleEntities.getTotalElements(), greaterThanOrEqualTo(1L));
+	}
+
+	// DATAES-422 - Add support for IndicesOptions in search queries
+	@Test
+	public void shouldPassIndicesOptionsForGivenSearchQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery idxQuery = new IndexQueryBuilder().withIndexName(INDEX_1_NAME).withId(sampleEntity.getId())
+				.withObject(sampleEntity).build();
+
+		elasticsearchTemplate.index(idxQuery);
+		elasticsearchTemplate.refresh(INDEX_1_NAME);
+
+		// when
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
+				.withIndices(INDEX_1_NAME, INDEX_2_NAME).withIndicesOptions(IndicesOptions.lenientExpandOpen()).build();
+		Page<SampleEntity> entities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		// then
+		assertThat(entities, is(notNullValue()));
+		assertThat(entities.getTotalElements(), greaterThanOrEqualTo(1L));
+	}
+
+	@Test
+	public void shouldDoBulkIndex() {
+		// given
+		List<IndexQuery> indexQueries = new ArrayList<>();
+		// first document
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		// second document
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		indexQueries = getIndexQueries(Arrays.asList(sampleEntity1, sampleEntity2));
+
+		// when
+		elasticsearchTemplate.bulkIndex(indexQueries);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		assertThat(sampleEntities.getTotalElements(), is(equalTo(2L)));
+	}
+
+	@Test
+	public void shouldDoBulkUpdate() {
+		// given
+		String documentId = randomNumeric(5);
+		String messageBeforeUpdate = "some test message";
+		String messageAfterUpdate = "test message";
+
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message(messageBeforeUpdate)
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		IndexRequest indexRequest = new IndexRequest();
+		indexRequest.source("message", messageAfterUpdate);
+		UpdateQuery updateQuery = new UpdateQueryBuilder().withId(documentId).withClass(SampleEntity.class)
+				.withIndexRequest(indexRequest).build();
+
+		List<UpdateQuery> queries = new ArrayList<>();
+		queries.add(updateQuery);
+
+		// when
+		elasticsearchTemplate.bulkUpdate(queries);
+		// then
+		GetQuery getQuery = new GetQuery();
+		getQuery.setId(documentId);
+		SampleEntity indexedEntity = elasticsearchTemplate.queryForObject(getQuery, SampleEntity.class);
+		assertThat(indexedEntity.getMessage(), is(messageAfterUpdate));
+	}
+
+	@Test
+	public void shouldDeleteDocumentForGivenId() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		// when
+		elasticsearchTemplate.delete(INDEX_NAME, TYPE_NAME, documentId);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("id", documentId)).build();
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		assertThat(sampleEntities.getTotalElements(), equalTo(0L));
+	}
+
+	@Test
+	public void shouldDeleteEntityForGivenId() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		// when
+		elasticsearchTemplate.delete(SampleEntity.class, documentId);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("id", documentId)).build();
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		assertThat(sampleEntities.getTotalElements(), equalTo(0L));
+	}
+
+	@Test
+	public void shouldDeleteDocumentForGivenQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		// when
+		DeleteQuery deleteQuery = new DeleteQuery();
+		deleteQuery.setQuery(termQuery("id", documentId));
+		elasticsearchTemplate.delete(deleteQuery, SampleEntity.class);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("id", documentId)).build();
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		assertThat(sampleEntities.getTotalElements(), equalTo(0L));
+	}
+
+	@Test
+	public void shouldFilterSearchResultsForGivenFilter() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
+				.withFilter(boolQuery().filter(termQuery("id", documentId))).build();
+		// when
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		// then
+		assertThat(sampleEntities.getTotalElements(), equalTo(1L));
+	}
+
+	@Test
+	public void shouldSortResultsGivenSortCriteria() {
+		// given
+		List<IndexQuery> indexQueries = new ArrayList<>();
+		// first document
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId).message("abc").rate(10)
+				.version(System.currentTimeMillis()).build();
+
+		// second document
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2).message("xyz").rate(5)
+				.version(System.currentTimeMillis()).build();
+
+		// third document
+		String documentId3 = randomNumeric(5);
+		SampleEntity sampleEntity3 = SampleEntity.builder().id(documentId3).message("xyz").rate(15)
+				.version(System.currentTimeMillis()).build();
+
+		indexQueries = getIndexQueries(Arrays.asList(sampleEntity1, sampleEntity2, sampleEntity3));
+
+		elasticsearchTemplate.bulkIndex(indexQueries);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
+				.withSort(new FieldSortBuilder("rate").order(SortOrder.ASC)).build();
+		// when
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		// then
+		assertThat(sampleEntities.getTotalElements(), equalTo(3L));
+		assertThat(sampleEntities.getContent().get(0).getRate(), is(sampleEntity2.getRate()));
+	}
+
+	@Test
+	public void shouldSortResultsGivenMultipleSortCriteria() {
+		// given
+		List<IndexQuery> indexQueries = new ArrayList<>();
+		// first document
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId).message("abc").rate(10)
+				.version(System.currentTimeMillis()).build();
+
+		// second document
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2).message("xyz").rate(5)
+				.version(System.currentTimeMillis()).build();
+
+		// third document
+		String documentId3 = randomNumeric(5);
+		SampleEntity sampleEntity3 = SampleEntity.builder().id(documentId3).message("xyz").rate(15)
+				.version(System.currentTimeMillis()).build();
+
+		indexQueries = getIndexQueries(Arrays.asList(sampleEntity1, sampleEntity2, sampleEntity3));
+
+		elasticsearchTemplate.bulkIndex(indexQueries);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
+				.withSort(new FieldSortBuilder("rate").order(SortOrder.ASC))
+				.withSort(new FieldSortBuilder("message").order(SortOrder.ASC)).build();
+		// when
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		// then
+		assertThat(sampleEntities.getTotalElements(), equalTo(3L));
+		assertThat(sampleEntities.getContent().get(0).getRate(), is(sampleEntity2.getRate()));
+		assertThat(sampleEntities.getContent().get(1).getMessage(), is(sampleEntity1.getMessage()));
+	}
+
+	@Test // DATAES-312
+	public void shouldSortResultsGivenNullFirstSortCriteria() {
+		// given
+		List<IndexQuery> indexQueries;
+
+		// first document
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId).message("abc").rate(15)
+				.version(System.currentTimeMillis()).build();
+
+		// second document
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2).message("xyz").rate(5)
+				.version(System.currentTimeMillis()).build();
+
+		// third document
+		String documentId3 = randomNumeric(5);
+		SampleEntity sampleEntity3 = SampleEntity.builder().id(documentId3).rate(10).version(System.currentTimeMillis())
+				.build();
+
+		indexQueries = getIndexQueries(Arrays.asList(sampleEntity1, sampleEntity2, sampleEntity3));
+
+		elasticsearchTemplate.bulkIndex(indexQueries);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
+				.withPageable(PageRequest.of(0, 10, Sort.by(Sort.Order.asc("message").nullsFirst()))).build();
+
+		// when
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+
+		// then
+		assertThat(sampleEntities.getTotalElements(), equalTo(3L));
+		assertThat(sampleEntities.getContent().get(0).getRate(), is(sampleEntity3.getRate()));
+		assertThat(sampleEntities.getContent().get(1).getMessage(), is(sampleEntity1.getMessage()));
+	}
+
+	@Test // DATAES-312
+	public void shouldSortResultsGivenNullLastSortCriteria() {
+		// given
+		List<IndexQuery> indexQueries;
+
+		// first document
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId).message("abc").rate(15)
+				.version(System.currentTimeMillis()).build();
+
+		// second document
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2).message("xyz").rate(5)
+				.version(System.currentTimeMillis()).build();
+
+		// third document
+		String documentId3 = randomNumeric(5);
+		SampleEntity sampleEntity3 = SampleEntity.builder().id(documentId3).rate(10).version(System.currentTimeMillis())
+				.build();
+
+		indexQueries = getIndexQueries(Arrays.asList(sampleEntity1, sampleEntity2, sampleEntity3));
+
+		elasticsearchTemplate.bulkIndex(indexQueries);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
+				.withPageable(PageRequest.of(0, 10, Sort.by(Sort.Order.asc("message").nullsLast()))).build();
+
+		// when
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+
+		// then
+		assertThat(sampleEntities.getTotalElements(), equalTo(3L));
+		assertThat(sampleEntities.getContent().get(0).getRate(), is(sampleEntity1.getRate()));
+		assertThat(sampleEntities.getContent().get(1).getMessage(), is(sampleEntity2.getMessage()));
+	}
+
+	@Test
+	public void shouldExecuteStringQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		StringQuery stringQuery = new StringQuery(matchAllQuery().toString());
+		// when
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(stringQuery, SampleEntity.class);
+		// then
+		assertThat(sampleEntities.getTotalElements(), equalTo(1L));
+	}
+
+	@Test
+	public void shouldUseScriptedFields() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setRate(2);
+		sampleEntity.setMessage("some message");
+		sampleEntity.setVersion(System.currentTimeMillis());
+
+		IndexQuery indexQuery = new IndexQuery();
+		indexQuery.setId(documentId);
+		indexQuery.setObject(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		Map<String, Object> params = new HashMap<>();
+		params.put("factor", 2);
+		// when
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).withScriptField(
+				new ScriptField("scriptedRate", new Script(ScriptType.INLINE, "expression", "doc['rate'] * factor", params)))
+				.build();
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		// then
+		assertThat(sampleEntities.getTotalElements(), equalTo(1L));
+		assertThat(sampleEntities.getContent().get(0).getScriptedRate(), equalTo(4.0));
+	}
+
+	@Test
+	public void shouldReturnPageableResultsGivenStringQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		StringQuery stringQuery = new StringQuery(matchAllQuery().toString(), new PageRequest(0, 10));
+		// when
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(stringQuery, SampleEntity.class);
+
+		// then
+		assertThat(sampleEntities.getTotalElements(), is(greaterThanOrEqualTo(1L)));
+	}
+
+	@Test
+	public void shouldReturnSortedPageableResultsGivenStringQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setMessage("some message");
+		sampleEntity.setVersion(System.currentTimeMillis());
+
+		IndexQuery indexQuery = new IndexQuery();
+		indexQuery.setId(documentId);
+		indexQuery.setObject(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		StringQuery stringQuery = new StringQuery(matchAllQuery().toString(), new PageRequest(0, 10),
+				new Sort(new Sort.Order(Sort.Direction.ASC, "message")));
+		// when
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(stringQuery, SampleEntity.class);
+		// then
+		assertThat(sampleEntities.getTotalElements(), is(greaterThanOrEqualTo(1L)));
+	}
+
+	@Test
+	public void shouldReturnObjectMatchingGivenStringQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		StringQuery stringQuery = new StringQuery(termQuery("id", documentId).toString());
+		// when
+		SampleEntity sampleEntity1 = elasticsearchTemplate.queryForObject(stringQuery, SampleEntity.class);
+		// then
+		assertThat(sampleEntity1, is(notNullValue()));
+		assertThat(sampleEntity1.getId(), is(equalTo(documentId)));
+	}
+
+	@Test
+	public void shouldCreateIndexGivenEntityClass() {
+		// when
+		boolean created = elasticsearchTemplate.createIndex(SampleEntity.class);
+		elasticsearchTemplate.putMapping(SampleEntity.class);
+		final Map setting = elasticsearchTemplate.getSetting(SampleEntity.class);
+		// then
+		assertThat(created, is(true));
+		assertThat(setting.get("index.number_of_shards"), Matchers.<Object> is("1"));
+		assertThat(setting.get("index.number_of_replicas"), Matchers.<Object> is("0"));
+	}
+
+	@Test
+	public void shouldExecuteGivenCriteriaQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("test message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("message").contains("test"));
+
+		// when
+		SampleEntity sampleEntity1 = elasticsearchTemplate.queryForObject(criteriaQuery, SampleEntity.class);
+		// then
+		assertThat(sampleEntity1, is(notNullValue()));
+	}
+
+	@Test
+	public void shouldDeleteGivenCriteriaQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("test message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("message").contains("test"));
+
+		// when
+		elasticsearchTemplate.delete(criteriaQuery, SampleEntity.class);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+		StringQuery stringQuery = new StringQuery(matchAllQuery().toString());
+		List<SampleEntity> sampleEntities = elasticsearchTemplate.queryForList(stringQuery, SampleEntity.class);
+
+		assertThat(sampleEntities.size(), is(0));
+	}
+
+	@Test
+	public void shouldReturnSpecifiedFields() {
+		// given
+		String documentId = randomNumeric(5);
+		String message = "some test message";
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message(message)
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).withIndices(INDEX_NAME)
+				.withTypes(TYPE_NAME).withFields("message").build();
+		// when
+		Page<String> page = elasticsearchTemplate.queryForPage(searchQuery, String.class, new SearchResultMapper() {
+			@Override
+			public <T> AggregatedPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
+				List<String> values = new ArrayList<>();
+				for (SearchHit searchHit : response.getHits()) {
+					values.add((String) searchHit.getSourceAsMap().get("message"));
+				}
+				return new AggregatedPageImpl<>((List<T>) values);
+			}
+		});
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(equalTo(1L)));
+		assertThat(page.getContent().get(0), is(message));
+	}
+
+	@Test
+	public void shouldReturnFieldsBasedOnSourceFilter() {
+		// given
+		String documentId = randomNumeric(5);
+		String message = "some test message";
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message(message)
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		FetchSourceFilterBuilder sourceFilter = new FetchSourceFilterBuilder();
+		sourceFilter.withIncludes("message");
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).withIndices(INDEX_NAME)
+				.withTypes(TYPE_NAME).withSourceFilter(sourceFilter.build()).build();
+		// when
+		Page<SampleEntity> page = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(equalTo(1L)));
+		assertThat(page.getContent().get(0).getMessage(), is(message));
+	}
+
+	@Test
+	public void shouldReturnSimilarResultsGivenMoreLikeThisQuery() {
+		// given
+		String sampleMessage = "So we build a web site or an application and want to add search to it, "
+				+ "and then it hits us: getting search working is hard. We want our search solution to be fast,"
+				+ " we want a painless setup and a completely free search schema, we want to be able to index data simply using JSON over HTTP, "
+				+ "we want our search server to be always available, we want to be able to start with one machine and scale to hundreds, "
+				+ "we want real-time search, we want simple multi-tenancy, and we want a solution that is built for the cloud.";
+
+		String documentId1 = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId1).message(sampleMessage)
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+
+		String documentId2 = randomNumeric(5);
+
+		elasticsearchTemplate.index(getIndexQuery(
+				SampleEntity.builder().id(documentId2).message(sampleMessage).version(System.currentTimeMillis()).build()));
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		MoreLikeThisQuery moreLikeThisQuery = new MoreLikeThisQuery();
+		moreLikeThisQuery.setId(documentId2);
+		moreLikeThisQuery.addFields("message");
+		moreLikeThisQuery.setMinDocFreq(1);
+		// when
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.moreLikeThis(moreLikeThisQuery, SampleEntity.class);
+
+		// then
+		assertThat(sampleEntities.getTotalElements(), is(equalTo(1L)));
+		assertThat(sampleEntities.getContent(), hasItem(sampleEntity));
+	}
+
+	/*
+	DATAES-167
+	 */
+	@Test
+	public void shouldReturnResultsWithScanAndScrollForGivenCriteriaQuery() {
+		// given
+		List<IndexQuery> entities = createSampleEntitiesWithMessage("Test message", 30);
+		// when
+		elasticsearchTemplate.bulkIndex(entities);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
+		criteriaQuery.addIndices(INDEX_NAME);
+		criteriaQuery.addTypes(TYPE_NAME);
+		criteriaQuery.setPageable(new PageRequest(0, 10));
+
+		ScrolledPage<SampleEntity> scroll = (ScrolledPage<SampleEntity>) elasticsearchTemplate.startScroll(1000,
+				criteriaQuery, SampleEntity.class);
+		List<SampleEntity> sampleEntities = new ArrayList<>();
+		while (scroll.hasContent()) {
+			sampleEntities.addAll(scroll.getContent());
+			scroll = (ScrolledPage<SampleEntity>) elasticsearchTemplate.continueScroll(scroll.getScrollId(), 1000,
+					SampleEntity.class);
+		}
+		elasticsearchTemplate.clearScroll(scroll.getScrollId());
+		assertThat(sampleEntities.size(), is(equalTo(30)));
+	}
+
+	@Test
+	public void shouldReturnResultsWithScanAndScrollForGivenSearchQuery() {
+		// given
+		List<IndexQuery> entities = createSampleEntitiesWithMessage("Test message", 30);
+		// when
+		elasticsearchTemplate.bulkIndex(entities);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).withIndices(INDEX_NAME)
+				.withTypes(TYPE_NAME).withPageable(new PageRequest(0, 10)).build();
+
+		ScrolledPage<SampleEntity> scroll = (ScrolledPage<SampleEntity>) elasticsearchTemplate.startScroll(1000,
+				searchQuery, SampleEntity.class);
+		List<SampleEntity> sampleEntities = new ArrayList<>();
+		while (scroll.hasContent()) {
+			sampleEntities.addAll(scroll.getContent());
+			scroll = (ScrolledPage<SampleEntity>) elasticsearchTemplate.continueScroll(scroll.getScrollId(), 1000,
+					SampleEntity.class);
+		}
+		elasticsearchTemplate.clearScroll(scroll.getScrollId());
+		assertThat(sampleEntities.size(), is(equalTo(30)));
+	}
+
+	final SearchResultMapper searchResultMapper = new SearchResultMapper() {
+		@Override
+		public <T> AggregatedPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
+			List<SampleEntity> result = new ArrayList<SampleEntity>();
+			for (SearchHit searchHit : response.getHits()) {
+				if (response.getHits().getHits().length <= 0) {
+					return new AggregatedPageImpl<T>(Collections.EMPTY_LIST, response.getScrollId());
+				}
+				String message = (String) searchHit.getSourceAsMap().get("message");
+				SampleEntity sampleEntity = new SampleEntity();
+				sampleEntity.setId(searchHit.getId());
+				sampleEntity.setMessage(message);
+				result.add(sampleEntity);
+			}
+
+			if (result.size() > 0) {
+				return new AggregatedPageImpl<T>((List<T>) result, response.getScrollId());
+			}
+			return new AggregatedPageImpl<T>(Collections.EMPTY_LIST, response.getScrollId());
+		}
+	};
+
+	/*
+	DATAES-167
+	*/
+	@Test
+	public void shouldReturnResultsWithScanAndScrollForSpecifiedFieldsForCriteriaQuery() {
+		// given
+		List<IndexQuery> entities = createSampleEntitiesWithMessage("Test message", 30);
+		// when
+		elasticsearchTemplate.bulkIndex(entities);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
+		criteriaQuery.addIndices(INDEX_NAME);
+		criteriaQuery.addTypes(TYPE_NAME);
+		criteriaQuery.addFields("message");
+		criteriaQuery.setPageable(new PageRequest(0, 10));
+
+		Page<SampleEntity> scroll = elasticsearchTemplate.startScroll(1000, criteriaQuery, SampleEntity.class,
+				searchResultMapper);
+		String scrollId = ((ScrolledPage<?>) scroll).getScrollId();
+		List<SampleEntity> sampleEntities = new ArrayList<>();
+		while (scroll.hasContent()) {
+			sampleEntities.addAll(scroll.getContent());
+			scrollId = ((ScrolledPage<?>) scroll).getScrollId();
+			scroll = elasticsearchTemplate.continueScroll(scrollId, 1000, SampleEntity.class, searchResultMapper);
+		}
+		elasticsearchTemplate.clearScroll(scrollId);
+		assertThat(sampleEntities.size(), is(equalTo(30)));
+	}
+
+	/*
+	DATAES-84
+	*/
+	@Test
+	public void shouldReturnResultsWithScanAndScrollForSpecifiedFieldsForSearchCriteria() {
+		// given
+		List<IndexQuery> entities = createSampleEntitiesWithMessage("Test message", 30);
+		// when
+		elasticsearchTemplate.bulkIndex(entities);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).withIndices(INDEX_NAME)
+				.withTypes(TYPE_NAME).withFields("message").withQuery(matchAllQuery()).withPageable(new PageRequest(0, 10))
+				.build();
+
+		Page<SampleEntity> scroll = elasticsearchTemplate.startScroll(1000, searchQuery, SampleEntity.class,
+				searchResultMapper);
+		String scrollId = ((ScrolledPage) scroll).getScrollId();
+		List<SampleEntity> sampleEntities = new ArrayList<>();
+		while (scroll.hasContent()) {
+			sampleEntities.addAll(scroll.getContent());
+			scrollId = ((ScrolledPage) scroll).getScrollId();
+			scroll = elasticsearchTemplate.continueScroll(scrollId, 1000, SampleEntity.class, searchResultMapper);
+		}
+		elasticsearchTemplate.clearScroll(scrollId);
+		assertThat(sampleEntities.size(), is(equalTo(30)));
+	}
+
+	/*
+	DATAES-167
+	 */
+	@Test
+	public void shouldReturnResultsForScanAndScrollWithCustomResultMapperForGivenCriteriaQuery() {
+		// given
+		List<IndexQuery> entities = createSampleEntitiesWithMessage("Test message", 30);
+		// when
+		elasticsearchTemplate.bulkIndex(entities);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
+		criteriaQuery.addIndices(INDEX_NAME);
+		criteriaQuery.addTypes(TYPE_NAME);
+		criteriaQuery.setPageable(new PageRequest(0, 10));
+
+		Page<SampleEntity> scroll = elasticsearchTemplate.startScroll(1000, criteriaQuery, SampleEntity.class,
+				searchResultMapper);
+		String scrollId = ((ScrolledPage) scroll).getScrollId();
+		List<SampleEntity> sampleEntities = new ArrayList<>();
+		while (scroll.hasContent()) {
+			sampleEntities.addAll(scroll.getContent());
+			scrollId = ((ScrolledPage) scroll).getScrollId();
+			scroll = elasticsearchTemplate.continueScroll(scrollId, 1000, SampleEntity.class, searchResultMapper);
+		}
+		elasticsearchTemplate.clearScroll(scrollId);
+		assertThat(sampleEntities.size(), is(equalTo(30)));
+	}
+
+	@Test
+	public void shouldReturnResultsForScanAndScrollWithCustomResultMapperForGivenSearchQuery() {
+		// given
+		List<IndexQuery> entities = createSampleEntitiesWithMessage("Test message", 30);
+		// when
+		elasticsearchTemplate.bulkIndex(entities);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).withIndices(INDEX_NAME)
+				.withTypes(TYPE_NAME).withPageable(new PageRequest(0, 10)).build();
+
+		Page<SampleEntity> scroll = elasticsearchTemplate.startScroll(1000, searchQuery, SampleEntity.class,
+				searchResultMapper);
+		String scrollId = ((ScrolledPage) scroll).getScrollId();
+		List<SampleEntity> sampleEntities = new ArrayList<>();
+		while (scroll.hasContent()) {
+			sampleEntities.addAll(scroll.getContent());
+			scrollId = ((ScrolledPage) scroll).getScrollId();
+			scroll = elasticsearchTemplate.continueScroll(scrollId, 1000, SampleEntity.class, searchResultMapper);
+		}
+		elasticsearchTemplate.clearScroll(scrollId);
+		assertThat(sampleEntities.size(), is(equalTo(30)));
+	}
+
+	/*
+	DATAES-217
+	 */
+	@Test
+	public void shouldReturnResultsWithScanAndScrollForGivenCriteriaQueryAndClass() {
+		// given
+		List<IndexQuery> entities = createSampleEntitiesWithMessage("Test message", 30);
+		// when
+		elasticsearchTemplate.bulkIndex(entities);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
+		criteriaQuery.setPageable(new PageRequest(0, 10));
+
+		Page<SampleEntity> scroll = elasticsearchTemplate.startScroll(1000, criteriaQuery, SampleEntity.class);
+		String scrollId = ((ScrolledPage) scroll).getScrollId();
+		List<SampleEntity> sampleEntities = new ArrayList<>();
+		while (scroll.hasContent()) {
+			sampleEntities.addAll(scroll.getContent());
+			scrollId = ((ScrolledPage) scroll).getScrollId();
+			scroll = elasticsearchTemplate.continueScroll(scrollId, 1000, SampleEntity.class);
+		}
+		elasticsearchTemplate.clearScroll(scrollId);
+		assertThat(sampleEntities.size(), is(equalTo(30)));
+	}
+
+	/*
+	DATAES-217
+	 */
+	@Test
+	public void shouldReturnResultsWithScanAndScrollForGivenSearchQueryAndClass() {
+		// given
+		List<IndexQuery> entities = createSampleEntitiesWithMessage("Test message", 30);
+		// when
+		elasticsearchTemplate.bulkIndex(entities);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
+				.withPageable(new PageRequest(0, 10)).build();
+
+		Page<SampleEntity> scroll = elasticsearchTemplate.startScroll(1000, searchQuery, SampleEntity.class);
+		String scrollId = ((ScrolledPage) scroll).getScrollId();
+		List<SampleEntity> sampleEntities = new ArrayList<>();
+		while (scroll.hasContent()) {
+			sampleEntities.addAll(scroll.getContent());
+			scrollId = ((ScrolledPage) scroll).getScrollId();
+			scroll = elasticsearchTemplate.continueScroll(scrollId, 1000, SampleEntity.class);
+		}
+		elasticsearchTemplate.clearScroll(scrollId);
+		assertThat(sampleEntities.size(), is(equalTo(30)));
+	}
+
+	/*
+	DATAES-167
+	 */
+	@Test
+	public void shouldReturnResultsWithStreamForGivenCriteriaQuery() {
+		// given
+		List<IndexQuery> entities = createSampleEntitiesWithMessage("Test message", 30);
+		// when
+		elasticsearchTemplate.bulkIndex(entities);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
+		criteriaQuery.addIndices(INDEX_NAME);
+		criteriaQuery.addTypes(TYPE_NAME);
+		criteriaQuery.setPageable(new PageRequest(0, 10));
+
+		CloseableIterator<SampleEntity> stream = elasticsearchTemplate.stream(criteriaQuery, SampleEntity.class);
+		List<SampleEntity> sampleEntities = new ArrayList<>();
+		while (stream.hasNext()) {
+			sampleEntities.add(stream.next());
+		}
+		assertThat(sampleEntities.size(), is(equalTo(30)));
+	}
+
+	private static List<IndexQuery> createSampleEntitiesWithMessage(String message, int numberOfEntities) {
+		List<IndexQuery> indexQueries = new ArrayList<>();
+		for (int i = 0; i < numberOfEntities; i++) {
+			String documentId = UUID.randomUUID().toString();
+			SampleEntity sampleEntity = new SampleEntity();
+			sampleEntity.setId(documentId);
+			sampleEntity.setMessage(message);
+			sampleEntity.setRate(2);
+			sampleEntity.setVersion(System.currentTimeMillis());
+			IndexQuery indexQuery = new IndexQuery();
+			indexQuery.setId(documentId);
+			indexQuery.setObject(sampleEntity);
+			indexQueries.add(indexQuery);
+		}
+		return indexQueries;
+	}
+
+	@Test
+	public void shouldReturnListForGivenCriteria() {
+		// given
+		List<IndexQuery> indexQueries = new ArrayList<>();
+		// first document
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId).message("test message")
+				.version(System.currentTimeMillis()).build();
+
+		// second document
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2).message("test test").rate(5)
+				.version(System.currentTimeMillis()).build();
+
+		// third document
+		String documentId3 = randomNumeric(5);
+		SampleEntity sampleEntity3 = SampleEntity.builder().id(documentId3).message("some message").rate(15)
+				.version(System.currentTimeMillis()).build();
+
+		indexQueries = getIndexQueries(Arrays.asList(sampleEntity1, sampleEntity2, sampleEntity3));
+
+		// when
+		elasticsearchTemplate.bulkIndex(indexQueries);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// when
+		CriteriaQuery singleCriteriaQuery = new CriteriaQuery(new Criteria("message").contains("test"));
+		CriteriaQuery multipleCriteriaQuery = new CriteriaQuery(
+				new Criteria("message").contains("some").and("message").contains("message"));
+		List<SampleEntity> sampleEntitiesForSingleCriteria = elasticsearchTemplate.queryForList(singleCriteriaQuery,
+				SampleEntity.class);
+		List<SampleEntity> sampleEntitiesForAndCriteria = elasticsearchTemplate.queryForList(multipleCriteriaQuery,
+				SampleEntity.class);
+		// then
+		assertThat(sampleEntitiesForSingleCriteria.size(), is(2));
+		assertThat(sampleEntitiesForAndCriteria.size(), is(1));
+	}
+
+	@Test
+	public void shouldReturnListForGivenStringQuery() {
+		// given
+		// first document
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId).message("test message")
+				.version(System.currentTimeMillis()).build();
+
+		// second document
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2).message("test test").rate(5)
+				.version(System.currentTimeMillis()).build();
+
+		// third document
+		String documentId3 = randomNumeric(5);
+		SampleEntity sampleEntity3 = SampleEntity.builder().id(documentId3).message("some message").rate(15)
+				.version(System.currentTimeMillis()).build();
+
+		List<IndexQuery> indexQueries = getIndexQueries(Arrays.asList(sampleEntity1, sampleEntity2, sampleEntity3));
+
+		// when
+		elasticsearchTemplate.bulkIndex(indexQueries);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// when
+		StringQuery stringQuery = new StringQuery(matchAllQuery().toString());
+		List<SampleEntity> sampleEntities = elasticsearchTemplate.queryForList(stringQuery, SampleEntity.class);
+		// then
+		assertThat(sampleEntities.size(), is(3));
+	}
+
+	@Test
+	public void shouldPutMappingForGivenEntity() throws Exception {
+		// given
+		Class entity = SampleMappingEntity.class;
+		elasticsearchTemplate.deleteIndex(entity);
+		elasticsearchTemplate.createIndex(entity);
+		// when
+		assertThat(elasticsearchTemplate.putMapping(entity), is(true));
+	}
+
+	@Test
+	public void shouldDeleteIndexForGivenEntity() {
+		// given
+		Class clazz = SampleEntity.class;
+		// when
+		elasticsearchTemplate.deleteIndex(clazz);
+		// then
+		assertThat(elasticsearchTemplate.indexExists(clazz), is(false));
+	}
+
+	@Test
+	public void shouldDoPartialUpdateForExistingDocument() {
+		// given
+		String documentId = randomNumeric(5);
+		String messageBeforeUpdate = "some test message";
+		String messageAfterUpdate = "test message";
+
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message(messageBeforeUpdate)
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		IndexRequest indexRequest = new IndexRequest();
+		indexRequest.source("message", messageAfterUpdate);
+		UpdateQuery updateQuery = new UpdateQueryBuilder().withId(documentId).withClass(SampleEntity.class)
+				.withIndexRequest(indexRequest).build();
+		// when
+		elasticsearchTemplate.update(updateQuery);
+		// then
+		GetQuery getQuery = new GetQuery();
+		getQuery.setId(documentId);
+		SampleEntity indexedEntity = elasticsearchTemplate.queryForObject(getQuery, SampleEntity.class);
+		assertThat(indexedEntity.getMessage(), is(messageAfterUpdate));
+	}
+
+	@Test
+	public void shouldDoUpsertIfDocumentDoesNotExist() {
+		// given
+		String documentId = randomNumeric(5);
+		String message = "test message";
+		IndexRequest indexRequest = new IndexRequest();
+		indexRequest.source("message", message);
+		UpdateQuery updateQuery = new UpdateQueryBuilder().withId(documentId).withDoUpsert(true)
+				.withClass(SampleEntity.class).withIndexRequest(indexRequest).build();
+		// when
+		elasticsearchTemplate.update(updateQuery);
+		// then
+		GetQuery getQuery = new GetQuery();
+		getQuery.setId(documentId);
+		SampleEntity indexedEntity = elasticsearchTemplate.queryForObject(getQuery, SampleEntity.class);
+		assertThat(indexedEntity.getMessage(), is(message));
+	}
+
+	@Test
+	public void shouldReturnHighlightedFieldsForGivenQueryAndFields() {
+
+		// given
+		String documentId = randomNumeric(5);
+		String actualMessage = "some test message";
+		String highlightedMessage = "some <em>test</em> message";
+
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message(actualMessage)
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		final List<HighlightBuilder.Field> message = new HighlightBuilder().field("message").fields();
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchQuery("message", "test"))
+				.withHighlightFields(message.toArray(new HighlightBuilder.Field[message.size()])).build();
+
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class,
+				new SearchResultMapper() {
+					@Override
+					public <T> AggregatedPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
+						List<SampleEntity> chunk = new ArrayList<>();
+						SearchHits hits = response.getHits();
+						for (SearchHit searchHit : hits.getHits()) {
+							SampleEntity user = new SampleEntity();
+							user.setId(searchHit.getId());
+							user.setMessage((String) searchHit.getSourceAsMap().get("message"));
+							user.setHighlightedMessage(searchHit.getHighlightFields().get("message").fragments()[0].toString());
+							chunk.add(user);
+						}
+						if (chunk.size() > 0) {
+							return new AggregatedPageImpl<>((List<T>) chunk);
+						}
+						return null;
+					}
+				});
+
+		assertThat(sampleEntities.getContent().get(0).getHighlightedMessage(), is(highlightedMessage));
+	}
+
+	@Test // DATAES-412
+	public void shouldReturnMultipleHighlightFields() {
+
+		// given
+		String documentId = randomNumeric(5);
+		String actualType = "some test type";
+		String actualMessage = "some test message";
+		String highlightedType = "some <em>test</em> type";
+		String highlightedMessage = "some <em>test</em> message";
+
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).type(actualType).message(actualMessage)
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder()
+				.withQuery(boolQuery().must(termQuery("type", "test")).must(termQuery("message", "test")))
+				.withHighlightFields(new HighlightBuilder.Field("type"), new HighlightBuilder.Field("message")).build();
+
+		// when
+		elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class, new SearchResultMapper() {
+			@Override
+			public <T> AggregatedPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
+				for (SearchHit searchHit : response.getHits()) {
+					Map<String, HighlightField> highlightFields = searchHit.getHighlightFields();
+					HighlightField highlightFieldType = highlightFields.get("type");
+					HighlightField highlightFieldMessage = highlightFields.get("message");
+
+					// then
+					assertNotNull(highlightFieldType);
+					assertNotNull(highlightFieldMessage);
+					assertThat(highlightFieldType.fragments()[0].toString(), is(highlightedType));
+					assertThat(highlightFieldMessage.fragments()[0].toString(), is(highlightedMessage));
+				}
+				return null;
+			}
+		});
+	}
+
+	@Test
+	public void shouldDeleteDocumentBySpecifiedTypeUsingDeleteQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// when
+		DeleteQuery deleteQuery = new DeleteQuery();
+		deleteQuery.setQuery(termQuery("id", documentId));
+		deleteQuery.setIndex(INDEX_NAME);
+		deleteQuery.setType(TYPE_NAME);
+		elasticsearchTemplate.delete(deleteQuery);
+		elasticsearchTemplate.refresh(INDEX_NAME);
+		// then
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("id", documentId)).build();
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		assertThat(sampleEntities.getTotalElements(), equalTo(0L));
+	}
+
+	@Test
+	public void shouldIndexDocumentForSpecifiedSource() {
+
+		// given
+		String documentSource = "{\"id\":\"2333343434\",\"type\":null,\"message\":\"some message\",\"rate\":0,\"available\":false,\"highlightedMessage\":null,\"version\":1385208779482}";
+		IndexQuery indexQuery = new IndexQuery();
+		indexQuery.setId("2333343434");
+		indexQuery.setSource(documentSource);
+		indexQuery.setIndexName(INDEX_NAME);
+		indexQuery.setType(TYPE_NAME);
+		// when
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("id", indexQuery.getId()))
+				.withIndices(INDEX_NAME).withTypes(TYPE_NAME).build();
+		// then
+		Page<SampleEntity> page = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class,
+				new SearchResultMapper() {
+					@Override
+					public <T> AggregatedPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
+						List<SampleEntity> values = new ArrayList<>();
+						for (SearchHit searchHit : response.getHits()) {
+							SampleEntity sampleEntity = new SampleEntity();
+							sampleEntity.setId(searchHit.getId());
+							sampleEntity.setMessage((String) searchHit.getSourceAsMap().get("message"));
+							values.add(sampleEntity);
+						}
+						return new AggregatedPageImpl<>((List<T>) values);
+					}
+				});
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getContent().size(), is(1));
+		assertThat(page.getContent().get(0).getId(), is(indexQuery.getId()));
+	}
+
+	@Test(expected = ElasticsearchException.class)
+	public void shouldThrowElasticsearchExceptionWhenNoDocumentSpecified() {
+		// given
+		IndexQuery indexQuery = new IndexQuery();
+		indexQuery.setId("2333343434");
+		indexQuery.setIndexName(INDEX_NAME);
+		indexQuery.setType(TYPE_NAME);
+
+		// when
+		elasticsearchTemplate.index(indexQuery);
+	}
+
+	@Test
+	public void shouldReturnIds() {
+		// given
+		List<IndexQuery> entities = createSampleEntitiesWithMessage("Test message", 30);
+		// when
+		elasticsearchTemplate.bulkIndex(entities);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("message", "message"))
+				.withIndices(INDEX_NAME).withTypes(TYPE_NAME).withPageable(new PageRequest(0, 100)).build();
+		// then
+		List<String> ids = elasticsearchTemplate.queryForIds(searchQuery);
+		assertThat(ids, is(notNullValue()));
+		assertThat(ids.size(), is(30));
+	}
+
+	@Test
+	public void shouldReturnDocumentAboveMinimalScoreGivenQuery() {
+		// given
+		List<IndexQuery> indexQueries = new ArrayList<>();
+
+		indexQueries.add(buildIndex(SampleEntity.builder().id("1").message("ab").build()));
+		indexQueries.add(buildIndex(SampleEntity.builder().id("2").message("bc").build()));
+		indexQueries.add(buildIndex(SampleEntity.builder().id("3").message("ac").build()));
+
+		elasticsearchTemplate.bulkIndex(indexQueries);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		// when
+		SearchQuery searchQuery = new NativeSearchQueryBuilder()
+				.withQuery(boolQuery().must(wildcardQuery("message", "*a*")).should(wildcardQuery("message", "*b*")))
+				.withIndices(INDEX_NAME).withTypes(TYPE_NAME).withMinScore(2.0F).build();
+
+		Page<SampleEntity> page = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		// then
+		assertThat(page.getTotalElements(), is(1L));
+		assertThat(page.getContent().get(0).getMessage(), is("ab"));
+	}
+
+	@Test // DATAES-462
+	public void shouldReturnScores() {
+
+		// given
+		List<IndexQuery> indexQueries = new ArrayList<>();
+
+		indexQueries.add(buildIndex(SampleEntity.builder().id("1").message("ab xz").build()));
+		indexQueries.add(buildIndex(SampleEntity.builder().id("2").message("bc").build()));
+		indexQueries.add(buildIndex(SampleEntity.builder().id("3").message("ac xz hi").build()));
+
+		elasticsearchTemplate.bulkIndex(indexQueries);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		// when
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("message", "xz"))
+				.withSort(SortBuilders.fieldSort("message")).withTrackScores(true).build();
+
+		AggregatedPage<SampleEntity> page = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+
+		// then
+		assertThat(page.getMaxScore(), greaterThan(0f));
+		assertThat(page.getContent().get(0).getScore(), greaterThan(0f));
+	}
+
+	@Test
+	public void shouldDoIndexWithoutId() {
+		// given
+		// document
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setMessage("some message");
+		sampleEntity.setVersion(System.currentTimeMillis());
+
+		IndexQuery indexQuery = new IndexQuery();
+		indexQuery.setObject(sampleEntity);
+		// when
+		String documentId = elasticsearchTemplate.index(indexQuery);
+		// then
+		assertThat(sampleEntity.getId(), is(equalTo(documentId)));
+
+		GetQuery getQuery = new GetQuery();
+		getQuery.setId(documentId);
+		SampleEntity result = elasticsearchTemplate.queryForObject(getQuery, SampleEntity.class);
+		assertThat(result.getId(), is(equalTo(documentId)));
+	}
+
+	@Test
+	public void shouldDoBulkIndexWithoutId() {
+		// given
+		List<IndexQuery> indexQueries = new ArrayList<>();
+		// first document
+		SampleEntity sampleEntity1 = new SampleEntity();
+		sampleEntity1.setMessage("some message");
+		sampleEntity1.setVersion(System.currentTimeMillis());
+
+		IndexQuery indexQuery1 = new IndexQuery();
+		indexQuery1.setObject(sampleEntity1);
+		indexQueries.add(indexQuery1);
+
+		// second document
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setMessage("some message");
+		sampleEntity2.setVersion(System.currentTimeMillis());
+
+		IndexQuery indexQuery2 = new IndexQuery();
+		indexQuery2.setObject(sampleEntity2);
+		indexQueries.add(indexQuery2);
+		// when
+		elasticsearchTemplate.bulkIndex(indexQueries);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		// then
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		assertThat(sampleEntities.getTotalElements(), is(equalTo(2L)));
+
+		assertThat(sampleEntities.getContent().get(0).getId(), is(notNullValue()));
+		assertThat(sampleEntities.getContent().get(1).getId(), is(notNullValue()));
+	}
+
+	@Test
+	public void shouldIndexMapWithIndexNameAndTypeAtRuntime() {
+		// given
+		Map<String, Object> person1 = new HashMap<>();
+		person1.put("userId", "1");
+		person1.put("email", "smhdiu@gmail.com");
+		person1.put("title", "Mr");
+		person1.put("firstName", "Mohsin");
+		person1.put("lastName", "Husen");
+
+		Map<String, Object> person2 = new HashMap<>();
+		person2.put("userId", "2");
+		person2.put("email", "akonczak@gmail.com");
+		person2.put("title", "Mr");
+		person2.put("firstName", "Artur");
+		person2.put("lastName", "Konczak");
+
+		IndexQuery indexQuery1 = new IndexQuery();
+		indexQuery1.setId("1");
+		indexQuery1.setObject(person1);
+		indexQuery1.setIndexName(INDEX_NAME);
+		indexQuery1.setType(TYPE_NAME);
+
+		IndexQuery indexQuery2 = new IndexQuery();
+		indexQuery2.setId("2");
+		indexQuery2.setObject(person2);
+		indexQuery2.setIndexName(INDEX_NAME);
+		indexQuery2.setType(TYPE_NAME);
+
+		List<IndexQuery> indexQueries = new ArrayList<>();
+		indexQueries.add(indexQuery1);
+		indexQueries.add(indexQuery2);
+
+		// when
+		elasticsearchTemplate.bulkIndex(indexQueries);
+		elasticsearchTemplate.refresh(INDEX_NAME);
+
+		// then
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withIndices(INDEX_NAME).withTypes(TYPE_NAME)
+				.withQuery(matchAllQuery()).build();
+		Page<Map> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, Map.class, new SearchResultMapper() {
+			@Override
+			public <T> AggregatedPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
+				List<Map> chunk = new ArrayList<>();
+				for (SearchHit searchHit : response.getHits()) {
+					if (response.getHits().getHits().length <= 0) {
+						return null;
+					}
+					Map<String, Object> person = new HashMap<>();
+					person.put("userId", searchHit.getSourceAsMap().get("userId"));
+					person.put("email", searchHit.getSourceAsMap().get("email"));
+					person.put("title", searchHit.getSourceAsMap().get("title"));
+					person.put("firstName", searchHit.getSourceAsMap().get("firstName"));
+					person.put("lastName", searchHit.getSourceAsMap().get("lastName"));
+					chunk.add(person);
+				}
+				if (chunk.size() > 0) {
+					return new AggregatedPageImpl<>((List<T>) chunk);
+				}
+				return null;
+			}
+		});
+		assertThat(sampleEntities.getTotalElements(), is(equalTo(2L)));
+		assertThat(sampleEntities.getContent().get(0).get("userId"), is(person1.get("userId")));
+		assertThat(sampleEntities.getContent().get(1).get("userId"), is(person2.get("userId")));
+	}
+
+	@Test
+	public void shouldIndexSampleEntityWithIndexAndTypeAtRuntime() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = new IndexQueryBuilder().withId(documentId).withIndexName(INDEX_NAME).withType(TYPE_NAME)
+				.withObject(sampleEntity).build();
+
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(INDEX_NAME);
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withIndices(INDEX_NAME).withTypes(TYPE_NAME)
+				.withQuery(matchAllQuery()).build();
+		// when
+		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class);
+		// then
+		assertThat(sampleEntities, is(notNullValue()));
+		assertThat(sampleEntities.getTotalElements(), greaterThanOrEqualTo(1L));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldReturnCountForGivenCriteriaQueryWithGivenIndexUsingCriteriaQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
+		criteriaQuery.addIndices(INDEX_NAME);
+		// when
+		long count = elasticsearchTemplate.count(criteriaQuery);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-67
+	 */
+	@Test
+	public void shouldReturnCountForGivenSearchQueryWithGivenIndexUsingSearchQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).withIndices(INDEX_NAME).build();
+		// when
+		long count = elasticsearchTemplate.count(searchQuery);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldReturnCountForGivenCriteriaQueryWithGivenIndexAndTypeUsingCriteriaQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
+		criteriaQuery.addIndices(INDEX_NAME);
+		criteriaQuery.addTypes("test-type");
+		// when
+		long count = elasticsearchTemplate.count(criteriaQuery);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-67
+	 */
+	@Test
+	public void shouldReturnCountForGivenSearchQueryWithGivenIndexAndTypeUsingSearchQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).withIndices(INDEX_NAME)
+				.withTypes("test-type").build();
+		// when
+		long count = elasticsearchTemplate.count(searchQuery);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldReturnCountForGivenCriteriaQueryWithGivenMultiIndices() {
+		// given
+		cleanUpIndices();
+		String documentId1 = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId1).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery1 = new IndexQueryBuilder().withId(sampleEntity1.getId()).withIndexName("test-index-1")
+				.withObject(sampleEntity1).build();
+
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2).message("some test message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery2 = new IndexQueryBuilder().withId(sampleEntity2.getId()).withIndexName("test-index-2")
+				.withObject(sampleEntity2).build();
+
+		elasticsearchTemplate.bulkIndex(Arrays.asList(indexQuery1, indexQuery2));
+		elasticsearchTemplate.refresh("test-index-1");
+		elasticsearchTemplate.refresh("test-index-2");
+
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
+		criteriaQuery.addIndices("test-index-1", "test-index-2");
+		// when
+		long count = elasticsearchTemplate.count(criteriaQuery);
+		// then
+		assertThat(count, is(equalTo(2L)));
+	}
+
+	/*
+	DATAES-67
+	 */
+	@Test
+	public void shouldReturnCountForGivenSearchQueryWithGivenMultiIndices() {
+		// given
+		cleanUpIndices();
+		String documentId1 = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId1).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery1 = new IndexQueryBuilder().withId(sampleEntity1.getId()).withIndexName("test-index-1")
+				.withObject(sampleEntity1).build();
+
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2).message("some test message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery2 = new IndexQueryBuilder().withId(sampleEntity2.getId()).withIndexName("test-index-2")
+				.withObject(sampleEntity2).build();
+
+		elasticsearchTemplate.bulkIndex(Arrays.asList(indexQuery1, indexQuery2));
+		elasticsearchTemplate.refresh("test-index-1");
+		elasticsearchTemplate.refresh("test-index-2");
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
+				.withIndices("test-index-1", "test-index-2").build();
+		// when
+		long count = elasticsearchTemplate.count(searchQuery);
+		// then
+		assertThat(count, is(equalTo(2L)));
+	}
+
+	private void cleanUpIndices() {
+		elasticsearchTemplate.deleteIndex("test-index-1");
+		elasticsearchTemplate.deleteIndex("test-index-2");
+		elasticsearchTemplate.createIndex("test-index-1");
+		elasticsearchTemplate.createIndex("test-index-2");
+		elasticsearchTemplate.refresh("test-index-1");
+		elasticsearchTemplate.refresh("test-index-2");
+	}
+
+	/*
+	DATAES-71
+	*/
+	@Test
+	public void shouldCreatedIndexWithSpecifiedIndexName() {
+		// given
+		elasticsearchTemplate.deleteIndex("test-index");
+		// when
+		elasticsearchTemplate.createIndex("test-index");
+		// then
+		assertThat(elasticsearchTemplate.indexExists("test-index"), is(true));
+	}
+
+	/*
+	DATAES-72
+	*/
+	@Test
+	public void shouldDeleteIndexForSpecifiedIndexName() {
+		// given
+		elasticsearchTemplate.createIndex(SampleEntity.class);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		// when
+		elasticsearchTemplate.deleteIndex("test-index");
+		// then
+		assertThat(elasticsearchTemplate.indexExists("test-index"), is(false));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldReturnCountForGivenCriteriaQueryWithGivenIndexNameForSpecificIndex() {
+		// given
+		cleanUpIndices();
+		String documentId1 = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId1).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery1 = new IndexQueryBuilder().withId(sampleEntity1.getId()).withIndexName("test-index-1")
+				.withObject(sampleEntity1).build();
+
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2).message("some test message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery2 = new IndexQueryBuilder().withId(sampleEntity2.getId()).withIndexName("test-index-2")
+				.withObject(sampleEntity2).build();
+
+		elasticsearchTemplate.bulkIndex(Arrays.asList(indexQuery1, indexQuery2));
+		elasticsearchTemplate.refresh("test-index-1");
+		elasticsearchTemplate.refresh("test-index-2");
+
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
+		criteriaQuery.addIndices("test-index-1");
+		// when
+		long count = elasticsearchTemplate.count(criteriaQuery);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-67
+	*/
+	@Test
+	public void shouldReturnCountForGivenSearchQueryWithGivenIndexNameForSpecificIndex() {
+		// given
+		cleanUpIndices();
+		String documentId1 = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId1).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery1 = new IndexQueryBuilder().withId(sampleEntity1.getId()).withIndexName("test-index-1")
+				.withObject(sampleEntity1).build();
+
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2).message("some test message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery2 = new IndexQueryBuilder().withId(sampleEntity2.getId()).withIndexName("test-index-2")
+				.withObject(sampleEntity2).build();
+
+		elasticsearchTemplate.bulkIndex(Arrays.asList(indexQuery1, indexQuery2));
+		elasticsearchTemplate.refresh("test-index-1");
+		elasticsearchTemplate.refresh("test-index-2");
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).withIndices("test-index-1")
+				.build();
+		// when
+		long count = elasticsearchTemplate.count(searchQuery);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void shouldThrowAnExceptionForGivenCriteriaQueryWhenNoIndexSpecifiedForCountQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
+		// when
+		long count = elasticsearchTemplate.count(criteriaQuery);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-67
+	*/
+	@Test(expected = IllegalArgumentException.class)
+	public void shouldThrowAnExceptionForGivenSearchQueryWhenNoIndexSpecifiedForCountQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = SampleEntity.builder().id(documentId).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery = getIndexQuery(sampleEntity);
+		elasticsearchTemplate.index(indexQuery);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
+		// when
+		long count = elasticsearchTemplate.count(searchQuery);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-71
+	*/
+	@Test
+	public void shouldCreateIndexWithGivenSettings() {
+		// given
+		String settings = "{\n" + "        \"index\": {\n" + "            \"number_of_shards\": \"1\",\n"
+				+ "            \"number_of_replicas\": \"0\",\n" + "            \"analysis\": {\n"
+				+ "                \"analyzer\": {\n" + "                    \"emailAnalyzer\": {\n"
+				+ "                        \"type\": \"custom\",\n"
+				+ "                        \"tokenizer\": \"uax_url_email\"\n" + "                    }\n"
+				+ "                }\n" + "            }\n" + "        }\n" + "}";
+
+		elasticsearchTemplate.deleteIndex("test-index");
+		// when
+		elasticsearchTemplate.createIndex("test-index", settings);
+		// then
+		Map map = elasticsearchTemplate.getSetting("test-index");
+		boolean hasAnalyzer = map.containsKey("index.analysis.analyzer.emailAnalyzer.tokenizer");
+		String emailAnalyzer = (String) map.get("index.analysis.analyzer.emailAnalyzer.tokenizer");
+		assertThat(elasticsearchTemplate.indexExists("test-index"), is(true));
+		assertThat(hasAnalyzer, is(true));
+		assertThat(emailAnalyzer, is("uax_url_email"));
+	}
+
+	/*
+	DATAES-71
+	*/
+	@Test
+	public void shouldCreateGivenSettingsForGivenIndex() {
+		// given
+		// delete , create and apply mapping in before method
+
+		// then
+		Map map = elasticsearchTemplate.getSetting(SampleEntity.class);
+		assertThat(elasticsearchTemplate.indexExists("test-index"), is(true));
+		assertThat(map.containsKey("index.refresh_interval"), is(true));
+		assertThat(map.containsKey("index.number_of_replicas"), is(true));
+		assertThat(map.containsKey("index.number_of_shards"), is(true));
+		assertThat(map.containsKey("index.store.type"), is(true));
+		assertThat((String) map.get("index.refresh_interval"), is("-1"));
+		assertThat((String) map.get("index.number_of_replicas"), is("0"));
+		assertThat((String) map.get("index.number_of_shards"), is("1"));
+		assertThat((String) map.get("index.store.type"), is("fs"));
+	}
+
+	/*
+	DATAES-88
+	*/
+	@Test
+	public void shouldCreateIndexWithGivenClassAndSettings() {
+		// given
+		String settings = "{\n" + "        \"index\": {\n" + "            \"number_of_shards\": \"1\",\n"
+				+ "            \"number_of_replicas\": \"0\",\n" + "            \"analysis\": {\n"
+				+ "                \"analyzer\": {\n" + "                    \"emailAnalyzer\": {\n"
+				+ "                        \"type\": \"custom\",\n"
+				+ "                        \"tokenizer\": \"uax_url_email\"\n" + "                    }\n"
+				+ "                }\n" + "            }\n" + "        }\n" + "}";
+
+		elasticsearchTemplate.deleteIndex(SampleEntity.class);
+		elasticsearchTemplate.createIndex(SampleEntity.class, settings);
+		elasticsearchTemplate.putMapping(SampleEntity.class);
+		elasticsearchTemplate.refresh(SampleEntity.class);
+
+		// then
+		Map map = elasticsearchTemplate.getSetting(SampleEntity.class);
+		assertThat(elasticsearchTemplate.indexExists(INDEX_NAME), is(true));
+		assertThat(map.containsKey("index.number_of_replicas"), is(true));
+		assertThat(map.containsKey("index.number_of_shards"), is(true));
+		assertThat((String) map.get("index.number_of_replicas"), is("0"));
+		assertThat((String) map.get("index.number_of_shards"), is("1"));
+	}
+
+	@Test
+	public void shouldTestResultsAcrossMultipleIndices() {
+		// given
+		String documentId1 = randomNumeric(5);
+		SampleEntity sampleEntity1 = SampleEntity.builder().id(documentId1).message("some message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery1 = new IndexQueryBuilder().withId(sampleEntity1.getId()).withIndexName("test-index-1")
+				.withObject(sampleEntity1).build();
+
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = SampleEntity.builder().id(documentId2).message("some test message")
+				.version(System.currentTimeMillis()).build();
+
+		IndexQuery indexQuery2 = new IndexQueryBuilder().withId(sampleEntity2.getId()).withIndexName("test-index-2")
+				.withObject(sampleEntity2).build();
+
+		elasticsearchTemplate.bulkIndex(Arrays.asList(indexQuery1, indexQuery2));
+		elasticsearchTemplate.refresh("test-index-1");
+		elasticsearchTemplate.refresh("test-index-2");
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
+				.withIndices("test-index-1", "test-index-2").build();
+		// when
+		List<SampleEntity> sampleEntities = elasticsearchTemplate.queryForList(searchQuery, SampleEntity.class);
+
+		// then
+		assertThat(sampleEntities.size(), is(equalTo(2)));
+	}
+
+	@Test
+	/**
+	 * This is basically a demonstration to show composing entities out of heterogeneous indexes.
+	 */
+	public void shouldComposeObjectsReturnedFromHeterogeneousIndexes() {
+
+		// Given
+
+		HetroEntity1 entity1 = new HetroEntity1(randomNumeric(3), "aFirstName");
+		HetroEntity2 entity2 = new HetroEntity2(randomNumeric(4), "aLastName");
+
+		IndexQuery idxQuery1 = new IndexQueryBuilder().withIndexName(INDEX_1_NAME).withId(entity1.getId())
+				.withObject(entity1).build();
+		IndexQuery idxQuery2 = new IndexQueryBuilder().withIndexName(INDEX_2_NAME).withId(entity2.getId())
+				.withObject(entity2).build();
+
+		elasticsearchTemplate.bulkIndex(Arrays.asList(idxQuery1, idxQuery2));
+		elasticsearchTemplate.refresh(INDEX_1_NAME);
+		elasticsearchTemplate.refresh(INDEX_2_NAME);
+
+		// When
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).withTypes("hetro")
+				.withIndices(INDEX_1_NAME, INDEX_2_NAME).build();
+		Page<ResultAggregator> page = elasticsearchTemplate.queryForPage(searchQuery, ResultAggregator.class,
+				new SearchResultMapper() {
+					@Override
+					public <T> AggregatedPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
+						List<ResultAggregator> values = new ArrayList<>();
+						for (SearchHit searchHit : response.getHits()) {
+							String id = String.valueOf(searchHit.getSourceAsMap().get("id"));
+							String firstName = StringUtils.isNotEmpty((String) searchHit.getSourceAsMap().get("firstName"))
+									? (String) searchHit.getSourceAsMap().get("firstName")
+									: "";
+							String lastName = StringUtils.isNotEmpty((String) searchHit.getSourceAsMap().get("lastName"))
+									? (String) searchHit.getSourceAsMap().get("lastName")
+									: "";
+							values.add(new ResultAggregator(id, firstName, lastName));
+						}
+						return new AggregatedPageImpl<>((List<T>) values);
+					}
+				});
+
+		assertThat(page.getTotalElements(), is(2l));
+	}
+
+	@Test
+	public void shouldCreateIndexUsingServerDefaultConfiguration() {
+		// given
+
+		// when
+		boolean created = elasticsearchTemplate.createIndex(UseServerConfigurationEntity.class);
+		// then
+		assertThat(created, is(true));
+		final Map setting = elasticsearchTemplate.getSetting(UseServerConfigurationEntity.class);
+		assertThat(setting.get("index.number_of_shards"), Matchers.<Object> is("5"));
+		assertThat(setting.get("index.number_of_replicas"), Matchers.<Object> is("1"));
+	}
+
+	@Test
+	public void shouldReadFileFromClasspathRetainingNewlines() {
+		// given
+		String settingsFile = "/settings/test-settings.yml";
+
+		// when
+		String content = ElasticsearchTemplate.readFileFromClasspath(settingsFile);
+
+		// then
+		assertThat(content,
+				is("index:\n" + "  number_of_shards: 1\n" + "  number_of_replicas: 0\n" + "  analysis:\n" + "    analyzer:\n"
+						+ "      emailAnalyzer:\n" + "        type: custom\n" + "        tokenizer: uax_url_email\n"));
+	}
+
+	private IndexQuery getIndexQuery(SampleEntity sampleEntity) {
+		return new IndexQueryBuilder().withId(sampleEntity.getId()).withObject(sampleEntity)
+				.withVersion(sampleEntity.getVersion()).build();
+	}
+
+	private List<IndexQuery> getIndexQueries(List<SampleEntity> sampleEntities) {
+		List<IndexQuery> indexQueries = new ArrayList<>();
+		for (SampleEntity sampleEntity : sampleEntities) {
+			indexQueries.add(getIndexQuery(sampleEntity));
+		}
+		return indexQueries;
+	}
+
+	@Document(indexName = INDEX_2_NAME, replicas = 0, shards = 1)
+	class ResultAggregator {
+
+		private String id;
+		private String firstName;
+		private String lastName;
+
+		ResultAggregator(String id, String firstName, String lastName) {
+			this.id = id;
+			this.firstName = firstName;
+			this.lastName = lastName;
+		}
+	}
+}

--- a/src/test/java/org/springframework/data/elasticsearch/core/MappingBuilderTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/MappingBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2016 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 import static org.springframework.data.elasticsearch.utils.IndexBuilder.*;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Date;
@@ -45,13 +46,19 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Mohsin Husen
  * @author Keivn Leturc
  * @author Nordine Bittich
+ * @author Don Wellington
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("classpath:elasticsearch-template-test.xml")
 public class MappingBuilderTests {
 
-	@Autowired
-	private ElasticsearchTemplate elasticsearchTemplate;
+	@Autowired private ElasticsearchTemplate elasticsearchTemplate;
+
+	private String xContentBuilderToString(XContentBuilder builder) {
+		builder.close();
+		ByteArrayOutputStream bos = (ByteArrayOutputStream) builder.getOutputStream();
+		return bos.toString();
+	}
 
 	@Test
 	public void shouldNotFailOnCircularReference() {
@@ -63,43 +70,43 @@ public class MappingBuilderTests {
 
 	@Test
 	public void testInfiniteLoopAvoidance() throws IOException {
-		final String expected = "{\"mapping\":{\"properties\":{\"message\":{\"store\":true,\"" +
-				"type\":\"text\",\"index\":false," +
-				"\"analyzer\":\"standard\"}}}}";
+		final String expected = "{\"mapping\":{\"properties\":{\"message\":{\"store\":true,\""
+				+ "type\":\"text\",\"index\":false," + "\"analyzer\":\"standard\"}}}}";
 
 		XContentBuilder xContentBuilder = MappingBuilder.buildMapping(SampleTransientEntity.class, "mapping", "id", null);
-		assertThat(xContentBuilder.string(), is(expected));
+		assertThat(xContentBuilderToString(xContentBuilder), is(expected));
 	}
 
 	@Test
 	public void shouldUseValueFromAnnotationType() throws IOException {
-		//Given
+		// Given
 		final String expected = "{\"mapping\":{\"properties\":{\"price\":{\"store\":false,\"type\":\"double\"}}}}";
 
-		//When
+		// When
 		XContentBuilder xContentBuilder = MappingBuilder.buildMapping(StockPrice.class, "mapping", "id", null);
 
-		//Then
-		assertThat(xContentBuilder.string(), is(expected));
+		// Then
+		assertThat(xContentBuilderToString(xContentBuilder), is(expected));
 	}
 
 	@Test
 	public void shouldAddStockPriceDocumentToIndex() throws IOException {
-		//Given
+		// Given
 
-		//When
+		// When
 		elasticsearchTemplate.deleteIndex(StockPrice.class);
 		elasticsearchTemplate.createIndex(StockPrice.class);
 		elasticsearchTemplate.putMapping(StockPrice.class);
 		String symbol = "AU";
 		double price = 2.34;
 		String id = "abc";
-		elasticsearchTemplate.index(buildIndex(StockPrice.builder().id(id).symbol(symbol).price(new BigDecimal(price)).build()));
+		elasticsearchTemplate
+				.index(buildIndex(StockPrice.builder().id(id).symbol(symbol).price(new BigDecimal(price)).build()));
 		elasticsearchTemplate.refresh(StockPrice.class);
 
 		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
 		List<StockPrice> result = elasticsearchTemplate.queryForList(searchQuery, StockPrice.class);
-		//Then
+		// Then
 		assertThat(result.size(), is(1));
 		StockPrice entry = result.get(0);
 		assertThat(entry.getSymbol(), is(symbol));
@@ -110,7 +117,7 @@ public class MappingBuilderTests {
 	public void shouldCreateMappingForSpecifiedParentType() throws IOException {
 		final String expected = "{\"mapping\":{\"_parent\":{\"type\":\"parentType\"},\"properties\":{}}}";
 		XContentBuilder xContentBuilder = MappingBuilder.buildMapping(MinimalEntity.class, "mapping", "id", "parentType");
-		assertThat(xContentBuilder.string(), is(expected));
+		assertThat(xContentBuilderToString(xContentBuilder), is(expected));
 	}
 
 	/*
@@ -118,13 +125,12 @@ public class MappingBuilderTests {
 	 */
 	@Test
 	public void shouldBuildMappingWithSuperclass() throws IOException {
-		final String expected = "{\"mapping\":{\"properties\":{\"message\":{\"store\":true,\"" +
-				"type\":\"text\",\"index\":false,\"analyzer\":\"standard\"}" +
-				",\"createdDate\":{\"store\":false," +
-				"\"type\":\"date\",\"index\":false}}}}";
+		final String expected = "{\"mapping\":{\"properties\":{\"message\":{\"store\":true,\""
+				+ "type\":\"text\",\"index\":false,\"analyzer\":\"standard\"}" + ",\"createdDate\":{\"store\":false,"
+				+ "\"type\":\"date\",\"index\":false}}}}";
 
 		XContentBuilder xContentBuilder = MappingBuilder.buildMapping(SampleInheritedEntity.class, "mapping", "id", null);
-		assertThat(xContentBuilder.string(), is(expected));
+		assertThat(xContentBuilderToString(xContentBuilder), is(expected));
 	}
 
 	/*
@@ -132,21 +138,22 @@ public class MappingBuilderTests {
 	 */
 	@Test
 	public void shouldAddSampleInheritedEntityDocumentToIndex() throws IOException {
-		//Given
+		// Given
 
-		//When
+		// When
 		elasticsearchTemplate.deleteIndex(SampleInheritedEntity.class);
 		elasticsearchTemplate.createIndex(SampleInheritedEntity.class);
 		elasticsearchTemplate.putMapping(SampleInheritedEntity.class);
 		Date createdDate = new Date();
 		String message = "msg";
 		String id = "abc";
-		elasticsearchTemplate.index(new SampleInheritedEntityBuilder(id).createdDate(createdDate).message(message).buildIndex());
+		elasticsearchTemplate
+				.index(new SampleInheritedEntityBuilder(id).createdDate(createdDate).message(message).buildIndex());
 		elasticsearchTemplate.refresh(SampleInheritedEntity.class);
 
 		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
 		List<SampleInheritedEntity> result = elasticsearchTemplate.queryForList(searchQuery, SampleInheritedEntity.class);
-		//Then
+		// Then
 		assertThat(result.size(), is(1));
 		SampleInheritedEntity entry = result.get(0);
 		assertThat(entry.getCreatedDate(), is(createdDate));
@@ -155,13 +162,13 @@ public class MappingBuilderTests {
 
 	@Test
 	public void shouldBuildMappingsForGeoPoint() throws IOException {
-		//given
+		// given
 
-		//when
+		// when
 		XContentBuilder xContentBuilder = MappingBuilder.buildMapping(GeoEntity.class, "mapping", "id", null);
 
-		//then
-		final String result = xContentBuilder.string();
+		// then
+		final String result = xContentBuilderToString(xContentBuilder);
 
 		assertThat(result, containsString("\"pointA\":{\"type\":\"geo_point\""));
 		assertThat(result, containsString("\"pointB\":{\"type\":\"geo_point\""));
@@ -174,40 +181,40 @@ public class MappingBuilderTests {
 	 */
 	@Test
 	public void shouldHandleReverseRelationship() {
-		//given
+		// given
 		elasticsearchTemplate.createIndex(User.class);
 		elasticsearchTemplate.putMapping(User.class);
 		elasticsearchTemplate.createIndex(Group.class);
 		elasticsearchTemplate.putMapping(Group.class);
-		//when
+		// when
 
-		//then
+		// then
 
 	}
 
 	@Test
 	public void shouldMapBooks() {
-		//given
+		// given
 		elasticsearchTemplate.createIndex(Book.class);
 		elasticsearchTemplate.putMapping(Book.class);
-		//when
-		//then
+		// when
+		// then
 
 	}
 
 	@Test // DATAES-420
 	public void shouldUseBothAnalyzer() {
-		//given
+		// given
 		elasticsearchTemplate.deleteIndex(Book.class);
 		elasticsearchTemplate.createIndex(Book.class);
 		elasticsearchTemplate.putMapping(Book.class);
 
-		//when
+		// when
 		Map mapping = elasticsearchTemplate.getMapping(Book.class);
 		Map descriptionMapping = (Map) ((Map) mapping.get("properties")).get("description");
 		Map prefixDescription = (Map) ((Map) descriptionMapping.get("fields")).get("prefix");
 
-		//then
+		// then
 		assertThat(prefixDescription.size(), is(3));
 		assertThat(prefixDescription.get("type"), equalTo("text"));
 		assertThat(prefixDescription.get("analyzer"), equalTo("stop"));

--- a/src/test/java/org/springframework/data/elasticsearch/core/SimpleElasticsearchDateMappingTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/SimpleElasticsearchDateMappingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2014 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.springframework.data.elasticsearch.core;
 
 import java.beans.IntrospectionException;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -26,6 +27,7 @@ import org.springframework.data.elasticsearch.entities.SampleDateMappingEntity;
 /**
  * @author Jakub Vavrik
  * @author Mohsin Husen
+ * @author Don Wellington
  */
 public class SimpleElasticsearchDateMappingTests {
 
@@ -37,6 +39,9 @@ public class SimpleElasticsearchDateMappingTests {
 	@Test
 	public void testCorrectDateMappings() throws NoSuchFieldException, IntrospectionException, IOException {
 		XContentBuilder xContentBuilder = MappingBuilder.buildMapping(SampleDateMappingEntity.class, "mapping", "id", null);
-		Assert.assertEquals(EXPECTED_MAPPING, xContentBuilder.string());
+		xContentBuilder.close();
+		ByteArrayOutputStream bos = (ByteArrayOutputStream) xContentBuilder.getOutputStream();
+		String result = bos.toString();
+		Assert.assertEquals(EXPECTED_MAPPING, result);
 	}
 }

--- a/src/test/java/org/springframework/data/elasticsearch/repositories/CustomMethodRepositoryBaseTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repositories/CustomMethodRepositoryBaseTests.java
@@ -1,0 +1,1202 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.repositories;
+
+import static org.apache.commons.lang.RandomStringUtils.*;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.elasticsearch.core.ElasticsearchTemplate;
+import org.springframework.data.elasticsearch.core.geo.GeoPoint;
+import org.springframework.data.elasticsearch.entities.SampleEntity;
+import org.springframework.data.elasticsearch.repositories.custom.SampleCustomMethodRepository;
+import org.springframework.data.geo.Box;
+import org.springframework.data.geo.Distance;
+import org.springframework.data.geo.Metrics;
+import org.springframework.data.geo.Point;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Rizwan Idrees
+ * @author Mohsin Husen
+ * @author Franck Marchand
+ * @author Kevin Leturc
+ * @author Christoph Strobl
+ * @author Don Wellington
+ */
+
+public abstract class CustomMethodRepositoryBaseTests {
+
+	@Autowired private SampleCustomMethodRepository repository;
+
+	@Test
+	public void shouldExecuteCustomMethod() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setMessage("some message");
+		repository.save(sampleEntity);
+		// when
+		Page<SampleEntity> page = repository.findByType("test", new PageRequest(0, 10));
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(greaterThanOrEqualTo(1L)));
+	}
+
+	@Test
+	public void shouldExecuteCustomMethodForNot() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("some");
+		sampleEntity.setMessage("some message");
+		repository.save(sampleEntity);
+		// when
+		Page<SampleEntity> page = repository.findByTypeNot("test", new PageRequest(0, 10));
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(equalTo(1L)));
+	}
+
+	@Test
+	public void shouldExecuteCustomMethodWithQuery() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		String searchTerm = "customQuery";
+		sampleEntity.setMessage(searchTerm);
+		repository.save(sampleEntity);
+		// when
+		Page<SampleEntity> page = repository.findByMessage(searchTerm.toLowerCase(), new PageRequest(0, 10));
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(greaterThanOrEqualTo(1L)));
+	}
+
+	@Test
+	public void shouldExecuteCustomMethodWithLessThan() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(9);
+		sampleEntity.setMessage("some message");
+		repository.save(sampleEntity);
+
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId2);
+		sampleEntity2.setType("test");
+		sampleEntity2.setRate(20);
+		sampleEntity2.setMessage("some message");
+		repository.save(sampleEntity2);
+
+		// when
+		Page<SampleEntity> page = repository.findByRateLessThan(10, new PageRequest(0, 10));
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(equalTo(1L)));
+	}
+
+	@Test
+	public void shouldExecuteCustomMethodWithBefore() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(10);
+		sampleEntity.setMessage("some message");
+		repository.save(sampleEntity);
+
+		// when
+		Page<SampleEntity> page = repository.findByRateBefore(10, new PageRequest(0, 10));
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(equalTo(1L)));
+	}
+
+	@Test
+	public void shouldExecuteCustomMethodWithAfter() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(10);
+		sampleEntity.setMessage("some message");
+		repository.save(sampleEntity);
+
+		// when
+		Page<SampleEntity> page = repository.findByRateAfter(10, new PageRequest(0, 10));
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(equalTo(1L)));
+	}
+
+	@Test
+	public void shouldExecuteCustomMethodWithLike() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(10);
+		sampleEntity.setMessage("foo");
+		repository.save(sampleEntity);
+
+		// when
+		Page<SampleEntity> page = repository.findByMessageLike("fo", new PageRequest(0, 10));
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(equalTo(1L)));
+	}
+
+	@Test
+	public void shouldExecuteCustomMethodForStartingWith() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(10);
+		sampleEntity.setMessage("foo");
+		repository.save(sampleEntity);
+
+		// when
+		Page<SampleEntity> page = repository.findByMessageStartingWith("fo", new PageRequest(0, 10));
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(equalTo(1L)));
+	}
+
+	@Test
+	public void shouldExecuteCustomMethodForEndingWith() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(10);
+		sampleEntity.setMessage("foo");
+		repository.save(sampleEntity);
+
+		// when
+		Page<SampleEntity> page = repository.findByMessageEndingWith("o", new PageRequest(0, 10));
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(equalTo(1L)));
+	}
+
+	@Test
+	public void shouldExecuteCustomMethodForContains() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(10);
+		sampleEntity.setMessage("foo");
+		repository.save(sampleEntity);
+
+		// when
+		Page<SampleEntity> page = repository.findByMessageContaining("fo", new PageRequest(0, 10));
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(equalTo(1L)));
+	}
+
+	@Test
+	public void shouldExecuteCustomMethodForIn() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setMessage("foo");
+		repository.save(sampleEntity);
+
+		// given
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId2);
+		sampleEntity2.setType("test");
+		sampleEntity2.setMessage("bar");
+		repository.save(sampleEntity2);
+
+		List<String> ids = Arrays.asList(documentId, documentId2);
+
+		// when
+		Page<SampleEntity> page = repository.findByIdIn(ids, new PageRequest(0, 10));
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(equalTo(2L)));
+	}
+
+	@Test
+	public void shouldExecuteCustomMethodForNotIn() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setMessage("foo");
+		repository.save(sampleEntity);
+
+		// given
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId2);
+		sampleEntity2.setType("test");
+		sampleEntity2.setMessage("bar");
+		repository.save(sampleEntity2);
+
+		List<String> ids = Arrays.asList(documentId);
+
+		// when
+		Page<SampleEntity> page = repository.findByIdNotIn(ids, new PageRequest(0, 10));
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(equalTo(1L)));
+		assertThat(page.getContent().get(0).getId(), is(documentId2));
+	}
+
+	@Test
+	public void shouldExecuteCustomMethodForTrue() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setMessage("foo");
+		sampleEntity.setAvailable(true);
+		repository.save(sampleEntity);
+
+		// given
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId2);
+		sampleEntity2.setType("test");
+		sampleEntity2.setMessage("bar");
+		sampleEntity2.setAvailable(false);
+		repository.save(sampleEntity2);
+		// when
+		Page<SampleEntity> page = repository.findByAvailableTrue(new PageRequest(0, 10));
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(equalTo(1L)));
+	}
+
+	@Test
+	public void shouldExecuteCustomMethodForFalse() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setMessage("foo");
+		sampleEntity.setAvailable(true);
+		repository.save(sampleEntity);
+
+		// given
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId2);
+		sampleEntity2.setType("test");
+		sampleEntity2.setMessage("bar");
+		sampleEntity2.setAvailable(false);
+		repository.save(sampleEntity2);
+		// when
+		Page<SampleEntity> page = repository.findByAvailableFalse(new PageRequest(0, 10));
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(equalTo(1L)));
+	}
+
+	@Test
+	public void shouldExecuteCustomMethodForOrderBy() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("abc");
+		sampleEntity.setMessage("test");
+		sampleEntity.setAvailable(true);
+		repository.save(sampleEntity);
+
+		// document 2
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId2);
+		sampleEntity2.setType("xyz");
+		sampleEntity2.setMessage("bar");
+		sampleEntity2.setAvailable(false);
+		repository.save(sampleEntity2);
+
+		// document 3
+		String documentId3 = randomNumeric(5);
+		SampleEntity sampleEntity3 = new SampleEntity();
+		sampleEntity3.setId(documentId3);
+		sampleEntity3.setType("def");
+		sampleEntity3.setMessage("foo");
+		sampleEntity3.setAvailable(false);
+		repository.save(sampleEntity3);
+
+		// when
+		Page<SampleEntity> page = repository.findByMessageOrderByTypeAsc("foo", new PageRequest(0, 10));
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(equalTo(1L)));
+	}
+
+	@Test
+	public void shouldExecuteCustomMethodWithBooleanParameter() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setMessage("foo");
+		sampleEntity.setAvailable(true);
+		repository.save(sampleEntity);
+
+		// given
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId2);
+		sampleEntity2.setType("test");
+		sampleEntity2.setMessage("bar");
+		sampleEntity2.setAvailable(false);
+		repository.save(sampleEntity2);
+		// when
+		Page<SampleEntity> page = repository.findByAvailable(false, new PageRequest(0, 10));
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(equalTo(1L)));
+	}
+
+	@Test
+	public void shouldReturnPageableResultsWithQueryAnnotationExpectedPageSize() {
+		// given
+		for (int i = 0; i < 30; i++) {
+			String documentId = String.valueOf(i);
+			SampleEntity sampleEntity = new SampleEntity();
+			sampleEntity.setId(documentId);
+			sampleEntity.setMessage("message");
+			sampleEntity.setVersion(System.currentTimeMillis());
+			repository.save(sampleEntity);
+		}
+		// when
+		Page<SampleEntity> pageResult = repository.findByMessage("message", new PageRequest(0, 23));
+		// then
+		assertThat(pageResult.getTotalElements(), is(equalTo(30L)));
+		assertThat(pageResult.getContent().size(), is(equalTo(23)));
+	}
+
+	@Test
+	public void shouldReturnPageableResultsWithGivenSortingOrder() {
+		// given
+		String documentId = random(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setMessage("abc");
+		sampleEntity.setVersion(System.currentTimeMillis());
+		repository.save(sampleEntity);
+
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId2);
+		sampleEntity2.setMessage("abd");
+		sampleEntity.setVersion(System.currentTimeMillis());
+		repository.save(sampleEntity2);
+
+		String documentId3 = randomNumeric(5);
+		SampleEntity sampleEntity3 = new SampleEntity();
+		sampleEntity3.setId(documentId3);
+		sampleEntity3.setMessage("abe");
+		sampleEntity.setVersion(System.currentTimeMillis());
+		repository.save(sampleEntity3);
+		// when
+		Page<SampleEntity> pageResult = repository.findByMessageContaining("a",
+				new PageRequest(0, 23, new Sort(new Sort.Order(Sort.Direction.DESC, "message"))));
+		// then
+		assertThat(pageResult.getContent().isEmpty(), is(false));
+		assertThat(pageResult.getContent().get(0).getMessage(), is(sampleEntity3.getMessage()));
+	}
+
+	@Test
+	public void shouldReturnListForMessage() {
+		// given
+		String documentId = random(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setMessage("abc");
+		sampleEntity.setVersion(System.currentTimeMillis());
+		repository.save(sampleEntity);
+
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId2);
+		sampleEntity2.setMessage("abd");
+		sampleEntity.setVersion(System.currentTimeMillis());
+		repository.save(sampleEntity2);
+
+		String documentId3 = randomNumeric(5);
+		SampleEntity sampleEntity3 = new SampleEntity();
+		sampleEntity3.setId(documentId3);
+		sampleEntity3.setMessage("abe");
+		sampleEntity.setVersion(System.currentTimeMillis());
+		repository.save(sampleEntity3);
+		// when
+		List<SampleEntity> sampleEntities = repository.findByMessage("abc");
+		// then
+		assertThat(sampleEntities.isEmpty(), is(false));
+		assertThat(sampleEntities.size(), is(1));
+	}
+
+	@Test
+	public void shouldExecuteCustomMethodWithGeoPoint() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(10);
+		sampleEntity.setMessage("foo");
+		sampleEntity.setLocation(new GeoPoint(45.7806d, 3.0875d));
+
+		repository.save(sampleEntity);
+
+		// when
+		Page<SampleEntity> page = repository.findByLocation(new GeoPoint(45.7806d, 3.0875d), new PageRequest(0, 10));
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(equalTo(1L)));
+	}
+
+	@Test
+	public void shouldExecuteCustomMethodWithGeoPointAndString() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(10);
+		sampleEntity.setMessage("foo");
+		sampleEntity.setLocation(new GeoPoint(45.7806d, 3.0875d));
+
+		repository.save(sampleEntity);
+
+		documentId = randomNumeric(5);
+		sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(10);
+		sampleEntity.setMessage("foo");
+		sampleEntity.setLocation(new GeoPoint(48.7806d, 3.0875d));
+
+		repository.save(sampleEntity);
+
+		// when
+		Page<SampleEntity> page = repository.findByLocationAndMessage(new GeoPoint(45.7806d, 3.0875d), "foo",
+				new PageRequest(0, 10));
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(equalTo(1L)));
+	}
+
+	@Test
+	public void shouldExecuteCustomMethodWithWithinGeoPoint() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(10);
+		sampleEntity.setMessage("foo");
+		sampleEntity.setLocation(new GeoPoint(45.7806d, 3.0875d));
+
+		repository.save(sampleEntity);
+
+		// when
+		Page<SampleEntity> page = repository.findByLocationWithin(new GeoPoint(45.7806d, 3.0875d), "2km",
+				new PageRequest(0, 10));
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(equalTo(1L)));
+	}
+
+	@Test
+	public void shouldExecuteCustomMethodWithWithinPoint() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(10);
+		sampleEntity.setMessage("foo");
+		sampleEntity.setLocation(new GeoPoint(45.7806d, 3.0875d));
+
+		repository.save(sampleEntity);
+
+		// when
+		Page<SampleEntity> page = repository.findByLocationWithin(new Point(45.7806d, 3.0875d),
+				new Distance(2, Metrics.KILOMETERS), new PageRequest(0, 10));
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(equalTo(1L)));
+	}
+
+	@Test
+	public void shouldExecuteCustomMethodWithNearBox() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(10);
+		sampleEntity.setMessage("foo");
+		sampleEntity.setLocation(new GeoPoint(45.7806d, 3.0875d));
+
+		repository.save(sampleEntity);
+
+		documentId = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId);
+		sampleEntity2.setType("test2");
+		sampleEntity2.setRate(10);
+		sampleEntity2.setMessage("foo");
+		sampleEntity2.setLocation(new GeoPoint(30.7806d, 0.0875d));
+
+		repository.save(sampleEntity2);
+
+		// when
+		Page<SampleEntity> pageAll = repository.findAll(new PageRequest(0, 10));
+		// then
+		assertThat(pageAll, is(notNullValue()));
+		assertThat(pageAll.getTotalElements(), is(equalTo(2L)));
+
+		// when
+		Page<SampleEntity> page = repository.findByLocationNear(new Box(new Point(46d, 3d), new Point(45d, 4d)),
+				new PageRequest(0, 10));
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(equalTo(1L)));
+	}
+
+	@Test
+	public void shouldExecuteCustomMethodWithNearPointAndDistance() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(10);
+		sampleEntity.setMessage("foo");
+		sampleEntity.setLocation(new GeoPoint(45.7806d, 3.0875d));
+
+		repository.save(sampleEntity);
+
+		// when
+		Page<SampleEntity> page = repository.findByLocationNear(new Point(45.7806d, 3.0875d),
+				new Distance(2, Metrics.KILOMETERS), new PageRequest(0, 10));
+		// then
+		assertThat(page, is(notNullValue()));
+		assertThat(page.getTotalElements(), is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-165
+	 */
+	@Test
+	public void shouldAllowReturningJava8StreamInCustomQuery() {
+		// given
+		List<SampleEntity> entities = createSampleEntities("abc", 30);
+		repository.saveAll(entities);
+
+		// when
+		Stream<SampleEntity> stream = repository.findByType("abc");
+		// then
+		assertThat(stream, is(notNullValue()));
+		assertThat(stream.count(), is(equalTo(30L)));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldCountCustomMethod() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setMessage("some message");
+
+		repository.save(sampleEntity);
+
+		documentId = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId);
+		sampleEntity2.setType("test2");
+		sampleEntity2.setMessage("some message");
+
+		repository.save(sampleEntity2);
+
+		// when
+		long count = repository.countByType("test");
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldCountCustomMethodForNot() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("some");
+		sampleEntity.setMessage("some message");
+
+		repository.save(sampleEntity);
+
+		documentId = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId);
+		sampleEntity2.setType("test");
+		sampleEntity2.setMessage("some message");
+
+		repository.save(sampleEntity2);
+
+		// when
+		long count = repository.countByTypeNot("test");
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldCountCustomMethodWithBooleanParameter() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setMessage("foo");
+		sampleEntity.setAvailable(true);
+		repository.save(sampleEntity);
+
+		// given
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId2);
+		sampleEntity2.setType("test");
+		sampleEntity2.setMessage("bar");
+		sampleEntity2.setAvailable(false);
+		repository.save(sampleEntity2);
+		// when
+		long count = repository.countByAvailable(false);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldCountCustomMethodWithLessThan() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(9);
+		sampleEntity.setMessage("some message");
+		repository.save(sampleEntity);
+
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId2);
+		sampleEntity2.setType("test");
+		sampleEntity2.setRate(20);
+		sampleEntity2.setMessage("some message");
+		repository.save(sampleEntity2);
+
+		// when
+		long count = repository.countByRateLessThan(10);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldCountCustomMethodWithBefore() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(10);
+		sampleEntity.setMessage("some message");
+
+		repository.save(sampleEntity);
+
+		documentId = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId);
+		sampleEntity2.setType("test");
+		sampleEntity2.setRate(20);
+		sampleEntity2.setMessage("some message");
+
+		repository.save(sampleEntity2);
+
+		// when
+		long count = repository.countByRateBefore(10);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldCountCustomMethodWithAfter() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(10);
+		sampleEntity.setMessage("some message");
+
+		repository.save(sampleEntity);
+
+		documentId = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId);
+		sampleEntity2.setType("test");
+		sampleEntity2.setRate(0);
+		sampleEntity2.setMessage("some message");
+
+		repository.save(sampleEntity2);
+
+		// when
+		long count = repository.countByRateAfter(10);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldCountCustomMethodWithLike() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(10);
+		sampleEntity.setMessage("foo");
+
+		repository.save(sampleEntity);
+
+		documentId = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId);
+		sampleEntity2.setType("test");
+		sampleEntity2.setRate(10);
+		sampleEntity2.setMessage("some message");
+
+		repository.save(sampleEntity2);
+
+		// when
+		long count = repository.countByMessageLike("fo");
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldCountCustomMethodForStartingWith() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(10);
+		sampleEntity.setMessage("foo");
+
+		repository.save(sampleEntity);
+
+		documentId = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId);
+		sampleEntity2.setType("test");
+		sampleEntity2.setRate(10);
+		sampleEntity2.setMessage("some message");
+
+		repository.save(sampleEntity2);
+
+		// when
+		long count = repository.countByMessageStartingWith("fo");
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldCountCustomMethodForEndingWith() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(10);
+		sampleEntity.setMessage("foo");
+
+		repository.save(sampleEntity);
+
+		documentId = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId);
+		sampleEntity2.setType("test");
+		sampleEntity2.setRate(10);
+		sampleEntity2.setMessage("some message");
+
+		repository.save(sampleEntity2);
+
+		// when
+		long count = repository.countByMessageEndingWith("o");
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldCountCustomMethodForContains() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(10);
+		sampleEntity.setMessage("foo");
+
+		repository.save(sampleEntity);
+
+		documentId = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId);
+		sampleEntity2.setType("test");
+		sampleEntity2.setRate(10);
+		sampleEntity2.setMessage("some message");
+
+		repository.save(sampleEntity2);
+
+		// when
+		long count = repository.countByMessageContaining("fo");
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldCountCustomMethodForIn() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setMessage("foo");
+		repository.save(sampleEntity);
+
+		// given
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId2);
+		sampleEntity2.setType("test");
+		sampleEntity2.setMessage("bar");
+		repository.save(sampleEntity2);
+
+		List<String> ids = Arrays.asList(documentId, documentId2);
+
+		// when
+		long count = repository.countByIdIn(ids);
+		// then
+		assertThat(count, is(equalTo(2L)));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldCountCustomMethodForNotIn() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setMessage("foo");
+		repository.save(sampleEntity);
+
+		// given
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId2);
+		sampleEntity2.setType("test");
+		sampleEntity2.setMessage("bar");
+		repository.save(sampleEntity2);
+
+		List<String> ids = Arrays.asList(documentId);
+
+		// when
+		long count = repository.countByIdNotIn(ids);
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldCountCustomMethodForTrue() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setMessage("foo");
+		sampleEntity.setAvailable(true);
+		repository.save(sampleEntity);
+
+		// given
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId2);
+		sampleEntity2.setType("test");
+		sampleEntity2.setMessage("bar");
+		sampleEntity2.setAvailable(false);
+		repository.save(sampleEntity2);
+		// when
+		long count = repository.countByAvailableTrue();
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldCountCustomMethodForFalse() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setMessage("foo");
+		sampleEntity.setAvailable(true);
+		repository.save(sampleEntity);
+
+		// given
+		String documentId2 = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId2);
+		sampleEntity2.setType("test");
+		sampleEntity2.setMessage("bar");
+		sampleEntity2.setAvailable(false);
+		repository.save(sampleEntity2);
+		// when
+		long count = repository.countByAvailableFalse();
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldCountCustomMethodWithWithinGeoPoint() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(10);
+		sampleEntity.setMessage("foo");
+		sampleEntity.setLocation(new GeoPoint(45.7806d, 3.0875d));
+
+		repository.save(sampleEntity);
+
+		documentId = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId);
+		sampleEntity2.setType("test");
+		sampleEntity2.setRate(10);
+		sampleEntity2.setMessage("foo");
+		sampleEntity2.setLocation(new GeoPoint(30.7806d, 0.0875d));
+
+		repository.save(sampleEntity2);
+
+		// when
+		long count = repository.countByLocationWithin(new GeoPoint(45.7806d, 3.0875d), "2km");
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldCountCustomMethodWithWithinPoint() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(10);
+		sampleEntity.setMessage("foo");
+		sampleEntity.setLocation(new GeoPoint(45.7806d, 3.0875d));
+
+		repository.save(sampleEntity);
+
+		documentId = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId);
+		sampleEntity2.setType("test");
+		sampleEntity2.setRate(10);
+		sampleEntity2.setMessage("foo");
+		sampleEntity2.setLocation(new GeoPoint(30.7806d, 0.0875d));
+
+		repository.save(sampleEntity2);
+
+		// when
+		long count = repository.countByLocationWithin(new Point(45.7806d, 3.0875d), new Distance(2, Metrics.KILOMETERS));
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldCountCustomMethodWithNearBox() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(10);
+		sampleEntity.setMessage("foo");
+		sampleEntity.setLocation(new GeoPoint(45.7806d, 3.0875d));
+
+		repository.save(sampleEntity);
+
+		documentId = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId);
+		sampleEntity2.setType("test2");
+		sampleEntity2.setRate(10);
+		sampleEntity2.setMessage("foo");
+		sampleEntity2.setLocation(new GeoPoint(30.7806d, 0.0875d));
+
+		repository.save(sampleEntity2);
+
+		// when
+		long count = repository.countByLocationNear(new Box(new Point(46d, 3d), new Point(45d, 4d)));
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	/*
+	DATAES-106
+	 */
+	@Test
+	public void shouldCountCustomMethodWithNearPointAndDistance() {
+		// given
+		String documentId = randomNumeric(5);
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setId(documentId);
+		sampleEntity.setType("test");
+		sampleEntity.setRate(10);
+		sampleEntity.setMessage("foo");
+		sampleEntity.setLocation(new GeoPoint(45.7806d, 3.0875d));
+
+		repository.save(sampleEntity);
+
+		documentId = randomNumeric(5);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId);
+		sampleEntity2.setType("test");
+		sampleEntity2.setRate(10);
+		sampleEntity2.setMessage("foo");
+		sampleEntity2.setLocation(new GeoPoint(30.7806d, 0.0875d));
+
+		repository.save(sampleEntity2);
+
+		// when
+		long count = repository.countByLocationNear(new Point(45.7806d, 3.0875d), new Distance(2, Metrics.KILOMETERS));
+		// then
+		assertThat(count, is(equalTo(1L)));
+	}
+
+	private List<SampleEntity> createSampleEntities(String type, int numberOfEntities) {
+		List<SampleEntity> entities = new ArrayList<>();
+		for (int i = 0; i < numberOfEntities; i++) {
+			SampleEntity entity = new SampleEntity();
+			entity.setId(randomNumeric(numberOfEntities));
+			entity.setAvailable(true);
+			entity.setMessage("Message");
+			entity.setType(type);
+			entities.add(entity);
+		}
+		return entities;
+	}
+}

--- a/src/test/java/org/springframework/data/elasticsearch/repositories/CustomMethodRepositoryRestTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repositories/CustomMethodRepositoryRestTests.java
@@ -12,13 +12,12 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
-package org.springframework.data.elasticsearch.repositories;
+ */package org.springframework.data.elasticsearch.repositories;
 
 import org.junit.Before;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.elasticsearch.core.ElasticsearchTemplate;
+import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate;
 import org.springframework.data.elasticsearch.entities.SampleEntity;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -29,9 +28,9 @@ import org.springframework.test.context.junit4.SpringRunner;
  *
  */
 @RunWith(SpringRunner.class)
-@ContextConfiguration("classpath:custom-method-repository-test.xml")
-public class CustomMethodRepositoryTests extends CustomMethodRepositoryBaseTests {
-	@Autowired private ElasticsearchTemplate elasticsearchTemplate;
+@ContextConfiguration("classpath:custom-method-repository-rest-test.xml")
+public class CustomMethodRepositoryRestTests extends CustomMethodRepositoryBaseTests {
+	@Autowired private ElasticsearchRestTemplate elasticsearchTemplate;
 
 	@Before
 	public void before() {

--- a/src/test/resources/custom-method-repository-rest-test.xml
+++ b/src/test/resources/custom-method-repository-rest-test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:elasticsearch="http://www.springframework.org/schema/data/elasticsearch"
+       xsi:schemaLocation="http://www.springframework.org/schema/data/elasticsearch http://www.springframework.org/schema/data/elasticsearch/spring-elasticsearch-1.0.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+
+    <import resource="elasticsearch-rest-template-test.xml"/>
+
+    <elasticsearch:repositories
+            base-package="org.springframework.data.elasticsearch.repositories.custom"/>
+
+</beans>

--- a/src/test/resources/elasticsearch-rest-template-test.xml
+++ b/src/test/resources/elasticsearch-rest-template-test.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:elasticsearch="http://www.springframework.org/schema/data/elasticsearch"
+       xsi:schemaLocation="http://www.springframework.org/schema/data/elasticsearch http://www.springframework.org/schema/data/elasticsearch/spring-elasticsearch.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <import resource="infrastructure.xml"/>
+
+    <bean name="elasticsearchTemplate"
+          class="org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate">
+        <constructor-arg name="client" ref="restClient"/>
+    </bean>
+    
+    <elasticsearch:rest-client id="restClient"/>
+
+</beans>

--- a/src/test/resources/infrastructure.xml
+++ b/src/test/resources/infrastructure.xml
@@ -6,7 +6,7 @@
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <elasticsearch:node-client id="client" local="true" cluster-name="#{T(java.util.UUID).randomUUID().toString()}"
-                               http-enabled="false" path-data="target/elasticsearchTestData" path-home="src/test/resources/test-home-dir"
+                               http-enabled="true" path-data="target/elasticsearchTestData" path-home="src/test/resources/test-home-dir"
                                path-configuration="node-client-configuration.yml"/>
 
     <!-- ip4 -->

--- a/src/test/resources/org/springframework/data/elasticsearch/config/namespace.xml
+++ b/src/test/resources/org/springframework/data/elasticsearch/config/namespace.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:elasticsearch="http://www.springframework.org/schema/data/elasticsearch"
-       xsi:schemaLocation="http://www.springframework.org/schema/data/elasticsearch http://www.springframework.org/schema/data/elasticsearch/spring-elasticsearch-1.0.xsd
+       xsi:schemaLocation="http://www.springframework.org/schema/data/elasticsearch http://www.springframework.org/schema/data/elasticsearch/spring-elasticsearch-1.1.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <elasticsearch:node-client id="client" local="true"
@@ -18,5 +18,7 @@
 
     <elasticsearch:repositories
             base-package="org.springframework.data.elasticsearch.repositories.sample"/>
+    
+    <elasticsearch:rest-client id="restClient"/>
 
 </beans>

--- a/src/test/resources/test-home-dir/modules/lang-expression/plugin-descriptor.properties
+++ b/src/test/resources/test-home-dir/modules/lang-expression/plugin-descriptor.properties
@@ -37,7 +37,7 @@ classname=org.elasticsearch.script.expression.ExpressionPlugin
 java.version=1.8
 #
 # 'elasticsearch.version': version of elasticsearch compiled against
-elasticsearch.version=6.2.2
+elasticsearch.version=6.3.0
 ### optional elements for plugins:
 #
 #  'extended.plugins': other plugins this plugin extends through SPI
@@ -47,4 +47,4 @@ extended.plugins=
 has.native.controller=false
 #
 # 'requires.keystore': whether or not the plugin needs the elasticsearch keystore be created
-requires.keystore=false
+#requires.keystore=false


### PR DESCRIPTION
Added an ElasticsearchRestTemplate and support for XML configuration of HighLevelRestClient.

ElasticSearchOperations no longer has getClient(). So, that will be a breaking change if anyone uses it.

Inclusive of changes for DATAES-468, since that pull request isn't accepted and I neglected to baseline DATAES-407 work on that branch and my git history go screwed up, so it is all squashed into here.

I decided to set the infrastructure.xml node client to http-enabled=true and import it for rest client tests. I am a little worried that we may need to do something to check for an unused port and assign appropriately for 100% reliability, and propagate that to the rest client configuration.  I don't know anything about the build server to know if there is a chance of port collision. Two branches of spring-data-elasticsearch on the same build agent?  Maybe for another day...

I altered CustomMethodRepositoryTest to do a test with both the old ElasticsearchTemplate and ElasticsearchRestTemplate to double check compatibility of the ElasticsearchRestTemplate. I didn't think doubling up all the repository tests was worth the effort.

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
