### PR TITLE
DATAES-563 - Repositories configuration assume "elasticsearchTemplate…

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/config/AbstractElasticsearchConfiguration.java
+++ b/src/main/java/org/springframework/data/elasticsearch/config/AbstractElasticsearchConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate;
 
 /**
  * @author Christoph Strobl
+ * @author Peter-Josef Meisch
  * @since 3.2
  * @see ElasticsearchConfigurationSupport
  */
@@ -41,7 +42,7 @@ public abstract class AbstractElasticsearchConfiguration extends ElasticsearchCo
 	 *
 	 * @return never {@literal null}.
 	 */
-	@Bean
+	@Bean(name = {"elasticsearchOperations", "elasticsearchTemplate"})
 	public ElasticsearchOperations elasticsearchOperations() {
 		return new ElasticsearchRestTemplate(elasticsearchClient(), elasticsearchConverter(), resultsMapper());
 	}

--- a/src/test/java/org/springframework/data/elasticsearch/config/ElasticsearchConfigurationSupportUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/config/ElasticsearchConfigurationSupportUnitTests.java
@@ -85,6 +85,20 @@ public class ElasticsearchConfigurationSupportUnitTests {
 		assertThat(context.getBean(ElasticsearchRestTemplate.class)).isNotNull();
 	}
 
+	@Test // DATAES-563
+	public void restConfigContainsElasticsearchOperationsByName() {
+
+		AbstractApplicationContext context = new AnnotationConfigApplicationContext(RestConfig.class);
+		assertThat(context.getBean("elasticsearchOperations")).isNotNull();
+	}
+
+	@Test // DATAES-563
+	public void restConfigContainsElasticsearchTemplateByName() {
+
+		AbstractApplicationContext context = new AnnotationConfigApplicationContext(RestConfig.class);
+		assertThat(context.getBean("elasticsearchTemplate")).isNotNull();
+	}
+
 	@Test // DATAES-504
 	public void reactiveConfigContainsReactiveElasticsearchTemplate() {
 

--- a/src/test/java/org/springframework/data/elasticsearch/config/ElasticsearchConfigurationTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/config/ElasticsearchConfigurationTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.config;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import org.elasticsearch.client.RestHighLevelClient;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.repositories.existing.index.CreateIndexFalseRepository;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Peter-Josef Meisch
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration
+public class ElasticsearchConfigurationTests {
+
+	/*
+	 * using a repository with an entity that is set to createIndex = false as we have no elastic running for this test
+	 * and just check that all the necessary beans are created.
+	 */
+	@Autowired private CreateIndexFalseRepository repository;
+
+	@Configuration
+	@EnableElasticsearchRepositories(
+			basePackages = { "org.springframework.data.elasticsearch.repositories.existing.index",
+					"org.springframework.data.elasticsearch.config" })
+	static class Config extends AbstractElasticsearchConfiguration {
+
+		@Override
+		public RestHighLevelClient elasticsearchClient() {
+			return mock(RestHighLevelClient.class);
+		}
+
+	}
+
+	@Test // DATAES-563
+	public void bootstrapsRepository() {
+		assertThat(repository, is(notNullValue()));
+	}
+}


### PR DESCRIPTION
…" bean name.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

template supports uses name based bean lookup and wants a "elasticsearchTemplate" bean, so this PR adds the bean name to the elasticsearchOperations bean.
