### PR TITLE
DATAES-523 - Allow specifying version type.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/annotations/Document.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/Document.java
@@ -17,6 +17,7 @@ package org.springframework.data.elasticsearch.annotations;
 
 import java.lang.annotation.*;
 
+import org.elasticsearch.index.VersionType;
 import org.springframework.data.annotation.Persistent;
 
 /**
@@ -25,6 +26,7 @@ import org.springframework.data.annotation.Persistent;
  * @author Rizwan Idrees
  * @author Mohsin Husen
  * @author Mason Chan
+ * @author Ivan Greene
  */
 
 @Persistent
@@ -48,4 +50,6 @@ public @interface Document {
 	String indexStoreType() default "fs";
 
 	boolean createIndex() default true;
+
+	VersionType versionType() default VersionType.EXTERNAL;
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
@@ -16,7 +16,6 @@
 package org.springframework.data.elasticsearch.core;
 
 import static org.elasticsearch.client.Requests.refreshRequest;
-import static org.elasticsearch.index.VersionType.EXTERNAL;
 import static org.elasticsearch.index.query.QueryBuilders.moreLikeThisQuery;
 import static org.elasticsearch.index.query.QueryBuilders.wrapperQuery;
 import static org.springframework.data.elasticsearch.core.MappingBuilder.buildMapping;
@@ -67,6 +66,7 @@ import org.elasticsearch.common.xcontent.DeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.query.MoreLikeThisQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -131,6 +131,7 @@ import org.springframework.util.StringUtils;
  * @author Don Wellington
  * @author Zetang Zeng
  * @author Peter Nowak
+ * @author Ivan Greene
  */
 public class ElasticsearchRestTemplate
 		implements ElasticsearchOperations, EsClient<RestHighLevelClient>, ApplicationContextAware {
@@ -1343,7 +1344,8 @@ public class ElasticsearchRestTemplate
 			}
 			if (query.getVersion() != null) {
 				indexRequest.version(query.getVersion());
-				indexRequest.versionType(EXTERNAL);
+				VersionType versionType = retrieveVersionTypeFromPersistentEntity(query.getObject().getClass());
+				indexRequest.versionType(versionType);
 			}
 
 			if (query.getParentId() != null) {
@@ -1518,6 +1520,13 @@ public class ElasticsearchRestTemplate
 			return new String[] { getPersistentEntityFor(clazz).getIndexType() };
 		}
 		return null;
+	}
+
+	private VersionType retrieveVersionTypeFromPersistentEntity(Class clazz) {
+		if (clazz != null) {
+			return getPersistentEntityFor(clazz).getVersionType();
+		}
+		return VersionType.EXTERNAL;
 	}
 
 	private List<String> extractIds(SearchResponse response) {

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
@@ -16,7 +16,6 @@
 package org.springframework.data.elasticsearch.core;
 
 import static org.elasticsearch.client.Requests.*;
-import static org.elasticsearch.index.VersionType.*;
 import static org.elasticsearch.index.query.QueryBuilders.*;
 import static org.springframework.data.elasticsearch.core.MappingBuilder.*;
 import static org.springframework.util.CollectionUtils.*;
@@ -65,6 +64,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.query.MoreLikeThisQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -137,6 +137,7 @@ import org.springframework.util.StringUtils;
  * @author Ted Liang
  * @author Jean-Baptiste Nizet
  * @author Zetang Zeng
+ * @author Ivan Greene
  */
 public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<Client>, ApplicationContextAware {
 
@@ -1175,7 +1176,8 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 			}
 			if (query.getVersion() != null) {
 				indexRequestBuilder.setVersion(query.getVersion());
-				indexRequestBuilder.setVersionType(EXTERNAL);
+				VersionType versionType = retrieveVersionTypeFromPersistentEntity(query.getObject().getClass());
+				indexRequestBuilder.setVersionType(versionType);
 			}
 
 			if (query.getParentId() != null) {
@@ -1286,6 +1288,13 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 			return new String[] { getPersistentEntityFor(clazz).getIndexType() };
 		}
 		return null;
+	}
+
+	private VersionType retrieveVersionTypeFromPersistentEntity(Class clazz) {
+		if (clazz != null) {
+			return getPersistentEntityFor(clazz).getVersionType();
+		}
+		return VersionType.EXTERNAL;
 	}
 
 	private List<String> extractIds(SearchResponse response) {

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentEntity.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentEntity.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.elasticsearch.core.mapping;
 
+import org.elasticsearch.index.VersionType;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.lang.Nullable;
 
@@ -26,6 +27,7 @@ import org.springframework.lang.Nullable;
  * @author Mark Paluch
  * @author Sascha Woo
  * @author Oliver Gierke
+ * @author Ivan Greene
  */
 public interface ElasticsearchPersistentEntity<T> extends PersistentEntity<T, ElasticsearchPersistentProperty> {
 
@@ -50,6 +52,8 @@ public interface ElasticsearchPersistentEntity<T> extends PersistentEntity<T, El
 	ElasticsearchPersistentProperty getParentIdProperty();
 
 	String settingPath();
+
+	VersionType getVersionType();
 
 	boolean isCreateIndexAndMapping();
 

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/SimpleElasticsearchPersistentEntity.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/SimpleElasticsearchPersistentEntity.java
@@ -19,6 +19,7 @@ import static org.springframework.util.StringUtils.*;
 
 import java.util.Locale;
 
+import org.elasticsearch.index.VersionType;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -28,7 +29,6 @@ import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Parent;
 import org.springframework.data.elasticsearch.annotations.Setting;
 import org.springframework.data.mapping.MappingException;
-import org.springframework.data.mapping.PersistentPropertyAccessor;
 import org.springframework.data.mapping.model.BasicPersistentEntity;
 import org.springframework.data.mapping.model.PersistentPropertyAccessorFactory;
 import org.springframework.data.util.TypeInformation;
@@ -47,6 +47,7 @@ import org.springframework.util.Assert;
  * @author Mohsin Husen
  * @author Mark Paluch
  * @author Sascha Woo
+ * @author Ivan Greene
  */
 public class SimpleElasticsearchPersistentEntity<T> extends BasicPersistentEntity<T, ElasticsearchPersistentProperty>
 		implements ElasticsearchPersistentEntity<T>, ApplicationContextAware {
@@ -65,6 +66,7 @@ public class SimpleElasticsearchPersistentEntity<T> extends BasicPersistentEntit
 	private ElasticsearchPersistentProperty parentIdProperty;
 	private ElasticsearchPersistentProperty scoreProperty;
 	private String settingPath;
+	private VersionType versionType;
 	private boolean createIndexAndMapping;
 
 	public SimpleElasticsearchPersistentEntity(TypeInformation<T> typeInformation) {
@@ -84,6 +86,7 @@ public class SimpleElasticsearchPersistentEntity<T> extends BasicPersistentEntit
 			this.replicas = document.replicas();
 			this.refreshInterval = document.refreshInterval();
 			this.indexStoreType = document.indexStoreType();
+			this.versionType = document.versionType();
 			this.createIndexAndMapping = document.createIndex();
 		}
 		if (clazz.isAnnotationPresent(Setting.class)) {
@@ -153,6 +156,11 @@ public class SimpleElasticsearchPersistentEntity<T> extends BasicPersistentEntit
 	@Override
 	public ElasticsearchPersistentProperty getParentIdProperty() {
 		return parentIdProperty;
+	}
+
+	@Override
+	public VersionType getVersionType() {
+		return versionType;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchEntityInformation.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchEntityInformation.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.elasticsearch.repository.support;
 
+import org.elasticsearch.index.VersionType;
 import org.springframework.data.repository.core.EntityInformation;
 
 /**
@@ -23,6 +24,7 @@ import org.springframework.data.repository.core.EntityInformation;
  * @author Rizwan Idrees
  * @author Mohsin Husen
  * @author Christoph Strobl
+ * @author Ivan Greene
  */
 public interface ElasticsearchEntityInformation<T, ID> extends EntityInformation<T, ID> {
 
@@ -33,6 +35,8 @@ public interface ElasticsearchEntityInformation<T, ID> extends EntityInformation
 	String getType();
 
 	Long getVersion(T entity);
+
+	VersionType getVersionType();
 
 	String getParentId(T entity);
 }

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/MappingElasticsearchEntityInformation.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/MappingElasticsearchEntityInformation.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.elasticsearch.repository.support;
 
+import org.elasticsearch.index.VersionType;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentEntity;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentProperty;
 import org.springframework.data.repository.core.support.PersistentEntityInformation;
@@ -32,6 +33,7 @@ import org.springframework.util.Assert;
  * @author Oliver Gierke
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Ivan Greene
  */
 public class MappingElasticsearchEntityInformation<T, ID> extends PersistentEntityInformation<T, ID>
 		implements ElasticsearchEntityInformation<T, ID> {
@@ -39,12 +41,13 @@ public class MappingElasticsearchEntityInformation<T, ID> extends PersistentEnti
 	private final ElasticsearchPersistentEntity<T> entityMetadata;
 	private final String indexName;
 	private final String type;
+	private final VersionType versionType;
 
 	public MappingElasticsearchEntityInformation(ElasticsearchPersistentEntity<T> entity) {
-		this(entity, entity.getIndexName(), entity.getIndexType());
+		this(entity, entity.getIndexName(), entity.getIndexType(), entity.getVersionType());
 	}
 
-	public MappingElasticsearchEntityInformation(ElasticsearchPersistentEntity<T> entity, String indexName, String type) {
+	public MappingElasticsearchEntityInformation(ElasticsearchPersistentEntity<T> entity, String indexName, String type, VersionType versionType) {
 		super(entity);
 
 		Assert.notNull(indexName, "IndexName must not be null!");
@@ -53,6 +56,7 @@ public class MappingElasticsearchEntityInformation<T, ID> extends PersistentEnti
 		this.entityMetadata = entity;
 		this.indexName = indexName;
 		this.type = type;
+		this.versionType = versionType;
 	}
 
 	@Override
@@ -79,6 +83,11 @@ public class MappingElasticsearchEntityInformation<T, ID> extends PersistentEnti
 		} catch (Exception e) {
 			throw new IllegalStateException("failed to load version field", e);
 		}
+	}
+
+	@Override
+	public VersionType getVersionType() {
+		return versionType;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/ReactiveElasticsearchRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/ReactiveElasticsearchRepositoryFactory.java
@@ -47,6 +47,7 @@ import org.springframework.util.Assert;
  * instances.
  *
  * @author Christoph Strobl
+ * @author Ivan Greene
  * @since 3.2
  */
 public class ReactiveElasticsearchRepositoryFactory extends ReactiveRepositoryFactorySupport {
@@ -116,7 +117,7 @@ public class ReactiveElasticsearchRepositoryFactory extends ReactiveRepositoryFa
 		ElasticsearchPersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(domainClass);
 
 		return new MappingElasticsearchEntityInformation<>((ElasticsearchPersistentEntity<T>) entity, entity.getIndexName(),
-				entity.getIndexType());
+				entity.getIndexType(), entity.getVersionType());
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/elasticsearch/entities/GTEVersionEntity.java
+++ b/src/test/java/org/springframework/data/elasticsearch/entities/GTEVersionEntity.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.entities;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.elasticsearch.index.VersionType;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Version;
+import org.springframework.data.elasticsearch.annotations.Document;
+
+/**
+ * @author Ivan Greene
+ */
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Builder
+@Document(indexName = "test-index-sample", type = "test-type", shards = 1, replicas = 0,
+		  refreshInterval = "-1", versionType = VersionType.EXTERNAL_GTE)
+public class GTEVersionEntity {
+
+	@Version
+	private Long version;
+
+	@Id
+	private String id;
+
+	private String name;
+}


### PR DESCRIPTION
- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Add the ability to specify a version type for documents. This should be mostly passive as the default has been EXTERNAL. The only breaking changes would be to the interfaces `ElasticsearchPersistentEntity` and `ElasticsearchEntityInformation` which expand and thus would break user's custom implementations unless they are extending the provided implementations. Any advice on the preferred way to deal with these additions is appreciated.