### PR TITLE
DATAES-611 - Fix broken build because of API changes in Spring webflux.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/client/reactive/RawActionResponse.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/reactive/RawActionResponse.java
@@ -30,11 +30,13 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.BodyExtractor;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 /**
  * Extension to {@link ActionResponse} that also implements {@link ClientResponse}.
  *
  * @author Christoph Strobl
+ * @author Peter-Josef Meisch
  * @since 3.2
  */
 class RawActionResponse extends ActionResponse implements ClientResponse {
@@ -174,4 +176,14 @@ class RawActionResponse extends ActionResponse implements ClientResponse {
 	public <T> Mono<ResponseEntity<List<T>>> toEntityList(ParameterizedTypeReference<T> typeReference) {
 		return delegate.toEntityList(typeReference);
 	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.web.reactive.function.client.ClientResponse#createException()
+	 */
+	@Override
+	public Mono<WebClientResponseException> createException() {
+		return delegate.createException();
+	}
+
 }


### PR DESCRIPTION
the latest version of spring webflux 5.2.0.BUILD-SNAPSHOT adds a method to the `ClientResponse` interface.
This PRT adapts the `RawActionResponse` to implement this.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
