### PR TITLE
DATAES-492 - Add missing normalizer property to @Field and @InnerField.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/annotations/Field.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/Field.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,8 @@ public @interface Field {
 	String searchAnalyzer() default "";
 
 	String analyzer() default "";
+
+	String normalizer() default "";
 
 	String[] ignoreFields() default {};
 

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/InnerField.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/InnerField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- *
+ * @author Artur Konczak
+ * @author Mohsin Husen
+ * @author Sascha Woo
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
@@ -44,4 +46,6 @@ public @interface InnerField {
 	String searchAnalyzer() default "";
 
 	String analyzer() default "";
+
+	String normalizer() default "";
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/MappingBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/MappingBuilder.java
@@ -63,6 +63,7 @@ class MappingBuilder {
 	public static final String FIELD_FORMAT = "format";
 	public static final String FIELD_SEARCH_ANALYZER = "search_analyzer";
 	public static final String FIELD_INDEX_ANALYZER = "analyzer";
+	public static final String FIELD_NORMALIZER = "normalizer";
 	public static final String FIELD_PROPERTIES = "properties";
 	public static final String FIELD_PARENT = "_parent";
 
@@ -269,6 +270,7 @@ class MappingBuilder {
 		String datePattern = null;
 		String analyzer = null;
 		String searchAnalyzer = null;
+		String normalizer = null;
 
 		if (annotation instanceof Field) {
 			// @Field
@@ -281,6 +283,7 @@ class MappingBuilder {
 			datePattern = fieldAnnotation.pattern();
 			analyzer = fieldAnnotation.analyzer();
 			searchAnalyzer = fieldAnnotation.searchAnalyzer();
+			normalizer = fieldAnnotation.normalizer();
 		} else if (annotation instanceof InnerField) {
 			// @InnerField
 			InnerField fieldAnnotation = (InnerField) annotation;
@@ -292,6 +295,7 @@ class MappingBuilder {
 			datePattern = fieldAnnotation.pattern();
 			analyzer = fieldAnnotation.analyzer();
 			searchAnalyzer = fieldAnnotation.searchAnalyzer();
+			normalizer = fieldAnnotation.normalizer();
 		} else {
 			throw new IllegalArgumentException("annotation must be an instance of @Field or @InnerField");
 		}
@@ -317,6 +321,9 @@ class MappingBuilder {
 		}
 		if (!StringUtils.isEmpty(searchAnalyzer)) {
 			builder.field(FIELD_SEARCH_ANALYZER, searchAnalyzer);
+		}
+		if (!StringUtils.isEmpty(normalizer)) {
+			builder.field(FIELD_NORMALIZER, normalizer);
 		}
 	}
 

--- a/src/test/java/org/springframework/data/elasticsearch/core/MappingBuilderTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/MappingBuilderTests.java
@@ -47,6 +47,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Keivn Leturc
  * @author Nordine Bittich
  * @author Don Wellington
+ * @author Sascha Woo
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("classpath:elasticsearch-template-test.xml")
@@ -221,5 +222,26 @@ public class MappingBuilderTests {
 		assertThat(prefixDescription.get("search_analyzer"), equalTo("standard"));
 		assertThat(descriptionMapping.get("type"), equalTo("text"));
 		assertThat(descriptionMapping.get("analyzer"), equalTo("whitespace"));
+	}
+
+	@Test // DATAES-492
+	public void shouldUseKeywordNormalizer() throws IOException {
+
+		// given
+		elasticsearchTemplate.deleteIndex(NormalizerEntity.class);
+		elasticsearchTemplate.createIndex(NormalizerEntity.class);
+		elasticsearchTemplate.putMapping(NormalizerEntity.class);
+
+		// when
+		Map mapping = elasticsearchTemplate.getMapping(NormalizerEntity.class);
+		Map properties = (Map) mapping.get("properties");
+		Map fieldName = (Map) properties.get("name");
+		Map fieldDescriptionLowerCase = (Map) ((Map) ((Map) properties.get("description")).get("fields")).get("lower_case");
+
+		// then
+		assertThat(fieldName.get("type"), equalTo("keyword"));
+		assertThat(fieldName.get("normalizer"), equalTo("lower_case_normalizer"));
+		assertThat(fieldDescriptionLowerCase.get("type"), equalTo("keyword"));
+		assertThat(fieldDescriptionLowerCase.get("normalizer"), equalTo("lower_case_normalizer"));
 	}
 }

--- a/src/test/java/org/springframework/data/elasticsearch/entities/NormalizerEntity.java
+++ b/src/test/java/org/springframework/data/elasticsearch/entities/NormalizerEntity.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.entities;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.InnerField;
+import org.springframework.data.elasticsearch.annotations.MultiField;
+import org.springframework.data.elasticsearch.annotations.Setting;
+
+/**
+ * @author Sascha Woo
+ */
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Document(indexName = "test-index-normalizer", type = "test", shards = 1, replicas = 0, refreshInterval = "-1")
+@Setting(settingPath = "/settings/test-normalizer.json")
+public class NormalizerEntity {
+
+	@Id private String id;
+
+	@Field(type = FieldType.Keyword, normalizer = "lower_case_normalizer")
+	private String name;
+
+	@MultiField(mainField = @Field(type = FieldType.Text), otherFields = { @InnerField(suffix = "lower_case",
+			type = FieldType.Keyword, normalizer = "lower_case_normalizer") })
+	private String description;
+}

--- a/src/test/resources/settings/test-normalizer.json
+++ b/src/test/resources/settings/test-normalizer.json
@@ -1,0 +1,13 @@
+{
+	"index": {
+		"analysis": {
+			"normalizer": {
+				"lower_case_normalizer": {
+					"type": "custom",
+					"char_filter": [],
+					"filter": [ "lowercase" ]
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
At the moment there is no way to configure a normalizer [1] in `@Field` and `@InnerField`. There is already a stackoverflow issue [2] for this limitation.

[1] https://www.elastic.co/guide/en/elasticsearch/reference/current/normalizer.html
[2] https://stackoverflow.com/questions/46084660/spring-data-elasticsearch-create-keyword-field-with-normalizer

Related Jira Issue: https://jira.spring.io/browse/DATAES-492
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
