### PR TITLE
DATAES-546 - Escaped double quotes in code snippet

### DIFF
--- a/src/main/asciidoc/reference/data-elasticsearch.adoc
+++ b/src/main/asciidoc/reference/data-elasticsearch.adoc
@@ -281,7 +281,7 @@ A list of supported keywords for Elasticsearch is shown below.
 [source,java]
 ----
 public interface BookRepository extends ElasticsearchRepository<Book, String> {
-    @Query("{"bool" : {"must" : {"field" : {"name" : "?0"}}}}")
+    @Query("{\"bool\" : {\"must\" : {\"field\" : {\"name\" : \"?0\"}}}}")
     Page<Book> findByName(String name,Pageable pageable);
 }                
 ----


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes. (1)
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only). (2)

This is only a documentation (AsciiDoc) change, so the last three bullet points seem to be irrelevant (unless I missed an author section somewhere in the AsciiDoc). The documentation for the `@Query` annotation does not escape the inner double quotes.
