### PR TITLE
DATAES-552 - @Query annotation fail when passing over 10 parameters

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchStringQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchStringQuery.java
@@ -32,6 +32,7 @@ import org.springframework.util.Assert;
  * @author Rizwan Idrees
  * @author Mohsin Husen
  * @author Mark Paluch
+ * @author Taylor Ono
  */
 public class ElasticsearchStringQuery extends AbstractElasticsearchRepositoryQuery {
 
@@ -86,8 +87,9 @@ public class ElasticsearchStringQuery extends AbstractElasticsearchRepositoryQue
 		String result = input;
 		while (matcher.find()) {
 			String group = matcher.group();
+			group = "\\" + group;
 			int index = Integer.parseInt(matcher.group(1));
-			result = result.replace(group, getParameterWithIndex(accessor, index));
+			result = result.replaceFirst(group, getParameterWithIndex(accessor, index));
 		}
 		return result;
 	}

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ReactiveElasticsearchStringQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ReactiveElasticsearchStringQuery.java
@@ -26,6 +26,7 @@ import org.springframework.util.ObjectUtils;
 
 /**
  * @author Christoph Strobl
+ * @author Taylor Ono
  * @since 3.2
  */
 public class ReactiveElasticsearchStringQuery extends AbstractReactiveElasticsearchRepositoryQuery {
@@ -60,8 +61,9 @@ public class ReactiveElasticsearchStringQuery extends AbstractReactiveElasticsea
 		String result = input;
 		while (matcher.find()) {
 			String group = matcher.group();
+			group = "\\" + group;
 			int index = Integer.parseInt(matcher.group(1));
-			result = result.replace(group, getParameterWithIndex(accessor, index));
+			result = result.replaceFirst(group, getParameterWithIndex(accessor, index));
 		}
 		return result;
 	}

--- a/src/test/java/org/springframework/data/elasticsearch/repository/query/ReactiveElasticsearchStringQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repository/query/ReactiveElasticsearchStringQueryUnitTests.java
@@ -87,6 +87,18 @@ public class ReactiveElasticsearchStringQueryUnitTests {
 		assertThat(((StringQuery) query).getSource()).isEqualTo(reference.getSource());
 	}
 
+    @Test // DATAES-552
+    public void shouldReplaceLotsOfParametersCorrectly() throws Exception{
+        ReactiveElasticsearchStringQuery elasticsearchStringQuery = createQueryForMethod("findWithQuiteSomeParameters", String.class, String.class,
+                String.class, String.class, String.class, String.class, String.class, String.class, String.class, String.class,
+                String.class, String.class);
+        StubParameterAccessor accesor = new StubParameterAccessor("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l");
+        org.springframework.data.elasticsearch.core.query.Query query = elasticsearchStringQuery.createQuery(accesor);
+        StringQuery reference = new StringQuery("name:(a, b, c, d, e, f, g, h, i, j, k, l)");
+        assertThat(query).isInstanceOf(StringQuery.class);
+        assertThat(((StringQuery) query).getSource()).isEqualTo(reference.getSource());
+    }
+
 	private ReactiveElasticsearchStringQuery createQueryForMethod(String name, Class<?>... parameters) throws Exception {
 
 		Method method = SampleRepository.class.getMethod(name, parameters);
@@ -104,5 +116,9 @@ public class ReactiveElasticsearchStringQueryUnitTests {
 
 		@Query("{ 'bool' : { 'must' : { 'term' : { 'name' : '?#{[0]}' } } } }")
 		Flux<Person> findByNameWithExpression(String param0);
+
+		@Query(value = "name:(?0, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)")
+		Person findWithQuiteSomeParameters(String arg0, String arg1, String arg2, String arg3, String arg4,
+												String arg5, String arg6, String arg7, String arg8, String arg9, String arg10, String arg11);
 	}
 }


### PR DESCRIPTION
Updated the replacePlaceholders method to use replaceFirst to prevent duplication substitutions

Additional explanations if necessary.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
