### PR TITLE
DATAES-568 - MappingBuilder must use the @Field annotation's name att…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,13 @@
 			</exclusions>
 		</dependency>
 
+		<dependency>
+			<groupId>org.skyscreamer</groupId>
+			<artifactId>jsonassert</artifactId>
+			<version>1.5.0</version>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- Upgrade xbean to 4.5 to prevent incompatibilities due to ASM versions -->
 		<dependency>
 			<groupId>org.apache.xbean</groupId>

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
@@ -17,7 +17,6 @@ package org.springframework.data.elasticsearch.core;
 
 import static org.elasticsearch.client.Requests.*;
 import static org.elasticsearch.index.query.QueryBuilders.*;
-import static org.springframework.data.elasticsearch.core.MappingBuilder.*;
 import static org.springframework.util.CollectionUtils.isEmpty;
 import static org.springframework.util.StringUtils.*;
 
@@ -223,18 +222,12 @@ public class ElasticsearchRestTemplate
 				logger.info("mappingPath in @Mapping has to be defined. Building mappings using @Field");
 			}
 		}
-		ElasticsearchPersistentEntity<T> persistentEntity = getPersistentEntityFor(clazz);
-		XContentBuilder xContentBuilder = null;
 		try {
-
-			ElasticsearchPersistentProperty property = persistentEntity.getRequiredIdProperty();
-
-			xContentBuilder = buildMapping(clazz, persistentEntity.getIndexType(), property.getFieldName(),
-					persistentEntity.getParentType());
+			MappingBuilder mappingBuilder = new MappingBuilder(elasticsearchConverter);
+			return putMapping(clazz, mappingBuilder.buildMapping(clazz));
 		} catch (Exception e) {
 			throw new ElasticsearchException("Failed to build mapping for " + clazz.getSimpleName(), e);
 		}
-		return putMapping(clazz, xContentBuilder);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
@@ -17,7 +17,6 @@ package org.springframework.data.elasticsearch.core;
 
 import static org.elasticsearch.client.Requests.*;
 import static org.elasticsearch.index.query.QueryBuilders.*;
-import static org.springframework.data.elasticsearch.core.MappingBuilder.*;
 import static org.springframework.util.CollectionUtils.*;
 
 import java.io.BufferedReader;
@@ -205,18 +204,12 @@ public class ElasticsearchTemplate implements ElasticsearchOperations, EsClient<
 				LOGGER.info("mappingPath in @Mapping has to be defined. Building mappings using @Field");
 			}
 		}
-		ElasticsearchPersistentEntity<T> persistentEntity = getPersistentEntityFor(clazz);
-		XContentBuilder xContentBuilder = null;
 		try {
-
-			ElasticsearchPersistentProperty property = persistentEntity.getRequiredIdProperty();
-
-			xContentBuilder = buildMapping(clazz, persistentEntity.getIndexType(), property.getFieldName(),
-					persistentEntity.getParentType());
+			MappingBuilder mappingBuilder = new MappingBuilder(elasticsearchConverter);
+			return putMapping(clazz, mappingBuilder.buildMapping(clazz));
 		} catch (Exception e) {
 			throw new ElasticsearchException("Failed to build mapping for " + clazz.getSimpleName(), e);
 		}
-		return putMapping(clazz, xContentBuilder);
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplateTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplateTests.java
@@ -50,8 +50,8 @@ public class ElasticsearchRestTemplateTests extends ElasticsearchTemplateTests {
 		// when
 		IndexRequest indexRequest = new IndexRequest();
 		indexRequest.source("{}", XContentType.JSON);
-		UpdateQuery updateQuery = new UpdateQueryBuilder().withId(randomNumeric(5))
-				.withClass(SampleEntity.class).withIndexRequest(indexRequest).build();
+		UpdateQuery updateQuery = new UpdateQueryBuilder().withId(randomNumeric(5)).withClass(SampleEntity.class)
+				.withIndexRequest(indexRequest).build();
 		elasticsearchTemplate.update(updateQuery);
 	}
 }

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
@@ -90,8 +90,8 @@ import org.springframework.data.util.CloseableIterator;
  * @author Peter Nowak
  * @author Ivan Greene
  * @author Dmitriy Yakovlev
+ * @author Peter-Josef Meisch
  */
-
 @Ignore
 public class ElasticsearchTemplateTests {
 
@@ -128,6 +128,8 @@ public class ElasticsearchTemplateTests {
 	@Before
 	public void before() {
 
+		deleteIndices();
+
 		elasticsearchTemplate.createIndex(SampleEntity.class);
 		elasticsearchTemplate.putMapping(SampleEntity.class);
 
@@ -137,7 +139,10 @@ public class ElasticsearchTemplateTests {
 
 	@After
 	public void after() {
+		deleteIndices();
+	}
 
+	private void deleteIndices() {
 		elasticsearchTemplate.deleteIndex(SampleEntity.class);
 		elasticsearchTemplate.deleteIndex(SampleEntityUUIDKeyed.class);
 		elasticsearchTemplate.deleteIndex(UseServerConfigurationEntity.class);

--- a/src/test/java/org/springframework/data/elasticsearch/core/MappingContextBaseTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/MappingContextBaseTests.java
@@ -1,0 +1,54 @@
+/* Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.elasticsearch.core;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.springframework.data.elasticsearch.config.ElasticsearchConfigurationSupport;
+import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
+import org.springframework.data.elasticsearch.core.convert.MappingElasticsearchConverter;
+import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
+import org.springframework.data.util.Lazy;
+
+/**
+ * @author Peter-Josef Meisch
+ */
+abstract class MappingContextBaseTests {
+
+	protected final Lazy<ElasticsearchConverter> elasticsearchConverter = Lazy.of(this::setupElasticsearchConverter);
+
+	private ElasticsearchConverter setupElasticsearchConverter() {
+		return new MappingElasticsearchConverter(setupMappingContext());
+	}
+
+	private SimpleElasticsearchMappingContext setupMappingContext() {
+
+		SimpleElasticsearchMappingContext mappingContext = new ElasticsearchConfigurationSupport() {
+			@Override
+			protected Collection<String> getMappingBasePackages() {
+				return Collections.singletonList("org.springframework.data.elasticsearch.entities.mapping");
+			}
+		}.elasticsearchMappingContext();
+
+		mappingContext.initialize();
+		return mappingContext;
+	}
+
+	final MappingBuilder getMappingBuilder() {
+		return new MappingBuilder(elasticsearchConverter.get());
+	}
+}

--- a/src/test/java/org/springframework/data/elasticsearch/core/SimpleDynamicTemplatesMappingTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/SimpleDynamicTemplatesMappingTests.java
@@ -2,8 +2,6 @@ package org.springframework.data.elasticsearch.core;
 
 import java.io.IOException;
 
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -16,35 +14,32 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * Dynamic templates tests
  *
  * @author Petr Kukral
+ * @author Peter-Josef Meisch
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration("classpath:elasticsearch-template-test.xml")
-public class SimpleDynamicTemplatesMappingTests {
+public class SimpleDynamicTemplatesMappingTests extends MappingContextBaseTests {
 
 	@Test
 	public void testCorrectDynamicTemplatesMappings() throws IOException {
-		XContentBuilder xContentBuilder = MappingBuilder.buildMapping(SampleDynamicTemplatesEntity.class,
-				"test-dynamictemplatestype", "id", null);
-		String EXPECTED_MAPPING_ONE = "{\"test-dynamictemplatestype\":{\"dynamic_templates\":" +
-				"[{\"with_custom_analyzer\":{" +
-				"\"mapping\":{\"type\":\"string\",\"analyzer\":\"standard_lowercase_asciifolding\"}," +
-				"\"path_match\":\"names.*\"}}]," +
-				"\"properties\":{\"names\":{\"type\":\"object\"}}}}";
-		Assert.assertEquals(EXPECTED_MAPPING_ONE, Strings.toString(xContentBuilder));
+		String mapping = getMappingBuilder().buildMapping(SampleDynamicTemplatesEntity.class);
+
+		String EXPECTED_MAPPING_ONE = "{\"test-dynamictemplatestype\":{\"dynamic_templates\":"
+				+ "[{\"with_custom_analyzer\":{"
+				+ "\"mapping\":{\"type\":\"string\",\"analyzer\":\"standard_lowercase_asciifolding\"},"
+				+ "\"path_match\":\"names.*\"}}]," + "\"properties\":{\"names\":{\"type\":\"object\"}}}}";
+		Assert.assertEquals(EXPECTED_MAPPING_ONE, mapping);
 	}
 
 	@Test
 	public void testCorrectDynamicTemplatesMappingsTwo() throws IOException {
-		XContentBuilder xContentBuilder = MappingBuilder.buildMapping(SampleDynamicTemplatesEntityTwo.class,
-				"test-dynamictemplatestype", "id", null);
-		String EXPECTED_MAPPING_TWO = "{\"test-dynamictemplatestype\":{\"dynamic_templates\":" +
-				"[{\"with_custom_analyzer\":{" +
-				"\"mapping\":{\"type\":\"string\",\"analyzer\":\"standard_lowercase_asciifolding\"}," +
-				"\"path_match\":\"names.*\"}}," +
-				"{\"participantA1_with_custom_analyzer\":{" +
-				"\"mapping\":{\"type\":\"string\",\"analyzer\":\"standard_lowercase_asciifolding\"}," +
-				"\"path_match\":\"participantA1.*\"}}]," +
-				"\"properties\":{\"names\":{\"type\":\"object\"}}}}";
-		Assert.assertEquals(EXPECTED_MAPPING_TWO, Strings.toString(xContentBuilder));
+		String mapping = getMappingBuilder().buildMapping(SampleDynamicTemplatesEntityTwo.class);
+		String EXPECTED_MAPPING_TWO = "{\"test-dynamictemplatestype\":{\"dynamic_templates\":"
+				+ "[{\"with_custom_analyzer\":{"
+				+ "\"mapping\":{\"type\":\"string\",\"analyzer\":\"standard_lowercase_asciifolding\"},"
+				+ "\"path_match\":\"names.*\"}}," + "{\"participantA1_with_custom_analyzer\":{"
+				+ "\"mapping\":{\"type\":\"string\",\"analyzer\":\"standard_lowercase_asciifolding\"},"
+				+ "\"path_match\":\"participantA1.*\"}}]," + "\"properties\":{\"names\":{\"type\":\"object\"}}}}";
+		Assert.assertEquals(EXPECTED_MAPPING_TWO, mapping);
 	}
 }

--- a/src/test/java/org/springframework/data/elasticsearch/core/SimpleElasticsearchDateMappingTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/SimpleElasticsearchDateMappingTests.java
@@ -15,11 +15,8 @@
  */
 package org.springframework.data.elasticsearch.core;
 
-import java.beans.IntrospectionException;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.data.elasticsearch.entities.SampleDateMappingEntity;
@@ -28,20 +25,20 @@ import org.springframework.data.elasticsearch.entities.SampleDateMappingEntity;
  * @author Jakub Vavrik
  * @author Mohsin Husen
  * @author Don Wellington
+ * @author Peter-Josef Meisch
  */
-public class SimpleElasticsearchDateMappingTests {
+public class SimpleElasticsearchDateMappingTests extends MappingContextBaseTests {
 
-	private static final String EXPECTED_MAPPING = "{\"mapping\":{\"properties\":{\"message\":{\"store\":true," +
-			"\"type\":\"text\",\"index\":false,\"analyzer\":\"standard\"},\"customFormatDate\":{\"store\":false,\"type\":\"date\",\"format\":\"dd.MM.yyyy hh:mm\"}," +
-			"\"defaultFormatDate\":{\"store\":false,\"type\":\"date\"},\"basicFormatDate\":{\"store\":false,\"" +
-			"type\":\"date\",\"format\":\"basic_date\"}}}}";
+	private static final String EXPECTED_MAPPING = "{\"mapping\":{\"properties\":{\"message\":{\"store\":true,"
+			+ "\"type\":\"text\",\"index\":false,\"analyzer\":\"standard\"},\"customFormatDate\":{\"store\":false,\"type\":\"date\",\"format\":\"dd.MM.yyyy hh:mm\"},"
+			+ "\"defaultFormatDate\":{\"store\":false,\"type\":\"date\"},\"basicFormatDate\":{\"store\":false,\""
+			+ "type\":\"date\",\"format\":\"basic_date\"}}}}";
 
 	@Test
-	public void testCorrectDateMappings() throws NoSuchFieldException, IntrospectionException, IOException {
-		XContentBuilder xContentBuilder = MappingBuilder.buildMapping(SampleDateMappingEntity.class, "mapping", "id", null);
-		xContentBuilder.close();
-		ByteArrayOutputStream bos = (ByteArrayOutputStream) xContentBuilder.getOutputStream();
-		String result = bos.toString();
-		Assert.assertEquals(EXPECTED_MAPPING, result);
+	public void testCorrectDateMappings() throws IOException {
+
+		String mapping = getMappingBuilder().buildMapping(SampleDateMappingEntity.class);
+
+		Assert.assertEquals(EXPECTED_MAPPING, mapping);
 	}
 }

--- a/src/test/java/org/springframework/data/elasticsearch/entities/FieldNameEntity.java
+++ b/src/test/java/org/springframework/data/elasticsearch/entities/FieldNameEntity.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */package org.springframework.data.elasticsearch.entities;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.CompletionField;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.InnerField;
+import org.springframework.data.elasticsearch.annotations.Mapping;
+import org.springframework.data.elasticsearch.annotations.MultiField;
+import org.springframework.data.elasticsearch.core.completion.Completion;
+import org.springframework.data.elasticsearch.core.geo.GeoPoint;
+
+/**
+ * @author Peter-Josef Meisch
+ */
+public class FieldNameEntity {
+
+	@Document(indexName = "fieldname-index", type = "fieldname-type")
+	public static class IdEntity {
+		@Id @Field("id-property")
+		private String id;
+	}
+
+	@Document(indexName = "fieldname-index", type = "fieldname-type")
+	public static class TextEntity {
+
+		@Id @Field("id-property")
+		private String id;
+
+		@Field(name = "text-property", type = FieldType.Text)
+		private String textProperty;
+	}
+
+	@Document(indexName = "fieldname-index", type = "fieldname-type")
+	public static class MappingEntity {
+
+		@Id @Field("id-property")
+		private String id;
+
+		@Field("mapping-property") @Mapping(mappingPath = "/mappings/test-field-analyzed-mappings.json")
+		private byte[] mappingProperty;
+	}
+
+	@Document(indexName = "fieldname-index", type = "fieldname-type")
+	public static class GeoPointEntity {
+
+		@Id @Field("id-property")
+		private String id;
+
+		@Field("geopoint-property")
+		private GeoPoint geoPoint;
+	}
+
+	@Document(indexName = "fieldname-index", type = "fieldname-type")
+	public static class CircularEntity {
+
+		@Id @Field("id-property")
+		private String id;
+
+		@Field(name = "circular-property", type = FieldType.Object,
+				ignoreFields = { "circular-property" })
+		private CircularEntity circularProperty;
+	}
+
+	@Document(indexName = "fieldname-index", type = "fieldname-type")
+	public static class CompletionEntity {
+
+		@Id @Field("id-property")
+		private String id;
+
+		@Field("completion-property")
+		@CompletionField(maxInputLength = 100)
+		private Completion suggest;
+	}
+
+	@Document(indexName = "fieldname-index", type = "fieldname-type")
+	public static class MultiFieldEntity {
+
+		@Id @Field("id-property")
+		private String id;
+
+		@Field("multifield-property")
+		@MultiField(
+				mainField = @Field(type = FieldType.Text, analyzer = "whitespace"),
+				otherFields = {
+						@InnerField(suffix = "prefix", type = FieldType.Text, analyzer = "stop", searchAnalyzer = "standard")
+				}
+		)
+		private String description;
+	}
+}

--- a/src/test/java/org/springframework/data/elasticsearch/entities/MinimalChildEntity.java
+++ b/src/test/java/org/springframework/data/elasticsearch/entities/MinimalChildEntity.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.entities;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Parent;
+
+/**
+ * MinimalChildEntity
+ *
+ * @author Peter-josef Meisch
+ */
+@Document(indexName = "test-index-minimal", type = "mapping")
+public class MinimalChildEntity {
+
+	@Id
+	private String id;
+
+	@Parent(type = "parentType")
+	private String parentId;
+}

--- a/src/test/resources/mappings/test-field-analyzed-mappings.json
+++ b/src/test/resources/mappings/test-field-analyzed-mappings.json
@@ -1,0 +1,4 @@
+{
+  "type": "string",
+  "analyzer": "standard_lowercase_asciifolding"
+}


### PR DESCRIPTION
…ribute.

I changed the `MappingBuilder` to use the `ElasticsearchPersistentEntity` and `ElasticsearchPersistentProperty` classes instead of doing it's own reflection on the class and fields. Using these we can now use the `getFieldname() ` of the property to get the customized field name.

The logic of the `MappingBuilder` itself was not changed besides the different field name. What need to be changed was the call to setup the `MappingBuilder` - which now is an object instead of a collection of static functions - therefore there are some necessary changes in the Template classes and the test setups.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
