### PR TITLE
DATAES-605 - Make batch size for streamQuery configurable.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchPartQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchPartQuery.java
@@ -16,7 +16,6 @@
 package org.springframework.data.elasticsearch.repository.query;
 
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentProperty;
 import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
@@ -24,9 +23,9 @@ import org.springframework.data.elasticsearch.repository.query.parser.Elasticsea
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.repository.query.ParametersParameterAccessor;
 import org.springframework.data.repository.query.parser.PartTree;
-import org.springframework.util.ClassUtils;
 import org.springframework.data.util.CloseableIterator;
 import org.springframework.data.util.StreamUtils;
+import org.springframework.util.ClassUtils;
 
 /**
  * ElasticsearchPartQuery
@@ -53,7 +52,7 @@ public class ElasticsearchPartQuery extends AbstractElasticsearchRepositoryQuery
 	public Object execute(Object[] parameters) {
 		ParametersParameterAccessor accessor = new ParametersParameterAccessor(queryMethod.getParameters(), parameters);
 		CriteriaQuery query = createQuery(accessor);
-		if(tree.isDelete()) {
+		if (tree.isDelete()) {
 			Object result = countOrGetDocumentsForDelete(query, accessor);
 			elasticsearchOperations.delete(query, queryMethod.getEntityInformation().getJavaType());
 			return result;
@@ -66,15 +65,16 @@ public class ElasticsearchPartQuery extends AbstractElasticsearchRepositoryQuery
 				query.setPageable(PageRequest.of(0, STREAMING_BATCH_SIZE));
 			}
 
-			return StreamUtils.createStreamFromIterator((CloseableIterator<Object>) elasticsearchOperations.stream(query, entityType));
+			return StreamUtils
+					.createStreamFromIterator((CloseableIterator<Object>) elasticsearchOperations.stream(query, entityType));
 
 		} else if (queryMethod.isCollectionQuery()) {
 			if (accessor.getPageable().isUnpaged()) {
 				int itemCount = (int) elasticsearchOperations.count(query, queryMethod.getEntityInformation().getJavaType());
 				query.setPageable(PageRequest.of(0, Math.max(1, itemCount)));
 			} else {
-			    query.setPageable(accessor.getPageable());
-		    }
+				query.setPageable(accessor.getPageable());
+			}
 			return elasticsearchOperations.queryForList(query, queryMethod.getEntityInformation().getJavaType());
 		} else if (tree.isCountProjection()) {
 			return elasticsearchOperations.count(query, queryMethod.getEntityInformation().getJavaType());

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchPartQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchPartQuery.java
@@ -38,6 +38,7 @@ import org.springframework.data.util.StreamUtils;
  */
 public class ElasticsearchPartQuery extends AbstractElasticsearchRepositoryQuery {
 
+	private static final int STREAMING_BATCH_SIZE = 100;
 	private final PartTree tree;
 	private final MappingContext<?, ElasticsearchPersistentProperty> mappingContext;
 
@@ -61,8 +62,7 @@ public class ElasticsearchPartQuery extends AbstractElasticsearchRepositoryQuery
 		} else if (queryMethod.isStreamQuery()) {
 			Class<?> entityType = queryMethod.getEntityInformation().getJavaType();
 			if (query.getPageable().isUnpaged()) {
-				int itemCount = (int) elasticsearchOperations.count(query, queryMethod.getEntityInformation().getJavaType());
-				query.setPageable(PageRequest.of(0, Math.max(1, itemCount)));
+				query.setPageable(PageRequest.of(0, STREAMING_BATCH_SIZE));
 			}
 
 			return StreamUtils.createStreamFromIterator((CloseableIterator<Object>) elasticsearchOperations.stream(query, entityType));

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchPartQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchPartQuery.java
@@ -37,8 +37,7 @@ import org.springframework.util.ClassUtils;
  * @author Rasmus Faber-Espensen
  */
 public class ElasticsearchPartQuery extends AbstractElasticsearchRepositoryQuery {
-
-	private static final int STREAMING_BATCH_SIZE = 100;
+	private static final int DEFAULT_STREAM_BATCH_SIZE = 500;
 	private final PartTree tree;
 	private final MappingContext<?, ElasticsearchPersistentProperty> mappingContext;
 
@@ -61,8 +60,10 @@ public class ElasticsearchPartQuery extends AbstractElasticsearchRepositoryQuery
 			return elasticsearchOperations.queryForPage(query, queryMethod.getEntityInformation().getJavaType());
 		} else if (queryMethod.isStreamQuery()) {
 			Class<?> entityType = queryMethod.getEntityInformation().getJavaType();
-			if (query.getPageable().isUnpaged()) {
-				query.setPageable(PageRequest.of(0, STREAMING_BATCH_SIZE));
+			if (accessor.getPageable().isUnpaged()) {
+				query.setPageable(PageRequest.of(0, DEFAULT_STREAM_BATCH_SIZE));
+			} else {
+				query.setPageable(accessor.getPageable());
 			}
 
 			return StreamUtils

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchPartQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchPartQuery.java
@@ -35,6 +35,7 @@ import org.springframework.data.util.StreamUtils;
  * @author Mohsin Husen
  * @author Kevin Leturc
  * @author Mark Paluch
+ * @author Rasmus Faber-Espensen
  */
 public class ElasticsearchPartQuery extends AbstractElasticsearchRepositoryQuery {
 

--- a/src/test/java/org/springframework/data/elasticsearch/repositories/custommethod/CustomMethodRepositoryBaseTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repositories/custommethod/CustomMethodRepositoryBaseTests.java
@@ -1235,7 +1235,7 @@ public abstract class CustomMethodRepositoryBaseTests {
 		// then
 		assertThat(count).isEqualTo(1L);
 	}
-
+	
 	private List<SampleEntity> createSampleEntities(String type, int numberOfEntities) {
 
 		List<SampleEntity> entities = new ArrayList<>();


### PR DESCRIPTION
- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

This is a fix for DATAES-605.

The current code counts the number of results for the query and uses that as the batch-size for the streaming.

The fix uses a fixed batch-size of 100.

This commit changed the behavior in 2017 without any explanation: https://github.com/spring-projects/spring-data-elasticsearch/commit/089d7746be2f2fc4a395bd5c814f664729121f21#diff-f715254bb7d625b8625261ad54d1f013