### PR TITLE
DATAES-407 - Polishing.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/AbstractElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/AbstractElasticsearchTemplate.java
@@ -1,28 +1,77 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.data.elasticsearch.core;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.search.SearchHit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
 import org.springframework.data.elasticsearch.ElasticsearchException;
+import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Mapping;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
+import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentEntity;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
  * AbstractElasticsearchTemplate
- * 
+ *
  * @author Sascha Woo
  */
-public abstract class AbstractElasticsearchTemplate {
+public abstract class AbstractElasticsearchTemplate implements ElasticsearchOperations, ApplicationContextAware {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(AbstractElasticsearchTemplate.class);
 
-	protected ElasticsearchConverter elasticsearchConverter;
+	protected final EntityOperations operations;
+	protected final ElasticsearchConverter elasticsearchConverter;
 
 	public AbstractElasticsearchTemplate(ElasticsearchConverter elasticsearchConverter) {
 
-		Assert.notNull(elasticsearchConverter, "elasticsearchConverter must not be null.");
+		Assert.notNull(elasticsearchConverter, "elasticsearchConverter must not be null!");
 		this.elasticsearchConverter = elasticsearchConverter;
+		this.operations = new EntityOperations(elasticsearchConverter.getMappingContext());
+	}
+
+	@Override
+	public ElasticsearchConverter getElasticsearchConverter() {
+		return elasticsearchConverter;
+	}
+
+	@Override
+	public ElasticsearchPersistentEntity<?> getPersistentEntityFor(Class<?> type) {
+
+		Assert.notNull(type, "type must not be null!");
+		Assert.isTrue(type.isAnnotationPresent(Document.class), "Unable to identify index name. " + type.getSimpleName()
+				+ " is not a Document. Make sure the document class is annotated with @Document(indexName=\"foo\")");
+
+		return elasticsearchConverter.getMappingContext().getRequiredPersistentEntity(type);
+	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext context) throws BeansException {
+		if (elasticsearchConverter instanceof ApplicationContextAware) {
+			((ApplicationContextAware) elasticsearchConverter).setApplicationContext(context);
+		}
 	}
 
 	protected String buildMapping(Class<?> clazz) {
@@ -47,6 +96,16 @@ public abstract class AbstractElasticsearchTemplate {
 		} catch (Exception e) {
 			throw new ElasticsearchException("Failed to build mapping for " + clazz.getSimpleName(), e);
 		}
+	}
+
+	protected List<String> extractIds(SearchResponse response) {
+
+		List<String> ids = new ArrayList<>();
+		for (SearchHit hit : response.getHits()) {
+			if (hit != null)
+				ids.add(hit.getId());
+		}
+		return ids;
 	}
 
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchOperations.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchOperations.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.springframework.data.domain.Page;
+import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentEntity;
 import org.springframework.data.elasticsearch.core.query.AliasQuery;
@@ -46,6 +47,7 @@ import org.springframework.lang.Nullable;
  * @author Zetang Zeng
  * @author Dmitriy Yakovlev
  * @author Peter-Josef Meisch
+ * @author Sascha Woo
  */
 public interface ElasticsearchOperations {
 
@@ -668,7 +670,14 @@ public interface ElasticsearchOperations {
 	 */
 	<T> Page<T> moreLikeThis(MoreLikeThisQuery query, Class<T> clazz);
 
-	ElasticsearchPersistentEntity getPersistentEntityFor(Class clazz);
+	/**
+	 * Returns a required {@link ElasticsearchPersistentEntity} for the given {@link Class}. Will throw
+	 * {@link IllegalArgumentException} for types that are not annotated with {@link Document} or considered simple ones.
+	 * 
+	 * @param @param type must not be {@literal null}.
+	 * @return the required {@link ElasticsearchPersistentEntity}
+	 */
+	ElasticsearchPersistentEntity<?> getPersistentEntityFor(Class<?> type);
 
 	/**
 	 * @return Converter in use

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchUtils.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core;
+
+import java.lang.reflect.Array;
+import java.util.List;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Utility methods for use in elasticsearch core.
+ * 
+ * @author Sascha Woo
+ */
+abstract class ElasticsearchUtils {
+
+	/**
+	 * Converts the given {@link List} of strings into an {@link Array} of strings.
+	 * 
+	 * @param values the {@link List} of strings
+	 * @return an {@link Array} of strings
+	 */
+	static String[] toArray(@Nullable List<String> values) {
+		if (values == null)
+			return new String[] {};
+		return values.toArray(new String[values.size()]);
+	}
+
+	/**
+	 * Create a type-safe generic array.
+	 * 
+	 * @param <T>
+	 * @param values the values of type {@code T}
+	 * @return type-safe generic array of type {@code T}
+	 */
+	@SafeVarargs
+	static <T> T[] toArray(T... values) {
+		return values;
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/UpdateQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/UpdateQuery.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.data.elasticsearch.core.query;
 
-import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 
 /**
@@ -28,7 +27,7 @@ public class UpdateQuery {
 	private UpdateRequest updateRequest;
 	private String indexName;
 	private String type;
-	private Class clazz;
+	private Class<?> clazz;
 	private boolean doUpsert;
 
 	public String getId() {
@@ -63,11 +62,11 @@ public class UpdateQuery {
 		this.type = type;
 	}
 
-	public Class getClazz() {
+	public Class<?> getClazz() {
 		return clazz;
 	}
 
-	public void setClazz(Class clazz) {
+	public void setClazz(Class<?> clazz) {
 		this.clazz = clazz;
 	}
 


### PR DESCRIPTION
* unify code between ElasticsearchTemplate and ElasticseachRestTemplate
* fix sort by score in ElasticseachRestTemplate
* fix removing an alias in ElasticseachRestTemplate (DATAES-541)
* improve assertion for index name and index type
* reduce dupe code
* add missing generics
* extend ElasticsearchOperations with more methods and use it template
* reuse ObjectMapper in ElasticseachRestTemplate
* organize imports + formatter
* cleanup code + remove unused methods

@mp911de @christophstrobl @akonczak Would you mind taking a look at this polishing commit
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
