### PR TITLE
DATAES-494 - ElasticTemplates refactoring.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/AbstractElasticTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/AbstractElasticTemplate.java
@@ -15,6 +15,16 @@
  */
 package org.springframework.data.elasticsearch.core;
 
+import static org.elasticsearch.client.Requests.*;
+import static org.elasticsearch.index.query.QueryBuilders.*;
+import static org.springframework.data.elasticsearch.core.MappingBuilder.*;
+import static org.springframework.util.CollectionUtils.isEmpty;
+import static org.springframework.util.StringUtils.*;
+
+import java.io.*;
+import java.util.*;
+import java.util.stream.*;
+
 import org.elasticsearch.action.admin.indices.create.*;
 import org.elasticsearch.action.admin.indices.refresh.*;
 import org.elasticsearch.action.get.*;
@@ -42,16 +52,6 @@ import org.springframework.data.elasticsearch.core.query.Query;
 import org.springframework.data.elasticsearch.core.utils.*;
 import org.springframework.data.util.*;
 import org.springframework.util.*;
-
-import java.io.*;
-import java.util.*;
-import java.util.stream.*;
-
-import static org.elasticsearch.client.Requests.*;
-import static org.elasticsearch.index.query.QueryBuilders.*;
-import static org.springframework.data.elasticsearch.core.MappingBuilder.*;
-import static org.springframework.util.CollectionUtils.isEmpty;
-import static org.springframework.util.StringUtils.*;
 
 /**
  * @author Nikita Guchakov

--- a/src/main/java/org/springframework/data/elasticsearch/core/AbstractElasticTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/AbstractElasticTemplate.java
@@ -1,0 +1,592 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core;
+
+import org.elasticsearch.action.admin.indices.create.*;
+import org.elasticsearch.action.admin.indices.refresh.*;
+import org.elasticsearch.action.get.*;
+import org.elasticsearch.action.search.*;
+import org.elasticsearch.client.*;
+import org.elasticsearch.common.*;
+import org.elasticsearch.common.collect.*;
+import org.elasticsearch.common.unit.*;
+import org.elasticsearch.common.xcontent.*;
+import org.elasticsearch.index.query.*;
+import org.elasticsearch.search.*;
+import org.elasticsearch.search.fetch.subphase.highlight.*;
+import org.elasticsearch.search.sort.*;
+import org.elasticsearch.search.suggest.*;
+import org.slf4j.*;
+import org.springframework.context.*;
+import org.springframework.data.domain.*;
+import org.springframework.data.elasticsearch.*;
+import org.springframework.data.elasticsearch.annotations.*;
+import org.springframework.data.elasticsearch.core.aggregation.*;
+import org.springframework.data.elasticsearch.core.convert.*;
+import org.springframework.data.elasticsearch.core.mapping.*;
+import org.springframework.data.elasticsearch.core.query.*;
+import org.springframework.data.elasticsearch.core.query.Query;
+import org.springframework.data.elasticsearch.core.utils.*;
+import org.springframework.data.util.*;
+import org.springframework.util.*;
+
+import java.io.*;
+import java.util.*;
+import java.util.stream.*;
+
+import static org.elasticsearch.client.Requests.*;
+import static org.elasticsearch.index.query.QueryBuilders.*;
+import static org.springframework.data.elasticsearch.core.MappingBuilder.*;
+import static org.springframework.util.CollectionUtils.isEmpty;
+import static org.springframework.util.StringUtils.*;
+
+/**
+ * @author Nikita Guchakov
+ */
+public abstract class AbstractElasticTemplate implements ElasticsearchOperations, ApplicationContextAware {
+	private static final Logger log = LoggerFactory.getLogger(AbstractElasticTemplate.class);
+	private static final String FIELD_SCORE = "_score";
+
+	private final ResultsMapper resultsMapper;
+	private ElasticsearchConverter elasticsearchConverter;
+
+	AbstractElasticTemplate(ElasticsearchConverter elasticsearchConverter, ResultsMapper resultsMapper) {
+		Assert.notNull(elasticsearchConverter, "ElasticsearchConverter must not be null!");
+		this.elasticsearchConverter = elasticsearchConverter;
+		Assert.notNull(resultsMapper, "ResultsMapper must not be null!");
+		this.resultsMapper = resultsMapper;
+	}
+
+	@Deprecated // use ClassPathUtils.readFileFromClasspath directly
+	public static String readFileFromClasspath(String url) {
+		return ClassPathUtils.readFileFromClasspath(url);
+	}
+
+	@Override
+	public boolean createIndex(String indexName) {
+		Assert.notNull(indexName, "No index defined for Query");
+		try {
+			return createIndex(Requests.createIndexRequest(indexName));
+		} catch (Exception e) {
+			throw new ElasticsearchException("Failed to create index " + indexName, e);
+		}
+	}
+
+	@Override
+	public <T> boolean createIndex(Class<T> clazz) {
+		return createIndexIfNotCreated(clazz);
+	}
+
+	abstract boolean createIndex(CreateIndexRequest indexRequest) throws IOException;
+
+	@Override
+	public <T> boolean putMapping(Class<T> clazz) {
+		if (clazz.isAnnotationPresent(Mapping.class)) {
+			String mappingPath = clazz.getAnnotation(Mapping.class).mappingPath();
+			if (!StringUtils.isEmpty(mappingPath)) {
+				String mappings = ClassPathUtils.readFileFromClasspath(mappingPath);
+				if (!StringUtils.isEmpty(mappings)) {
+					return putMapping(clazz, mappings);
+				}
+			}
+		}
+
+		log.info("mappingPath in @Mapping has to be defined. Building mappings using @Field");
+		ElasticsearchPersistentEntity<T> persistentEntity = getPersistentEntityFor(clazz);
+		try {
+			ElasticsearchPersistentProperty property = persistentEntity.getRequiredIdProperty();
+			XContentBuilder xContentBuilder = buildMapping(clazz, persistentEntity.getIndexType(), property.getFieldName(),
+					persistentEntity.getParentType());
+			return putMapping(clazz, xContentBuilder);
+		} catch (Exception e) {
+			throw new ElasticsearchException("Failed to build mapping for " + clazz.getSimpleName(), e);
+		}
+	}
+
+	@Override
+	public <T> boolean putMapping(Class<T> clazz, Object mapping) {
+		return putMapping(getPersistentEntityFor(clazz).getIndexName(), getPersistentEntityFor(clazz).getIndexType(),
+				mapping);
+	}
+
+	@Override
+	public <T> Map getMapping(Class<T> clazz) {
+		return getMapping(getPersistentEntityFor(clazz).getIndexName(), getPersistentEntityFor(clazz).getIndexType());
+	}
+
+	@Override
+	public ElasticsearchConverter getElasticsearchConverter() {
+		return elasticsearchConverter;
+	}
+
+	@Override
+	public <T> T queryForObject(GetQuery query, Class<T> clazz) {
+		return queryForObject(query, clazz, resultsMapper);
+	}
+
+	@Override
+	public <T> T queryForObject(GetQuery query, Class<T> clazz, GetResultMapper mapper) {
+		ElasticsearchPersistentEntity<T> persistentEntity = getPersistentEntityFor(clazz);
+		GetResponse response = queryForObject(query, persistentEntity.getIndexName(), persistentEntity.getIndexType());
+		return mapper.mapResult(response, clazz);
+	}
+
+	@Override
+	public <T> T queryForObject(CriteriaQuery query, Class<T> clazz) {
+		Page<T> page = queryForPage(query, clazz);
+		Assert.isTrue(page.getTotalElements() < 2, "Expected 1 but found " + page.getTotalElements() + " results");
+		return page.getTotalElements() > 0 ? page.getContent().get(0) : null;
+	}
+
+	@Override
+	public <T> Page<T> queryForPage(StringQuery query, Class<T> clazz) {
+		return queryForPage(query, clazz, resultsMapper);
+	}
+
+	@Override
+	public <T> AggregatedPage<T> queryForPage(SearchQuery query, Class<T> clazz) {
+		return queryForPage(query, clazz, resultsMapper);
+	}
+
+	@Override
+	public <T> T queryForObject(StringQuery query, Class<T> clazz) {
+		Page<T> page = queryForPage(query, clazz);
+		Assert.isTrue(page.getTotalElements() < 2, "Expected 1 but found " + page.getTotalElements() + " results");
+		return page.getTotalElements() > 0 ? page.getContent().get(0) : null;
+	}
+
+	@Override
+	public abstract <T> AggregatedPage<T> queryForPage(SearchQuery query, Class<T> clazz,
+			SearchResultMapper resultsMapper);
+
+	@Override
+	public <T> List<T> queryForList(CriteriaQuery query, Class<T> clazz) {
+		return queryForPage(query, clazz).getContent();
+	}
+
+	@Override
+	public <T> List<T> queryForList(StringQuery query, Class<T> clazz) {
+		return queryForPage(query, clazz).getContent();
+	}
+
+	@Override
+	public <T> List<T> queryForList(SearchQuery query, Class<T> clazz) {
+		return queryForPage(query, clazz).getContent();
+	}
+
+	@Override
+	public <T> CloseableIterator<T> stream(CriteriaQuery query, Class<T> clazz) {
+		final long scrollTimeInMillis = TimeValue.timeValueMinutes(1).millis();
+		return doStream(scrollTimeInMillis, (ScrolledPage<T>) startScroll(scrollTimeInMillis, query, clazz), clazz,
+				resultsMapper);
+	}
+
+	@Override
+	public <T> CloseableIterator<T> stream(SearchQuery query, Class<T> clazz) {
+		return stream(query, clazz, resultsMapper);
+	}
+
+	@Override
+	public <T> CloseableIterator<T> stream(SearchQuery query, final Class<T> clazz, final SearchResultMapper mapper) {
+		final long scrollTimeInMillis = TimeValue.timeValueMinutes(1).millis();
+		return doStream(scrollTimeInMillis, (ScrolledPage<T>) startScroll(scrollTimeInMillis, query, clazz, mapper), clazz,
+				mapper);
+	}
+
+	private <T> CloseableIterator<T> doStream(final long scrollTimeInMillis, final ScrolledPage<T> page,
+			final Class<T> clazz, final SearchResultMapper mapper) {
+		return new PageIterator<>(page,
+				nextScrollId -> (ScrolledPage<T>) continueScroll(nextScrollId, scrollTimeInMillis, clazz, mapper),
+				this::clearScroll);
+	}
+
+	@Override
+	public <T> void refresh(Class<T> clazz) {
+		refresh(getPersistentEntityFor(clazz).getIndexName());
+	}
+
+	@Override
+	public void refresh(String indexName) {
+		Assert.notNull(indexName, "No index defined for refresh()");
+		refresh(refreshRequest(indexName));
+	}
+
+	HighlightBuilder highlightFromQuery(SearchQuery searchQuery) {
+		HighlightBuilder highlightBuilder = searchQuery.getHighlightBuilder();
+		if (highlightBuilder == null) {
+			highlightBuilder = new HighlightBuilder();
+		}
+		if (searchQuery.getHighlightFields() == null) {
+			return highlightBuilder;
+		}
+		for (HighlightBuilder.Field highlightField : searchQuery.getHighlightFields()) {
+			highlightBuilder.field(highlightField);
+		}
+		return highlightBuilder;
+	}
+
+	SortBuilder toSortBuilder(Sort.Order order) {
+		SortOrder sortOrder = order.getDirection().isDescending() ? SortOrder.DESC : SortOrder.ASC;
+		if (FIELD_SCORE.equals(order.getProperty())) {
+			return SortBuilders.scoreSort().order(sortOrder);
+		} else {
+			FieldSortBuilder fieldSortBuilder = SortBuilders.fieldSort(order.getProperty()).order(sortOrder);
+
+			if (order.getNullHandling() == Sort.NullHandling.NULLS_FIRST) {
+				fieldSortBuilder.missing("_first");
+			} else if (order.getNullHandling() == Sort.NullHandling.NULLS_LAST) {
+				fieldSortBuilder.missing("_last");
+			}
+			return fieldSortBuilder;
+		}
+	}
+
+	@Override
+	public <T> Page<T> moreLikeThis(MoreLikeThisQuery query, Class<T> clazz) {
+
+		ElasticsearchPersistentEntity persistentEntity = getPersistentEntityFor(clazz);
+		String indexName = StringUtils.isEmpty(query.getIndexName()) ? persistentEntity.getIndexName()
+				: query.getIndexName();
+		String type = StringUtils.isEmpty(query.getType()) ? persistentEntity.getIndexType() : query.getType();
+
+		Assert.notNull(indexName, "No 'indexName' defined for MoreLikeThisQuery");
+		Assert.notNull(type, "No 'type' defined for MoreLikeThisQuery");
+		Assert.notNull(query.getId(), "No document id defined for MoreLikeThisQuery");
+
+		MoreLikeThisQueryBuilder moreLikeThisQueryBuilder = moreLikeThisQuery(
+				toArray(new MoreLikeThisQueryBuilder.Item(indexName, type, query.getId())));
+
+		if (query.getMinTermFreq() != null) {
+			moreLikeThisQueryBuilder.minTermFreq(query.getMinTermFreq());
+		}
+		if (query.getMaxQueryTerms() != null) {
+			moreLikeThisQueryBuilder.maxQueryTerms(query.getMaxQueryTerms());
+		}
+		if (!isEmpty(query.getStopWords())) {
+			moreLikeThisQueryBuilder.stopWords(toArray(query.getStopWords()));
+		}
+		if (query.getMinDocFreq() != null) {
+			moreLikeThisQueryBuilder.minDocFreq(query.getMinDocFreq());
+		}
+		if (query.getMaxDocFreq() != null) {
+			moreLikeThisQueryBuilder.maxDocFreq(query.getMaxDocFreq());
+		}
+		if (query.getMinWordLen() != null) {
+			moreLikeThisQueryBuilder.minWordLength(query.getMinWordLen());
+		}
+		if (query.getMaxWordLen() != null) {
+			moreLikeThisQueryBuilder.maxWordLength(query.getMaxWordLen());
+		}
+		if (query.getBoostTerms() != null) {
+			moreLikeThisQueryBuilder.boostTerms(query.getBoostTerms());
+		}
+
+		return queryForPage(new NativeSearchQueryBuilder().withQuery(moreLikeThisQueryBuilder).build(), clazz);
+	}
+
+	@Override
+	public <T> Map getSetting(Class<T> clazz) {
+		return getSetting(getPersistentEntityFor(clazz).getIndexName());
+	}
+
+	@Override
+	public ElasticsearchPersistentEntity getPersistentEntityFor(Class clazz) {
+		Assert.isTrue(clazz.isAnnotationPresent(Document.class), "Unable to identify index name. " + clazz.getSimpleName()
+				+ " is not a Document. Make sure the document class is annotated with @Document(indexName=\"foo\")");
+		return elasticsearchConverter.getMappingContext().getRequiredPersistentEntity(clazz);
+	}
+
+	SearchResponse doScroll(Class<?> clazz, long scrollTimeInMillis, CriteriaQuery criteriaQuery) {
+		Assert.notNull(criteriaQuery.getIndices(), "No index defined for Query");
+		Assert.notNull(criteriaQuery.getTypes(), "No type define for Query");
+		Assert.notNull(criteriaQuery.getPageable(), "Query.pageable is required for scan & scroll");
+
+		QueryBuilder elasticsearchQuery = new CriteriaQueryProcessor().createQueryFromCriteria(criteriaQuery.getCriteria());
+		QueryBuilder elasticsearchFilter = new CriteriaFilterProcessor()
+				.createFilterFromCriteria(criteriaQuery.getCriteria());
+
+		return scroll(clazz, scrollTimeInMillis, criteriaQuery, elasticsearchQuery, elasticsearchFilter);
+	}
+
+	@Override
+	public <T> String delete(Class<T> clazz, String id) {
+		ElasticsearchPersistentEntity persistentEntity = getPersistentEntityFor(clazz);
+		return delete(persistentEntity.getIndexName(), persistentEntity.getIndexType(), id);
+	}
+
+	@Override
+	public <T> LinkedList<T> multiGet(SearchQuery searchQuery, Class<T> clazz, MultiGetResultMapper getResultMapper) {
+		return getResultMapper.mapResults(getMultiResponse(searchQuery, clazz), clazz);
+	}
+
+	@Override
+	public <T> LinkedList<T> multiGet(SearchQuery searchQuery, Class<T> clazz) {
+		return getResultsMapper().mapResults(getMultiResponse(searchQuery, clazz), clazz);
+	}
+
+	private <T> MultiGetResponse getMultiResponse(Query searchQuery, Class<T> clazz) {
+
+		String indexName = !isEmpty(searchQuery.getIndices()) ? searchQuery.getIndices().get(0)
+				: getPersistentEntityFor(clazz).getIndexName();
+		String type = !isEmpty(searchQuery.getTypes()) ? searchQuery.getTypes().get(0)
+				: getPersistentEntityFor(clazz).getIndexType();
+
+		Assert.notNull(indexName, "No index defined for Query");
+		Assert.notNull(type, "No type define for Query");
+		Assert.notEmpty(searchQuery.getIds(), "No Id define for Query");
+
+		if (searchQuery.getFields() != null && !searchQuery.getFields().isEmpty()) {
+			searchQuery.addSourceFilter(new FetchSourceFilter(toArray(searchQuery.getFields()), null));
+		}
+
+		Stream<MultiGetRequest.Item> items = searchQuery.getIds().stream()
+				.map(id -> new MultiGetRequest.Item(indexName, type, id)).map(item -> item.routing(searchQuery.getRoute()));
+		return executeMultiRequest(items);
+	}
+
+	@Override
+	public <T> List<String> queryForIds(SearchQuery query) {
+		return extractIds(getIdsResponse(query));
+	}
+
+	abstract SearchResponse getIdsResponse(SearchQuery query);
+
+	@Override
+	public <T> long count(CriteriaQuery query) {
+		return count(query, null);
+	}
+
+	@Override
+	public <T> long count(SearchQuery query) {
+		return count(query, null);
+	}
+
+	abstract MultiGetResponse executeMultiRequest(Stream<MultiGetRequest.Item> items);
+
+	@Override
+	public <T> boolean deleteIndex(Class<T> clazz) {
+		return deleteIndex(getPersistentEntityFor(clazz).getIndexName());
+	}
+
+	@Override
+	public <T> boolean indexExists(Class<T> clazz) {
+		return indexExists(getPersistentEntityFor(clazz).getIndexName());
+	}
+
+	@Override
+	public void delete(DeleteQuery deleteQuery) {
+		Assert.notNull(deleteQuery.getIndex(), "No index defined for Query");
+		Assert.notNull(deleteQuery.getType(), "No type define for Query");
+		delete(deleteQuery, null);
+	}
+
+	@Override
+	public <T> void delete(CriteriaQuery criteriaQuery, Class<T> clazz) {
+		QueryBuilder elasticsearchQuery = new CriteriaQueryProcessor().createQueryFromCriteria(criteriaQuery.getCriteria());
+		Assert.notNull(elasticsearchQuery, "Query can not be null.");
+		DeleteQuery deleteQuery = new DeleteQuery();
+		deleteQuery.setQuery(elasticsearchQuery);
+		delete(deleteQuery, clazz);
+	}
+
+	@Override
+	public <T> void delete(DeleteQuery deleteQuery, Class<T> clazz) {
+
+		String indexName = hasText(deleteQuery.getIndex()) ? deleteQuery.getIndex()
+				: getPersistentEntityFor(clazz).getIndexName();
+		String typeName = hasText(deleteQuery.getType()) ? deleteQuery.getType()
+				: getPersistentEntityFor(clazz).getIndexType();
+		int pageSize = deleteQuery.getPageSize() != null ? deleteQuery.getPageSize() : 1000;
+		long scrollTimeInMillis = deleteQuery.getScrollTimeInMillis() != null ? deleteQuery.getScrollTimeInMillis()
+				: 10000L;
+
+		SearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(deleteQuery.getQuery()).withIndices(indexName)
+				.withTypes(typeName).withPageable(PageRequest.of(0, pageSize)).build();
+
+		SearchResultMapper onlyIdResultMapper = new IdResultMapper();
+		List<String> ids = new ArrayList<>();
+		Page<String> scrolledResult = startScroll(scrollTimeInMillis, searchQuery, String.class, onlyIdResultMapper);
+		do {
+			ids.addAll(scrolledResult.getContent());
+			scrolledResult = continueScroll(((ScrolledPage<T>) scrolledResult).getScrollId(), scrollTimeInMillis,
+					String.class, onlyIdResultMapper);
+		} while (!scrolledResult.getContent().isEmpty());
+
+		bulkDelete(indexName, typeName, ids);
+
+		clearScroll(((ScrolledPage<T>) scrolledResult).getScrollId());
+	}
+
+	SearchResponse doScroll(Class<?> clazz, long scrollTimeInMillis, SearchQuery searchQuery) {
+		Assert.notNull(searchQuery.getIndices(), "No index defined for Query");
+		Assert.notNull(searchQuery.getTypes(), "No type define for Query");
+		Assert.notNull(searchQuery.getPageable(), "Query.pageable is required for scan & scroll");
+		return scroll(clazz, scrollTimeInMillis, searchQuery);
+	}
+
+	@Override
+	public <T> Page<T> startScroll(long scrollTimeInMillis, SearchQuery searchQuery, Class<T> clazz) {
+		SearchResponse response = doScroll(clazz, scrollTimeInMillis, searchQuery);
+		return resultsMapper.mapResults(response, clazz, null);
+	}
+
+	@Override
+	public <T> Page<T> startScroll(long scrollTimeInMillis, CriteriaQuery criteriaQuery, Class<T> clazz) {
+		SearchResponse response = doScroll(clazz, scrollTimeInMillis, criteriaQuery);
+		return resultsMapper.mapResults(response, clazz, null);
+	}
+
+	@Override
+	public <T> Page<T> startScroll(long scrollTimeInMillis, SearchQuery searchQuery, Class<T> clazz,
+			SearchResultMapper mapper) {
+		SearchResponse response = doScroll(clazz, scrollTimeInMillis, searchQuery);
+		return mapper.mapResults(response, clazz, null);
+	}
+
+	@Override
+	public <T> Page<T> startScroll(long scrollTimeInMillis, CriteriaQuery criteriaQuery, Class<T> clazz,
+			SearchResultMapper mapper) {
+		SearchResponse response = doScroll(clazz, scrollTimeInMillis, criteriaQuery);
+		return mapper.mapResults(response, clazz, null);
+	}
+
+	@Override
+	public <T> Page<T> continueScroll(@Nullable String scrollId, long scrollTimeInMillis, Class<T> clazz) {
+		return continueScroll(scrollId, scrollTimeInMillis, clazz, resultsMapper);
+	}
+
+	@Override
+	public <T> boolean createIndex(Class<T> clazz, Object settings) {
+		return createIndex(getPersistentEntityFor(clazz).getIndexName(), settings);
+	}
+
+	String getPersistentEntityId(Object entity) {
+
+		ElasticsearchPersistentEntity<?> persistentEntity = getPersistentEntityFor(entity.getClass());
+		Object identifier = persistentEntity.getIdentifierAccessor(entity).getIdentifier();
+
+		return identifier != null ? identifier.toString() : null;
+
+	}
+
+	void setPersistentEntityId(Object entity, String id) {
+
+		ElasticsearchPersistentEntity<?> persistentEntity = getPersistentEntityFor(entity.getClass());
+		ElasticsearchPersistentProperty idProperty = persistentEntity.getIdProperty();
+
+		// Only deal with text because ES generated Ids are strings !
+
+		if (idProperty != null && idProperty.getType().isAssignableFrom(String.class)) {
+			persistentEntity.getPropertyAccessor(entity).setProperty(idProperty, id);
+		}
+	}
+
+	void setPersistentEntityIndexAndType(Query query, Class clazz) {
+		if (query.getIndices().isEmpty()) {
+			query.addIndices(retrieveIndexNameFromPersistentEntity(clazz));
+		}
+		if (query.getTypes().isEmpty()) {
+			query.addTypes(retrieveTypeFromPersistentEntity(clazz));
+		}
+	}
+
+	String[] retrieveIndexNameFromPersistentEntity(Class clazz) {
+		return clazz != null ? new String[] { getPersistentEntityFor(clazz).getIndexName() } : null;
+	}
+
+	private List<String> extractIds(SearchResponse response) {
+		List<String> ids = new ArrayList<>();
+		for (SearchHit hit : response.getHits()) {
+			if (hit != null) {
+				ids.add(hit.getId());
+			}
+		}
+		return ids;
+	}
+
+	String[] retrieveTypeFromPersistentEntity(Class clazz) {
+		return clazz != null ? new String[] { getPersistentEntityFor(clazz).getIndexType() } : null;
+	}
+
+	ResultsMapper getResultsMapper() {
+		return resultsMapper;
+	}
+
+	public SearchResponse suggest(SuggestBuilder suggestion, Class clazz) {
+		return suggest(suggestion, retrieveIndexNameFromPersistentEntity(clazz));
+	}
+
+	public void setApplicationContext(ApplicationContext context) {
+		if (getElasticsearchConverter() instanceof ApplicationContextAware) {
+			((ApplicationContextAware) getElasticsearchConverter()).setApplicationContext(context);
+		}
+	}
+
+	private <T> boolean createIndexIfNotCreated(Class<T> clazz) {
+		return indexExists(getPersistentEntityFor(clazz).getIndexName()) || createIndexWithSettings(clazz);
+	}
+
+	private <T> boolean createIndexWithSettings(Class<T> clazz) {
+		if (clazz.isAnnotationPresent(Setting.class)) {
+			String settingPath = clazz.getAnnotation(Setting.class).settingPath();
+			if (!StringUtils.isEmpty(settingPath)) {
+				String settings = ClassPathUtils.readFileFromClasspath(settingPath);
+				if (!StringUtils.isEmpty(settings)) {
+					return createIndex(getPersistentEntityFor(clazz).getIndexName(), settings);
+				}
+			} else {
+				log.info("settingPath in @Setting has to be defined. Using default instead.");
+			}
+		}
+		return createIndex(getPersistentEntityFor(clazz).getIndexName(), getDefaultSettings(getPersistentEntityFor(clazz)));
+	}
+
+	private <T> Map getDefaultSettings(ElasticsearchPersistentEntity<T> persistentEntity) {
+
+		if (persistentEntity.isUseServerConfiguration())
+			return new HashMap();
+
+		return new MapBuilder<String, String>().put("index.number_of_shards", String.valueOf(persistentEntity.getShards()))
+				.put("index.number_of_replicas", String.valueOf(persistentEntity.getReplicas()))
+				.put("index.refresh_interval", persistentEntity.getRefreshInterval())
+				.put("index.store.type", persistentEntity.getIndexStoreType()).map();
+	}
+
+	static String[] toArray(List<String> values) {
+		return values.toArray(new String[0]);
+	}
+
+	private static MoreLikeThisQueryBuilder.Item[] toArray(MoreLikeThisQueryBuilder.Item... values) {
+		return values;
+	}
+
+	@Override
+	public abstract void clearScroll(String scrollId);
+
+	public abstract SearchResponse suggest(SuggestBuilder suggestion, String... indices);
+
+	abstract SearchResponse scroll(Class<?> clazz, long scrollTimeInMillis, SearchQuery searchQuery);
+
+	abstract SearchResponse scroll(Class<?> clazz, long scrollTimeInMillis, CriteriaQuery criteriaQuery,
+			QueryBuilder elasticsearchQuery, QueryBuilder elasticsearchFilter);
+
+	abstract void bulkDelete(String indexName, String typeName, List<String> ids);
+
+	abstract GetResponse queryForObject(GetQuery query, String indexName, String indexType);
+
+	abstract void refresh(RefreshRequest refreshRequest);
+
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/BulkFailsHandler.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/BulkFailsHandler.java
@@ -15,13 +15,14 @@
  */
 package org.springframework.data.elasticsearch.core;
 
+import static java.util.stream.Collectors.*;
+
 import lombok.experimental.*;
-import org.elasticsearch.action.bulk.*;
-import org.springframework.data.elasticsearch.*;
 
 import java.util.*;
 
-import static java.util.stream.Collectors.*;
+import org.elasticsearch.action.bulk.*;
+import org.springframework.data.elasticsearch.*;
 
 /**
  * @author Nikita Guchakov

--- a/src/main/java/org/springframework/data/elasticsearch/core/BulkFailsHandler.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/BulkFailsHandler.java
@@ -15,21 +15,39 @@
  */
 package org.springframework.data.elasticsearch.core;
 
-import static java.util.stream.Collectors.*;
+import lombok.experimental.UtilityClass;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.springframework.data.elasticsearch.ElasticsearchException;
 
-import lombok.experimental.*;
+import java.util.Arrays;
+import java.util.Map;
 
-import java.util.*;
-
-import org.elasticsearch.action.bulk.*;
-import org.springframework.data.elasticsearch.*;
+import static java.util.stream.Collectors.toMap;
 
 /**
+ * @author Rizwan Idrees
+ * @author Mohsin Husen
+ * @author Artur Konczak
+ * @author Kevin Leturc
+ * @author Mason Chan
+ * @author Young Gu
+ * @author Oliver Gierke
+ * @author Mark Janssen
+ * @author Chris White
+ * @author Mark Paluch
+ * @author Ilkang Na
+ * @author Alen Turkovic
+ * @author Sascha Woo
+ * @author Ted Liang
+ * @author Don Wellington
  * @author Nikita Guchakov
  */
 @UtilityClass
 public class BulkFailsHandler {
+
 	void checkForBulkUpdateFailure(BulkResponse bulkResponse) {
+
 		if (!bulkResponse.hasFailures()) {
 			return;
 		}

--- a/src/main/java/org/springframework/data/elasticsearch/core/BulkFailsHandler.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/BulkFailsHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core;
+
+import lombok.experimental.*;
+import org.elasticsearch.action.bulk.*;
+import org.springframework.data.elasticsearch.*;
+
+import java.util.*;
+
+import static java.util.stream.Collectors.*;
+
+/**
+ * @author Nikita Guchakov
+ */
+@UtilityClass
+public class BulkFailsHandler {
+	void checkForBulkUpdateFailure(BulkResponse bulkResponse) {
+		if (!bulkResponse.hasFailures()) {
+			return;
+		}
+		Map<String, String> failedDocuments = Arrays.stream(bulkResponse.getItems()).filter(BulkItemResponse::isFailed)
+				.collect(toMap(BulkItemResponse::getId, BulkItemResponse::getFailureMessage, (a, b) -> b));
+		throw new ElasticsearchException(
+				"Bulk indexing has failures. Use ElasticsearchException.getFailedDocuments() for detailed messages ["
+						+ failedDocuments + "]",
+				failedDocuments);
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
@@ -15,9 +15,18 @@
  */
 package org.springframework.data.elasticsearch.core;
 
-import com.fasterxml.jackson.core.type.*;
-import com.fasterxml.jackson.databind.*;
+import static java.util.stream.Collectors.*;
+import static org.elasticsearch.index.VersionType.*;
+import static org.elasticsearch.index.query.QueryBuilders.*;
+import static org.springframework.util.CollectionUtils.isEmpty;
+import static org.springframework.util.StringUtils.*;
+
 import lombok.extern.slf4j.*;
+
+import java.io.*;
+import java.util.*;
+import java.util.stream.*;
+
 import org.apache.http.util.*;
 import org.elasticsearch.action.*;
 import org.elasticsearch.action.admin.indices.alias.*;
@@ -52,15 +61,8 @@ import org.springframework.data.elasticsearch.core.mapping.*;
 import org.springframework.data.elasticsearch.core.query.*;
 import org.springframework.util.*;
 
-import java.io.*;
-import java.util.*;
-import java.util.stream.*;
-
-import static java.util.stream.Collectors.*;
-import static org.elasticsearch.index.VersionType.*;
-import static org.elasticsearch.index.query.QueryBuilders.*;
-import static org.springframework.util.CollectionUtils.isEmpty;
-import static org.springframework.util.StringUtils.*;
+import com.fasterxml.jackson.core.type.*;
+import com.fasterxml.jackson.databind.*;
 
 /**
  * ElasticsearchRestTemplate
@@ -760,8 +762,7 @@ public class ElasticsearchRestTemplate extends AbstractElasticTemplate
 	public Boolean addAlias(AliasQuery query) {
 		Assert.notNull(query.getIndexName(), "No index defined for Alias");
 		Assert.notNull(query.getAliasName(), "No alias defined");
-		final AliasActions aliasAction = AliasActions.add()
-				.alias(query.getAliasName()).index(query.getIndexName());
+		final AliasActions aliasAction = AliasActions.add().alias(query.getAliasName()).index(query.getIndexName());
 
 		if (query.getFilterBuilder() != null) {
 			aliasAction.filter(query.getFilterBuilder());

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
@@ -15,6 +15,16 @@
  */
 package org.springframework.data.elasticsearch.core;
 
+import static java.util.function.Function.*;
+import static org.elasticsearch.client.Requests.*;
+import static org.elasticsearch.index.VersionType.*;
+import static org.elasticsearch.index.query.QueryBuilders.*;
+import static org.springframework.util.CollectionUtils.*;
+
+import java.io.*;
+import java.util.*;
+import java.util.stream.*;
+
 import org.elasticsearch.action.*;
 import org.elasticsearch.action.admin.indices.alias.*;
 import org.elasticsearch.action.admin.indices.alias.get.*;
@@ -46,16 +56,6 @@ import org.springframework.data.elasticsearch.core.facet.*;
 import org.springframework.data.elasticsearch.core.mapping.*;
 import org.springframework.data.elasticsearch.core.query.*;
 import org.springframework.util.*;
-
-import java.io.*;
-import java.util.*;
-import java.util.stream.*;
-
-import static java.util.function.Function.*;
-import static org.elasticsearch.client.Requests.*;
-import static org.elasticsearch.index.VersionType.*;
-import static org.elasticsearch.index.query.QueryBuilders.*;
-import static org.springframework.util.CollectionUtils.*;
 
 /**
  * ElasticsearchTemplate

--- a/src/main/java/org/springframework/data/elasticsearch/core/PageIterator.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/PageIterator.java
@@ -15,10 +15,10 @@
  */
 package org.springframework.data.elasticsearch.core;
 
-import org.springframework.data.util.*;
-
 import java.util.*;
 import java.util.function.*;
+
+import org.springframework.data.util.*;
 
 /**
  * Iterator through elastic scroll pages.

--- a/src/main/java/org/springframework/data/elasticsearch/core/PageIterator.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/PageIterator.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core;
+
+import org.springframework.data.util.*;
+
+import java.util.*;
+import java.util.function.*;
+
+/**
+ * Iterator through elastic scroll pages.
+ * 
+ * @author Nikita Guchakov
+ */
+class PageIterator<T> implements CloseableIterator<T> {
+
+	private final Function<String, ScrolledPage<T>> pageRetriever;
+	private final Consumer<String> onClear;
+
+	/**
+	 * As we couldn't retrieve single result with scroll, store current hits.
+	 */
+	private volatile Iterator<T> currentHits;
+
+	/**
+	 * The scroll id.
+	 */
+	private volatile String scrollId;
+
+	/**
+	 * If stream is finished (ie: cluster returns no results.
+	 */
+	private volatile boolean finished;
+
+	PageIterator(ScrolledPage<T> page, Function<String, ScrolledPage<T>> pageRetriever, // scrollId ->
+			Consumer<String> onClear // scrollId ->
+	) {
+		this.onClear = onClear;
+		this.pageRetriever = pageRetriever;
+		currentHits = page.iterator();
+		scrollId = page.getScrollId();
+		finished = !currentHits.hasNext();
+	}
+
+	@Override
+	public void close() {
+		try {
+			// Clear scroll on cluster only in case of error (cause elasticsearch auto clear scroll when it's done)
+			if (!finished && scrollId != null && currentHits != null && currentHits.hasNext()) {
+				onClear.accept(scrollId);
+			}
+		} finally {
+			currentHits = null;
+			scrollId = null;
+		}
+	}
+
+	@Override
+	public boolean hasNext() {
+		if (finished) {
+			return false;
+		}
+		// Test if it remains hits
+		if (currentHits == null || !currentHits.hasNext()) {
+			final ScrolledPage<T> scroll = pageRetriever.apply(scrollId);
+			currentHits = scroll.iterator();
+			scrollId = scroll.getScrollId();
+			finished = !currentHits.hasNext();
+		}
+		return currentHits.hasNext();
+	}
+
+	@Override
+	public T next() {
+		if (!hasNext()) {
+			throw new NoSuchElementException();
+		}
+		return currentHits.next();
+	}
+
+	@Override
+	public void remove() {
+		throw new UnsupportedOperationException("remove");
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchConverter.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchConverter.java
@@ -15,10 +15,9 @@
  */
 package org.springframework.data.elasticsearch.core.convert;
 
-import org.springframework.core.convert.ConversionService;
-import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentEntity;
-import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentProperty;
-import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.core.convert.*;
+import org.springframework.data.elasticsearch.core.mapping.*;
+import org.springframework.data.mapping.context.*;
 
 /**
  * ElasticsearchConverter
@@ -30,14 +29,14 @@ import org.springframework.data.mapping.context.MappingContext;
 public interface ElasticsearchConverter {
 
 	/**
-	 * Returns the underlying {@link org.springframework.data.mapping.context.MappingContext} used by the converter.
+	 * Returns the underlying {@link MappingContext} used by the converter.
 	 *
 	 * @return never {@literal null}
 	 */
 	MappingContext<? extends ElasticsearchPersistentEntity<?>, ElasticsearchPersistentProperty> getMappingContext();
 
 	/**
-	 * Returns the underlying {@link org.springframework.core.convert.ConversionService} used by the converter.
+	 * Returns the underlying {@link ConversionService} used by the converter.
 	 *
 	 * @return never {@literal null}.
 	 */

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/IdResultMapper.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/IdResultMapper.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core.mapping;
+
+import org.elasticsearch.action.search.*;
+import org.elasticsearch.search.*;
+import org.springframework.data.domain.*;
+import org.springframework.data.elasticsearch.core.*;
+import org.springframework.data.elasticsearch.core.aggregation.*;
+import org.springframework.data.elasticsearch.core.aggregation.impl.*;
+
+import java.util.*;
+
+import static java.util.Collections.*;
+import static java.util.stream.Collectors.*;
+
+/**
+ * @author Nikita Guchakov
+ */
+public class IdResultMapper implements SearchResultMapper {
+
+	@Override
+	public <T> AggregatedPage<T> mapResults(SearchResponse response, Class<T> clazz, Pageable pageable) {
+		List<String> result = Arrays.stream(response.getHits().getHits()).map(SearchHit::getId).collect(toList());
+		result = result.isEmpty() ? emptyList() : result;
+		return new AggregatedPageImpl<>((List<T>) result, response.getScrollId());
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/IdResultMapper.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/IdResultMapper.java
@@ -15,17 +15,17 @@
  */
 package org.springframework.data.elasticsearch.core.mapping;
 
+import static java.util.Collections.*;
+import static java.util.stream.Collectors.*;
+
+import java.util.*;
+
 import org.elasticsearch.action.search.*;
 import org.elasticsearch.search.*;
 import org.springframework.data.domain.*;
 import org.springframework.data.elasticsearch.core.*;
 import org.springframework.data.elasticsearch.core.aggregation.*;
 import org.springframework.data.elasticsearch.core.aggregation.impl.*;
-
-import java.util.*;
-
-import static java.util.Collections.*;
-import static java.util.stream.Collectors.*;
 
 /**
  * @author Nikita Guchakov

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/IdResultMapper.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/IdResultMapper.java
@@ -15,19 +15,35 @@
  */
 package org.springframework.data.elasticsearch.core.mapping;
 
-import static java.util.Collections.*;
-import static java.util.stream.Collectors.*;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.search.SearchHit;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.SearchResultMapper;
+import org.springframework.data.elasticsearch.core.aggregation.AggregatedPage;
+import org.springframework.data.elasticsearch.core.aggregation.impl.AggregatedPageImpl;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
 
-import org.elasticsearch.action.search.*;
-import org.elasticsearch.search.*;
-import org.springframework.data.domain.*;
-import org.springframework.data.elasticsearch.core.*;
-import org.springframework.data.elasticsearch.core.aggregation.*;
-import org.springframework.data.elasticsearch.core.aggregation.impl.*;
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
 
 /**
+ * @author Rizwan Idrees
+ * @author Mohsin Husen
+ * @author Artur Konczak
+ * @author Kevin Leturc
+ * @author Mason Chan
+ * @author Young Gu
+ * @author Oliver Gierke
+ * @author Mark Janssen
+ * @author Chris White
+ * @author Mark Paluch
+ * @author Ilkang Na
+ * @author Alen Turkovic
+ * @author Sascha Woo
+ * @author Ted Liang
+ * @author Don Wellington
  * @author Nikita Guchakov
  */
 public class IdResultMapper implements SearchResultMapper {

--- a/src/main/java/org/springframework/data/elasticsearch/core/utils/ClassPathUtils.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/utils/ClassPathUtils.java
@@ -17,9 +17,10 @@ package org.springframework.data.elasticsearch.core.utils;
 
 import lombok.experimental.*;
 import lombok.extern.slf4j.*;
-import org.springframework.core.io.*;
 
 import java.nio.file.*;
+
+import org.springframework.core.io.*;
 
 @Slf4j
 @UtilityClass

--- a/src/main/java/org/springframework/data/elasticsearch/core/utils/ClassPathUtils.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/utils/ClassPathUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core.utils;
+
+import lombok.experimental.*;
+import lombok.extern.slf4j.*;
+import org.springframework.core.io.*;
+
+import java.nio.file.*;
+
+@Slf4j
+@UtilityClass
+public class ClassPathUtils {
+
+	public static String readFileFromClasspath(String url) {
+		try {
+			ClassPathResource classPathResource = new ClassPathResource(url);
+			return new String(Files.readAllBytes(Paths.get(classPathResource.getURI())));
+		} catch (Exception e) {
+			log.error(String.format("Failed to load file from url: %s: %s", url, e.getMessage()));
+			return null;
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/utils/ClassPathUtils.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/utils/ClassPathUtils.java
@@ -15,13 +15,16 @@
  */
 package org.springframework.data.elasticsearch.core.utils;
 
-import lombok.experimental.*;
-import lombok.extern.slf4j.*;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
 
-import java.nio.file.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
-import org.springframework.core.io.*;
-
+/**
+ * @author Nikita Guchakov
+ */
 @Slf4j
 @UtilityClass
 public class ClassPathUtils {

--- a/src/main/java/org/springframework/data/elasticsearch/repository/config/EnableElasticsearchRepositories.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/config/EnableElasticsearchRepositories.java
@@ -15,14 +15,14 @@
  */
 package org.springframework.data.elasticsearch.repository.config;
 
-import java.lang.annotation.*;
+import org.springframework.context.annotation.ComponentScan.*;
+import org.springframework.context.annotation.*;
+import org.springframework.data.elasticsearch.core.*;
+import org.springframework.data.elasticsearch.repository.support.*;
+import org.springframework.data.repository.config.*;
+import org.springframework.data.repository.query.QueryLookupStrategy.*;
 
-import org.springframework.context.annotation.ComponentScan.Filter;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.elasticsearch.core.ElasticsearchTemplate;
-import org.springframework.data.elasticsearch.repository.support.ElasticsearchRepositoryFactoryBean;
-import org.springframework.data.repository.config.DefaultRepositoryBaseClass;
-import org.springframework.data.repository.query.QueryLookupStrategy.Key;
+import java.lang.annotation.*;
 
 /**
  * Annotation to enable Elasticsearch repositories. Will scan the package of the annotated configuration class for
@@ -90,7 +90,7 @@ public @interface EnableElasticsearchRepositories {
 	/**
 	 * Returns the key of the {@link org.springframework.data.repository.query.QueryLookupStrategy} to be used for lookup
 	 * queries for query methods. Defaults to
-	 * {@link org.springframework.data.repository.query.QueryLookupStrategy.Key#CREATE_IF_NOT_FOUND}.
+	 * {@link Key#CREATE_IF_NOT_FOUND}.
 	 *
 	 * @return
 	 */

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
@@ -15,48 +15,29 @@
  */
 package org.springframework.data.elasticsearch.core;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import org.apache.commons.lang.StringUtils;
-import org.elasticsearch.action.get.MultiGetItemResponse;
-import org.elasticsearch.action.get.MultiGetResponse;
-import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.script.Script;
-import org.elasticsearch.script.ScriptType;
-import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
-import org.elasticsearch.search.fetch.subphase.highlight.HighlightField;
-import org.elasticsearch.search.sort.FieldSortBuilder;
-import org.elasticsearch.search.sort.SortBuilders;
-import org.elasticsearch.search.sort.SortOrder;
-import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.elasticsearch.ElasticsearchException;
-import org.springframework.data.elasticsearch.annotations.Document;
-import org.springframework.data.elasticsearch.core.aggregation.AggregatedPage;
-import org.springframework.data.elasticsearch.core.aggregation.impl.AggregatedPageImpl;
+import org.apache.commons.lang.*;
+import org.elasticsearch.action.get.*;
+import org.elasticsearch.action.index.*;
+import org.elasticsearch.action.search.*;
+import org.elasticsearch.action.support.*;
+import org.elasticsearch.script.*;
+import org.elasticsearch.search.*;
+import org.elasticsearch.search.fetch.subphase.highlight.*;
+import org.elasticsearch.search.sort.*;
+import org.hamcrest.*;
+import org.junit.*;
+import org.springframework.beans.factory.annotation.*;
+import org.springframework.data.domain.*;
+import org.springframework.data.elasticsearch.*;
+import org.springframework.data.elasticsearch.annotations.*;
+import org.springframework.data.elasticsearch.core.aggregation.*;
+import org.springframework.data.elasticsearch.core.aggregation.impl.*;
 import org.springframework.data.elasticsearch.core.query.*;
-import org.springframework.data.elasticsearch.entities.HetroEntity1;
-import org.springframework.data.elasticsearch.entities.HetroEntity2;
-import org.springframework.data.elasticsearch.entities.SampleEntity;
-import org.springframework.data.elasticsearch.entities.SampleMappingEntity;
-import org.springframework.data.elasticsearch.entities.UseServerConfigurationEntity;
-import org.springframework.data.util.CloseableIterator;
+import org.springframework.data.elasticsearch.entities.*;
+import org.springframework.data.util.*;
+
+import java.util.*;
+
 import static org.apache.commons.lang.RandomStringUtils.*;
 import static org.elasticsearch.index.query.QueryBuilders.*;
 import static org.hamcrest.Matchers.*;
@@ -2290,7 +2271,7 @@ public class ElasticsearchTemplateTests {
 				"    analyzer:\n" +
 				"      emailAnalyzer:\n" +
 				"        type: custom\n" +
-				"        tokenizer: uax_url_email\n"));
+				"        tokenizer: uax_url_email"));
 	}
 
 	private IndexQuery getIndexQuery(SampleEntity sampleEntity) {

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
@@ -15,6 +15,14 @@
  */
 package org.springframework.data.elasticsearch.core;
 
+import static org.apache.commons.lang.RandomStringUtils.*;
+import static org.elasticsearch.index.query.QueryBuilders.*;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.springframework.data.elasticsearch.utils.IndexBuilder.*;
+
+import java.util.*;
+
 import org.apache.commons.lang.*;
 import org.elasticsearch.action.get.*;
 import org.elasticsearch.action.index.*;
@@ -35,14 +43,6 @@ import org.springframework.data.elasticsearch.core.aggregation.impl.*;
 import org.springframework.data.elasticsearch.core.query.*;
 import org.springframework.data.elasticsearch.entities.*;
 import org.springframework.data.util.*;
-
-import java.util.*;
-
-import static org.apache.commons.lang.RandomStringUtils.*;
-import static org.elasticsearch.index.query.QueryBuilders.*;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
-import static org.springframework.data.elasticsearch.utils.IndexBuilder.*;
 
 /**
  * Base for testing rest/transport templates


### PR DESCRIPTION
Only refactoring changes. ElasticRestTemplate and ElasticTemplate had a lot of duplicate logic. Now extends AbstractElasticTemplate and use several util classes.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
