### PR TITLE
DATAES-544 - Add dynamic index name support

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/annotations/IndexName.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/IndexName.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.annotations;
+
+import org.springframework.data.annotation.Persistent;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates a property of a Document
+ * to indicate that it is the index name.
+ *
+ * @author Ivan Greene
+ */
+@Persistent
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface IndexName {
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchOperations.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchOperations.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
  * @author Mohsin Husen
  * @author Kevin Leturc
  * @author Zetang Zeng
+ * @author Ivan Greene
  */
 public interface ElasticsearchOperations {
 
@@ -82,6 +83,15 @@ public interface ElasticsearchOperations {
 	 * @param <T>
 	 */
 	<T> boolean putMapping(Class<T> clazz);
+
+	/**
+	 * Create mapping for a class in the given index
+	 *
+	 * @param indexName
+	 * @param clazz
+	 * @param <T>
+	 */
+	<T> boolean putMapping(String indexName, Class<T> clazz);
 
 	/**
 	 * Create mapping for a given indexName and type

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
@@ -202,6 +202,11 @@ public class ElasticsearchRestTemplate
 
 	@Override
 	public <T> boolean putMapping(Class<T> clazz) {
+		return putMapping(getPersistentEntityFor(clazz).getIndexName(), clazz);
+	}
+
+	@Override
+	public <T> boolean putMapping(String indexName, Class<T> clazz) {
 		if (clazz.isAnnotationPresent(Mapping.class)) {
 			String mappingPath = clazz.getAnnotation(Mapping.class).mappingPath();
 			if (hasText(mappingPath)) {
@@ -224,7 +229,7 @@ public class ElasticsearchRestTemplate
 		} catch (Exception e) {
 			throw new ElasticsearchException("Failed to build mapping for " + clazz.getSimpleName(), e);
 		}
-		return putMapping(clazz, xContentBuilder);
+		return putMapping(indexName, persistentEntity.getIndexType(), xContentBuilder);
 	}
 
 	@Override
@@ -303,7 +308,9 @@ public class ElasticsearchRestTemplate
 	@Override
 	public <T> T queryForObject(GetQuery query, Class<T> clazz, GetResultMapper mapper) {
 		ElasticsearchPersistentEntity<T> persistentEntity = getPersistentEntityFor(clazz);
-		GetRequest request = new GetRequest(persistentEntity.getIndexName(), persistentEntity.getIndexType(),
+		String indexName = query.getIndexName() == null ? persistentEntity.getIndexName()
+				: query.getIndexName();
+		GetRequest request = new GetRequest(indexName, persistentEntity.getIndexType(),
 				query.getId());
 		GetResponse response;
 		try {

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentEntity.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentEntity.java
@@ -33,6 +33,10 @@ public interface ElasticsearchPersistentEntity<T> extends PersistentEntity<T, El
 
 	String getIndexName();
 
+	boolean hasIndexNameProperty();
+
+	ElasticsearchPersistentProperty getIndexNameProperty();
+
 	String getIndexType();
 
 	short getShards();

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentProperty.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentProperty.java
@@ -25,6 +25,7 @@ import org.springframework.data.mapping.PersistentProperty;
  * @author Mohsin Husen
  * @author Sascha Woo
  * @author Oliver Gierke
+ * @author Ivan Greene
  */
 public interface ElasticsearchPersistentProperty extends PersistentProperty<ElasticsearchPersistentProperty> {
 
@@ -53,6 +54,14 @@ public interface ElasticsearchPersistentProperty extends PersistentProperty<Elas
 	 * @since 3.1
 	 */
 	boolean isParentProperty();
+
+	/**
+	 * Returns whether the current property is the index name property of the owning
+	 * {@link ElasticsearchPersistentEntity}.
+	 *
+	 * @return
+	 */
+	boolean isIndexNameProperty();
 
 	public enum PropertyToFieldNameConverter implements Converter<ElasticsearchPersistentProperty, String> {
 

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/SimpleElasticsearchPersistentProperty.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/SimpleElasticsearchPersistentProperty.java
@@ -18,6 +18,7 @@ package org.springframework.data.elasticsearch.core.mapping;
 import java.util.Arrays;
 import java.util.List;
 
+import org.springframework.data.elasticsearch.annotations.IndexName;
 import org.springframework.data.elasticsearch.annotations.Parent;
 import org.springframework.data.elasticsearch.annotations.Score;
 import org.springframework.data.mapping.Association;
@@ -35,6 +36,7 @@ import org.springframework.data.mapping.model.SimpleTypeHolder;
  * @author Mark Paluch
  * @author Sascha Woo
  * @author Oliver Gierke
+ * @author Ivan Greene
  */
 public class SimpleElasticsearchPersistentProperty extends
 		AnnotationBasedPersistentProperty<ElasticsearchPersistentProperty> implements ElasticsearchPersistentProperty {
@@ -44,6 +46,7 @@ public class SimpleElasticsearchPersistentProperty extends
 	private final boolean isScore;
 	private final boolean isParent;
 	private final boolean isId;
+	private final boolean isIndexName;
 
 	public SimpleElasticsearchPersistentProperty(Property property,
 			PersistentEntity<?, ElasticsearchPersistentProperty> owner, SimpleTypeHolder simpleTypeHolder) {
@@ -53,6 +56,7 @@ public class SimpleElasticsearchPersistentProperty extends
 		this.isId = super.isIdProperty() || SUPPORTED_ID_PROPERTY_NAMES.contains(getFieldName());
 		this.isScore = isAnnotationPresent(Score.class);
 		this.isParent = isAnnotationPresent(Parent.class);
+		this.isIndexName = isAnnotationPresent(IndexName.class);
 
 		if (isVersionProperty() && getType() != Long.class) {
 			throw new MappingException(String.format("Version property %s must be of type Long!", property.getName()));
@@ -65,6 +69,10 @@ public class SimpleElasticsearchPersistentProperty extends
 
 		if (isParent && getType() != String.class) {
 			throw new MappingException(String.format("Parent property %s must be of type String!", property.getName()));
+		}
+
+		if (isIndexName && getType() != String.class) {
+			throw new MappingException(String.format("Index name property %s must be of type String!", property.getName()));
 		}
 	}
 
@@ -120,5 +128,10 @@ public class SimpleElasticsearchPersistentProperty extends
 	@Override
 	public boolean isParentProperty() {
 		return isParent;
+	}
+
+	@Override
+	public boolean isIndexNameProperty() {
+		return isIndexName;
 	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/GetQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/GetQuery.java
@@ -20,10 +20,12 @@ package org.springframework.data.elasticsearch.core.query;
  *
  * @author Rizwan Idrees
  * @author Mohsin Husen
+ * @author Ivan Greene
  */
 public class GetQuery {
 
 	private String id;
+	private String indexName;
 
 	public String getId() {
 		return id;
@@ -31,6 +33,14 @@ public class GetQuery {
 
 	public void setId(String id) {
 		this.id = id;
+	}
+
+	public String getIndexName() {
+		return indexName;
+	}
+
+	public void setIndexName(String indexName) {
+		this.indexName = indexName;
 	}
 
 	public static GetQuery getById(String id) {

--- a/src/main/java/org/springframework/data/elasticsearch/repository/IndexedCrudRepository.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/IndexedCrudRepository.java
@@ -1,0 +1,29 @@
+package org.springframework.data.elasticsearch.repository;
+
+import org.springframework.data.repository.NoRepositoryBean;
+
+import java.util.Optional;
+
+/**
+ * Describes methods complementing those in {@link org.springframework.data.repository.CrudRepository}
+ * with a signature accepting an index name, to allow for dynamic index names.
+ *
+ * @author Ivan Greene
+ */
+@NoRepositoryBean
+public interface IndexedCrudRepository<T, ID> extends ElasticsearchRepository<T, ID> {
+
+    Optional<T> findById(String indexName, ID id);
+
+    boolean existsById(String indexName, ID id);
+
+    Iterable<T> findAll(String indexName);
+
+    Iterable<T> findAllById(String indexName, Iterable<ID> ids);
+
+    long count(String indexName);
+
+    void deleteById(String indexName, ID id);
+
+    void deleteAll(String indexName);
+}

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchEntityInformation.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchEntityInformation.java
@@ -32,6 +32,8 @@ public interface ElasticsearchEntityInformation<T, ID> extends EntityInformation
 
 	String getIndexName();
 
+	String getIndexName(T entity);
+
 	String getType();
 
 	Long getVersion(T entity);

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/MappingElasticsearchEntityInformation.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/MappingElasticsearchEntityInformation.java
@@ -44,13 +44,12 @@ public class MappingElasticsearchEntityInformation<T, ID> extends PersistentEnti
 	private final VersionType versionType;
 
 	public MappingElasticsearchEntityInformation(ElasticsearchPersistentEntity<T> entity) {
-		this(entity, entity.getIndexName(), entity.getIndexType(), entity.getVersionType());
+		this(entity, entity.hasIndexNameProperty() ? null : entity.getIndexName(), entity.getIndexType(), entity.getVersionType());
 	}
 
 	public MappingElasticsearchEntityInformation(ElasticsearchPersistentEntity<T> entity, String indexName, String type, VersionType versionType) {
 		super(entity);
 
-		Assert.notNull(indexName, "IndexName must not be null!");
 		Assert.notNull(type, "IndexType must not be null!");
 
 		this.entityMetadata = entity;
@@ -65,7 +64,20 @@ public class MappingElasticsearchEntityInformation<T, ID> extends PersistentEnti
 	}
 
 	@Override
+	public String getIndexName(T entity) {
+		if (indexName != null) {
+			return indexName;
+		}
+		ElasticsearchPersistentProperty indexNameProperty = entityMetadata.getIndexNameProperty();
+		return (String) entityMetadata.getPropertyAccessor(entity).getProperty(indexNameProperty);
+	}
+
+	@Override
 	public String getIndexName() {
+		if (indexName == null) {
+			// This will throw UnsupportedOperationException if index name is unavailable statically
+			return entityMetadata.getIndexName();
+		}
 		return indexName;
 	}
 

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/ReactiveElasticsearchRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/ReactiveElasticsearchRepositoryFactory.java
@@ -116,8 +116,7 @@ public class ReactiveElasticsearchRepositoryFactory extends ReactiveRepositoryFa
 
 		ElasticsearchPersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(domainClass);
 
-		return new MappingElasticsearchEntityInformation<>((ElasticsearchPersistentEntity<T>) entity, entity.getIndexName(),
-				entity.getIndexType(), entity.getVersionType());
+		return new MappingElasticsearchEntityInformation<>((ElasticsearchPersistentEntity<T>) entity);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/SimpleReactiveElasticsearchRepository.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/SimpleReactiveElasticsearchRepository.java
@@ -27,6 +27,7 @@ import org.springframework.util.Assert;
 
 /**
  * @author Christoph Strobl
+ * @author Ivan Greene
  * @since 3.2
  */
 public class SimpleReactiveElasticsearchRepository<T, ID> implements ReactiveElasticsearchRepository<T, ID> {
@@ -55,7 +56,7 @@ public class SimpleReactiveElasticsearchRepository<T, ID> implements ReactiveEla
 	public <S extends T> Mono<S> save(S entity) {
 
 		Assert.notNull(entity, "Entity must not be null!");
-		return elasticsearchOperations.save(entity, entityInformation.getIndexName(), entityInformation.getType());
+		return elasticsearchOperations.save(entity, entityInformation.getIndexName(entity), entityInformation.getType());
 	}
 
 	@Override
@@ -152,7 +153,7 @@ public class SimpleReactiveElasticsearchRepository<T, ID> implements ReactiveEla
 	public Mono<Void> delete(T entity) {
 
 		Assert.notNull(entity, "Entity must not be null!");
-		return elasticsearchOperations.delete(entity, entityInformation.getIndexName(), entityInformation.getType()) //
+		return elasticsearchOperations.delete(entity, entityInformation.getIndexName(entity), entityInformation.getType()) //
 				.then();
 	}
 

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
@@ -62,6 +62,7 @@ import org.springframework.data.elasticsearch.core.aggregation.AggregatedPage;
 import org.springframework.data.elasticsearch.core.aggregation.impl.AggregatedPageImpl;
 import org.springframework.data.elasticsearch.core.query.*;
 import org.springframework.data.elasticsearch.entities.Book;
+import org.springframework.data.elasticsearch.entities.DynamicIndexEntity;
 import org.springframework.data.elasticsearch.entities.GTEVersionEntity;
 import org.springframework.data.elasticsearch.entities.HetroEntity1;
 import org.springframework.data.elasticsearch.entities.HetroEntity2;
@@ -2596,6 +2597,32 @@ public class ElasticsearchTemplateTests {
 		assertThat(sampleEntities.size(), is(equalTo(2)));
 		assertThat(sampleEntities.stream().map(SampleEntity::getMessage).collect(Collectors.toList()),
 				not(contains(notFindableMessage)));
+	}
+
+	// DATAES-544
+	@Test(expected = UnsupportedOperationException.class)
+	public void shouldNotPutMappingForDynamicIndexEntity() {
+		elasticsearchTemplate.putMapping(DynamicIndexEntity.class);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void shouldNotDeleteIndexForDynamicIndexEntity() {
+		elasticsearchTemplate.deleteIndex(DynamicIndexEntity.class);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void shouldNotCreateIndexForDynamicIndexEntity() {
+		elasticsearchTemplate.createIndex(DynamicIndexEntity.class);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void shouldNotRefreshForDynamicIndexEntity() {
+		elasticsearchTemplate.refresh(DynamicIndexEntity.class);
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void shouldNotIndexExistsForDynamicIndexEntity() {
+		elasticsearchTemplate.indexExists(DynamicIndexEntity.class);
 	}
 
 	private IndexQuery getIndexQuery(SampleEntity sampleEntity) {

--- a/src/test/java/org/springframework/data/elasticsearch/entities/DynamicIndexEntity.java
+++ b/src/test/java/org/springframework/data/elasticsearch/entities/DynamicIndexEntity.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.entities;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.IndexName;
+
+/**
+ * @author Ivan Greene
+ */
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Document(indexName = "", type = "dynamic_index_entity")
+public class DynamicIndexEntity {
+
+	@IndexName
+	private String index;
+
+	@Id
+	private String id;
+
+	@Field(type = FieldType.Text)
+	private String name;
+}

--- a/src/test/java/org/springframework/data/elasticsearch/repositories/dynamicindex/DynamicIndexRepository.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repositories/dynamicindex/DynamicIndexRepository.java
@@ -1,0 +1,10 @@
+package org.springframework.data.elasticsearch.repositories.dynamicindex;
+
+import org.springframework.data.elasticsearch.entities.DynamicIndexEntity;
+import org.springframework.data.elasticsearch.repository.IndexedCrudRepository;
+
+/**
+ * @author Ivan Greene
+ */
+public interface DynamicIndexRepository extends IndexedCrudRepository<DynamicIndexEntity, String> {
+}

--- a/src/test/java/org/springframework/data/elasticsearch/repository/support/DynamicIndexRepositoryTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repository/support/DynamicIndexRepositoryTests.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.repository.support;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.elasticsearch.core.ElasticsearchTemplate;
+import org.springframework.data.elasticsearch.entities.DynamicIndexEntity;
+import org.springframework.data.elasticsearch.repositories.dynamicindex.DynamicIndexRepository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Ivan Greene
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("classpath:/dynamic-index-repository-test.xml")
+public class DynamicIndexRepositoryTests {
+
+	@Autowired private DynamicIndexRepository repository;
+
+	@Autowired private ElasticsearchTemplate elasticsearchTemplate;
+
+	private String indexNameA = "test-dyn-index-one";
+	private String indexNameB = "test-dyn-index-two";
+
+	@Before
+	public void before() {
+		elasticsearchTemplate.deleteIndex(indexNameA);
+		elasticsearchTemplate.createIndex(indexNameA);
+		elasticsearchTemplate.putMapping(indexNameA, DynamicIndexEntity.class);
+		elasticsearchTemplate.refresh(indexNameA);
+		elasticsearchTemplate.deleteIndex(indexNameB);
+		elasticsearchTemplate.createIndex(indexNameB);
+		elasticsearchTemplate.putMapping(indexNameB, DynamicIndexEntity.class);
+		elasticsearchTemplate.refresh(indexNameB);
+	}
+
+	private DynamicIndexEntity storeTestDocument(String indexName, String id, String name) {
+		DynamicIndexEntity entity = DynamicIndexEntity.builder()
+				.id(id)
+				.index(indexName)
+				.name(name)
+				.build();
+		return repository.save(entity);
+	}
+
+	@Test
+	public void shouldDoBasicCrud() {
+		// given
+		String documentIdA = RandomStringUtils.random(10);
+		String nameA = RandomStringUtils.random(10);
+
+		String documentIdB = RandomStringUtils.random(10);
+		String nameB = RandomStringUtils.random(10);
+
+		DynamicIndexEntity entityA = storeTestDocument(indexNameA, documentIdA, nameA);
+		DynamicIndexEntity entityB = storeTestDocument(indexNameB, documentIdB, nameB);
+
+		// then
+		assertEquals(1, repository.count(indexNameA));
+		assertTrue(repository.existsById(indexNameA, documentIdA));
+
+		Optional<DynamicIndexEntity> entityAFromElasticSearch = repository.findById(indexNameA, documentIdA);
+		assertTrue(entityAFromElasticSearch.isPresent());
+		assertEquals(entityA, entityAFromElasticSearch.get());
+
+		assertEquals(1, repository.count(indexNameB));
+		assertTrue(repository.existsById(indexNameB, documentIdB));
+
+		Optional<DynamicIndexEntity> entityBFromElasticSearch = repository.findById(indexNameB, documentIdB);
+		assertTrue(entityBFromElasticSearch.isPresent());
+		assertEquals(entityB, entityBFromElasticSearch.get());
+
+		repository.delete(entityA);
+		assertEquals(0, repository.count(indexNameA));
+		repository.deleteById(indexNameB, documentIdB);
+		assertEquals(0, repository.count(indexNameB));
+	}
+
+	@Test
+	public void shouldFindAll() {
+		List<DynamicIndexEntity> entities = Stream.generate(() -> storeTestDocument(indexNameA, RandomStringUtils.random(10), RandomStringUtils.random(10)))
+				.limit(10)
+				.collect(Collectors.toList());
+
+		List<DynamicIndexEntity> all = new ArrayList<>();
+		repository.findAll(indexNameA).forEach(all::add);
+
+		assertEquals(10, all.size());
+		assertTrue(all.containsAll(entities));
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void shouldNotFindAll() {
+		repository.findAll();
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void shouldNotDeleteAll() {
+		repository.deleteAll();
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void shouldNotCount() {
+		repository.count();
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void shouldNotRefresh() {
+		repository.refresh();
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void shouldNotExistsById() {
+		repository.existsById("foo");
+	}
+
+}

--- a/src/test/resources/dynamic-index-repository-test.xml
+++ b/src/test/resources/dynamic-index-repository-test.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:elasticsearch="http://www.springframework.org/schema/data/elasticsearch"
+       xsi:schemaLocation="http://www.springframework.org/schema/data/elasticsearch http://www.springframework.org/schema/data/elasticsearch/spring-elasticsearch.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+
+    <import resource="infrastructure.xml"/>
+
+    <bean name="elasticsearchTemplate"
+          class="org.springframework.data.elasticsearch.core.ElasticsearchTemplate">
+        <constructor-arg name="client" ref="client"/>
+    </bean>
+
+
+    <elasticsearch:repositories
+            base-package="org.springframework.data.elasticsearch.repositories.dynamicindex"/>
+
+</beans>


### PR DESCRIPTION
Adds dynamic index name support for documents. For operations like findAll or deleteAll, we throw an UnsupportedOperationException indicating that the index name is not accessible without an instance. We add the interface `IndexedCrudRepository` with methods complementing those in CrudRepository to accept an index name, such as `findAll(String indexName)`, `deleteAll(String indexName)`, `count(String indexName)`, etc to make this more manageable when we don't necessarily have an instance of the entity in hand, but still know the dynamic index name.

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).