### PR TITLE
DATAES-603 - Add support for bulk options in Elasticsearch-Template c…

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchOperations.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchOperations.java
@@ -21,12 +21,11 @@ import java.util.stream.Collectors;
 
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
-import org.elasticsearch.common.Nullable;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentEntity;
 import org.springframework.data.elasticsearch.core.query.AliasQuery;
+import org.springframework.data.elasticsearch.core.query.BulkOptions;
 import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
 import org.springframework.data.elasticsearch.core.query.DeleteQuery;
 import org.springframework.data.elasticsearch.core.query.GetQuery;
@@ -36,6 +35,7 @@ import org.springframework.data.elasticsearch.core.query.SearchQuery;
 import org.springframework.data.elasticsearch.core.query.StringQuery;
 import org.springframework.data.elasticsearch.core.query.UpdateQuery;
 import org.springframework.data.util.CloseableIterator;
+import org.springframework.lang.Nullable;
 
 /**
  * ElasticsearchOperations
@@ -456,18 +456,40 @@ public interface ElasticsearchOperations {
 	UpdateResponse update(UpdateQuery updateQuery);
 
 	/**
-	 * Bulk index all objects. Will do save or update
+	 * Bulk index all objects. Will do save or update.
 	 *
-	 * @param queries
+	 * @param queries the queries to execute in bulk
 	 */
-	void bulkIndex(List<IndexQuery> queries);
+	default void bulkIndex(List<IndexQuery> queries) {
+		bulkIndex(queries, BulkOptions.defaultOptions());
+	}
+
+	/**
+	 * Bulk index all objects. Will do save or update.
+	 *
+	 * @param queries the queries to execute in bulk
+	 * @param bulkOptions options to be added to the bulk request
+	 * @since 3.2
+	 */
+	void bulkIndex(List<IndexQuery> queries, BulkOptions bulkOptions);
 
 	/**
 	 * Bulk update all objects. Will do update
 	 *
-	 * @param queries
+	 * @param queries the queries to execute in bulk
 	 */
-	void bulkUpdate(List<UpdateQuery> queries);
+	default void bulkUpdate(List<UpdateQuery> queries) {
+		bulkUpdate(queries, BulkOptions.defaultOptions());
+	}
+
+	/**
+	 * Bulk update all objects. Will do update
+	 *
+	 * @param queries the queries to execute in bulk
+	 * @param bulkOptions options to be added to the bulk request
+	 * @since 3.2
+	 */
+	void bulkUpdate(List<UpdateQuery> queries, BulkOptions bulkOptions);
 
 	/**
 	 * Delete the one object with provided id

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/BulkOptions.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/BulkOptions.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core.query;
+
+import java.util.List;
+
+import org.elasticsearch.action.support.ActiveShardCount;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.common.unit.TimeValue;
+
+/**
+ * Options that may be passed to an
+ * {@link org.springframework.data.elasticsearch.core.ElasticsearchOperations#bulkIndex(List, BulkOptions)} or
+ * {@link org.springframework.data.elasticsearch.core.ElasticsearchOperations#bulkUpdate(List, BulkOptions)} call. <br/>
+ * Use {@link BulkOptions#builder()} to obtain a builder, then set the desired properties and call
+ * {@link BulkOptionsBuilder#build()} to get the BulkOptions object.
+ *
+ * @author Peter-Josef Meisch
+ * @since 3.2
+ */
+public class BulkOptions {
+
+	private static final BulkOptions defaultOptions = builder().build();
+
+	private final TimeValue timeout;
+	private final WriteRequest.RefreshPolicy refreshPolicy;
+	private final ActiveShardCount waitForActiveShards;
+	private final String pipeline;
+	private final String routingId;
+
+	public static BulkOptionsBuilder builder() {
+		return new BulkOptionsBuilder();
+	}
+
+	public static BulkOptions defaultOptions() {
+		return defaultOptions;
+	}
+
+	private BulkOptions(TimeValue timeout, WriteRequest.RefreshPolicy refreshPolicy, ActiveShardCount waitForActiveShards,
+			String pipeline, String routingId) {
+		this.timeout = timeout;
+		this.refreshPolicy = refreshPolicy;
+		this.waitForActiveShards = waitForActiveShards;
+		this.pipeline = pipeline;
+		this.routingId = routingId;
+	}
+
+	public TimeValue getTimeout() {
+		return timeout;
+	}
+
+	public WriteRequest.RefreshPolicy getRefreshPolicy() {
+		return refreshPolicy;
+	}
+
+	public ActiveShardCount getWaitForActiveShards() {
+		return waitForActiveShards;
+	}
+
+	public String getPipeline() {
+		return pipeline;
+	}
+
+	public String getRoutingId() {
+		return routingId;
+	}
+
+	public static final class BulkOptionsBuilder {
+		private TimeValue timeout;
+		private WriteRequest.RefreshPolicy refreshPolicy;
+		private ActiveShardCount waitForActiveShards;
+		private String pipeline;
+		private String routingId;
+
+		private BulkOptionsBuilder() {}
+
+		public BulkOptionsBuilder withTimeout(TimeValue timeout) {
+			this.timeout = timeout;
+			return this;
+		}
+
+		public BulkOptionsBuilder withRefreshPolicy(WriteRequest.RefreshPolicy refreshPolicy) {
+			this.refreshPolicy = refreshPolicy;
+			return this;
+		}
+
+		public BulkOptionsBuilder withWaitForActiveShards(ActiveShardCount waitForActiveShards) {
+			this.waitForActiveShards = waitForActiveShards;
+			return this;
+		}
+
+		public BulkOptionsBuilder withPipeline(String pipeline) {
+			this.pipeline = pipeline;
+			return this;
+		}
+
+		public BulkOptionsBuilder withRoutingId(String routingId) {
+			this.routingId = routingId;
+			return this;
+		}
+
+		public BulkOptions build() {
+			return new BulkOptions(timeout, refreshPolicy, waitForActiveShards, pipeline, routingId);
+		}
+	}
+}


### PR DESCRIPTION
…lasses.

I know that tests are missing, but to test that the options are set into the `BulkRequestBuilder`/`BulkRequest` I would need to somehow intercept the request before it is sent out in the tests. That would mean that I would have to add some listener to the `Elasticsearch(Rest)Template` class just for testing. Doesn't seem good to me. Glad if anybody has an idea how this can be tested.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
