### PR TITLE
DATAES-510 - Add reactive scroll support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-elasticsearch</artifactId>
-	<version>4.0.0.BUILD-SNAPSHOT</version>
+	<version>4.0.0.DATAES-510-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.data.build</groupId>

--- a/src/main/java/org/springframework/data/elasticsearch/client/reactive/ReactiveElasticsearchClient.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/reactive/ReactiveElasticsearchClient.java
@@ -30,6 +30,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.main.MainResponse;
 import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.index.get.GetResult;
@@ -349,6 +350,31 @@ public interface ReactiveElasticsearchClient {
 	 * @return the {@link Flux} emitting {@link SearchHit hits} one by one.
 	 */
 	Flux<SearchHit> search(HttpHeaders headers, SearchRequest searchRequest);
+
+	/**
+	 * Execute the given {@link SearchRequest} against the {@literal search scroll} API.
+	 *
+	 * @param searchRequest must not be {@literal null}.
+	 * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html">Search
+	 *      Scroll API on elastic.co</a>
+	 * @return the {@link Flux} emitting {@link SearchHit hits} one by one.
+	 */
+	default Flux<SearchHit> scroll(SearchRequest searchRequest) {
+		return scroll(HttpHeaders.EMPTY, searchRequest);
+	}
+
+	/**
+	 * Execute the given {@link SearchRequest} against the {@literal search scroll} API. <br />
+	 * Scroll keeps track of {@link SearchResponse#getScrollId() scrollIds} returned by the server and provides them when
+	 * requesting more results via {@code _search/scroll}. All bound server resources are freed on completion.
+	 *
+	 * @param headers Use {@link HttpHeaders} to provide eg. authentication data. Must not be {@literal null}.
+	 * @param searchRequest must not be {@literal null}.
+	 * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html">Search
+	 *      Scroll API on elastic.co</a>
+	 * @return the {@link Flux} emitting {@link SearchHit hits} one by one.
+	 */
+	Flux<SearchHit> scroll(HttpHeaders headers, SearchRequest searchRequest);
 
 	/**
 	 * Execute a {@link DeleteByQueryRequest} against the {@literal delete by query} API.

--- a/src/test/resources/org/springframework/data/elasticsearch/client/scroll_clean.json
+++ b/src/test/resources/org/springframework/data/elasticsearch/client/scroll_clean.json
@@ -1,0 +1,4 @@
+{
+  "num_freed": 1,
+  "succeeded": true
+}

--- a/src/test/resources/org/springframework/data/elasticsearch/client/scroll_error.json
+++ b/src/test/resources/org/springframework/data/elasticsearch/client/scroll_error.json
@@ -1,0 +1,77 @@
+{
+  "error": {
+    "caused_by": {
+      "reason": "No search context found for id [1]",
+      "type": "search_context_missing_exception"
+    },
+    "failed_shards": [
+      {
+        "index": null,
+        "reason": {
+          "reason": "No search context found for id [1]",
+          "type": "search_context_missing_exception"
+        },
+        "shard": -1
+      },
+      {
+        "index": null,
+        "reason": {
+          "reason": "No search context found for id [2]",
+          "type": "search_context_missing_exception"
+        },
+        "shard": -1
+      },
+      {
+        "index": null,
+        "reason": {
+          "reason": "No search context found for id [3]",
+          "type": "search_context_missing_exception"
+        },
+        "shard": -1
+      },
+      {
+        "index": null,
+        "reason": {
+          "reason": "No search context found for id [4]",
+          "type": "search_context_missing_exception"
+        },
+        "shard": -1
+      },
+      {
+        "index": null,
+        "reason": {
+          "reason": "No search context found for id [5]",
+          "type": "search_context_missing_exception"
+        },
+        "shard": -1
+      }
+    ],
+    "grouped": true,
+    "phase": "query",
+    "reason": "all shards failed",
+    "root_cause": [
+      {
+        "reason": "No search context found for id [1]",
+        "type": "search_context_missing_exception"
+      },
+      {
+        "reason": "No search context found for id [2]",
+        "type": "search_context_missing_exception"
+      },
+      {
+        "reason": "No search context found for id [3]",
+        "type": "search_context_missing_exception"
+      },
+      {
+        "reason": "No search context found for id [4]",
+        "type": "search_context_missing_exception"
+      },
+      {
+        "reason": "No search context found for id [5]",
+        "type": "search_context_missing_exception"
+      }
+    ],
+    "type": "search_phase_execution_exception"
+  },
+  "status": 404
+}

--- a/src/test/resources/org/springframework/data/elasticsearch/client/scroll_no_more_results.json
+++ b/src/test/resources/org/springframework/data/elasticsearch/client/scroll_no_more_results.json
@@ -1,0 +1,16 @@
+{
+  "_shards": {
+    "failed": 0,
+    "skipped": 0,
+    "successful": 5,
+    "total": 5
+  },
+  "hits": {
+    "hits": [],
+    "max_score": 1.0,
+    "total": 100
+  },
+  "terminated_early": true,
+  "timed_out": false,
+  "took": 1
+}

--- a/src/test/resources/org/springframework/data/elasticsearch/client/scroll_ok.json
+++ b/src/test/resources/org/springframework/data/elasticsearch/client/scroll_ok.json
@@ -1,0 +1,39 @@
+{
+  "_shards": {
+    "failed": 0,
+    "skipped": 0,
+    "successful": 5,
+    "total": 5
+  },
+  "hits": {
+    "hits": [
+      {
+        "_index": "twitter",
+        "_type": "doc",
+        "_id": "2",
+        "_score": 0.2876821,
+        "_source": {
+          "user": "kimchy",
+          "post_date": "2009-11-15T14:12:12",
+          "message": "Another tweet, will it be indexed?"
+        }
+      },
+      {
+        "_index": "twitter",
+        "_type": "doc",
+        "_id": "1",
+        "_score": 0.2876821,
+        "_source": {
+          "user": "kimchy",
+          "post_date": "2009-11-15T13:12:00",
+          "message": "Trying out Elasticsearch, so far so good?"
+        }
+      }
+    ],
+    "max_score": 1.0,
+    "total": 100
+  },
+  "terminated_early": true,
+  "timed_out": false,
+  "took": 1
+}

--- a/src/test/resources/org/springframework/data/elasticsearch/client/search-ok-scroll.json
+++ b/src/test/resources/org/springframework/data/elasticsearch/client/search-ok-scroll.json
@@ -1,0 +1,39 @@
+{
+  "took": 52,
+  "timed_out": false,
+  "_scroll_id": "DnF1ZXJ5VGhlbkZldGNoBQAAAAAAAAAHFndhSE1uNUlLUXhXb1ZvQTNqOHNrMWcAAAAAAAAABhZ3YUhNbjVJS1F4V29Wb0EzajhzazFnAAAAAAAAAAgWd2FITW41SUtReFdvVm9BM2o4c2sxZwAAAAAAAAAJFndhSE1uNUlLUXhXb1ZvQTNqOHNrMWcAAAAAAAAAChZ3YUhNbjVJS1F4V29Wb0EzajhzazFn",
+  "_shards": {
+    "total": 5,
+    "successful": 5,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": 100,
+    "max_score": 0.2876821,
+    "hits": [
+      {
+        "_index": "twitter",
+        "_type": "doc",
+        "_id": "2",
+        "_score": 0.2876821,
+        "_source": {
+          "user": "kimchy",
+          "post_date": "2009-11-15T14:12:12",
+          "message": "Another tweet, will it be indexed?"
+        }
+      },
+      {
+        "_index": "twitter",
+        "_type": "doc",
+        "_id": "1",
+        "_score": 0.2876821,
+        "_source": {
+          "user": "kimchy",
+          "post_date": "2009-11-15T13:12:00",
+          "message": "Trying out Elasticsearch, so far so good?"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The `ReactiveElasticsearchClient` now support scrolling through large result sets, issuing `_search/scroll` requests while emitting data on the outbound channel. Resources bound via their `scrollId` are freed on completion of the resulting `Flux`.

```java
SearchRequest request = new SearchRequest("index").types("doc")
  .source(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery()))
  .scroll(TimeValue.timeValueMinutes(1));

Flux<SearchHit> result = client.scroll(request);
```