### PR TITLE
DATAES-616 - Fix implementations of ParameterAccessor interface.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ConvertingParameterAccessor.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ConvertingParameterAccessor.java
@@ -25,6 +25,7 @@ import org.springframework.lang.Nullable;
 
 /**
  * @author Christoph Strobl
+ * @author Peter-Josef Meisch
  * @since 3.2
  */
 public class ConvertingParameterAccessor implements ElasticsearchParameterAccessor {
@@ -58,7 +59,12 @@ public class ConvertingParameterAccessor implements ElasticsearchParameterAccess
 		return delegate.getDynamicProjection();
 	}
 
-	@Override
+    @Override
+    public Class<?> findDynamicProjection() {
+        return delegate.findDynamicProjection();
+    }
+
+    @Override
 	public Object getBindableValue(int index) {
 		return getConvertedValue(delegate.getBindableValue(index));
 	}

--- a/src/test/java/org/springframework/data/elasticsearch/repository/query/StubParameterAccessor.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repository/query/StubParameterAccessor.java
@@ -27,7 +27,7 @@ import org.springframework.data.repository.query.ParameterAccessor;
  * Simple {@link ParameterAccessor} that returns the given parameters unfiltered.
  *
  * @author Christoph Strobl
- * @currentRead Fool's Fate - Robin Hobb
+ * @author Peter-Josef Meisch
  */
 class StubParameterAccessor implements ElasticsearchParameterAccessor {
 
@@ -95,4 +95,9 @@ class StubParameterAccessor implements ElasticsearchParameterAccessor {
 	public Optional<Class<?>> getDynamicProjection() {
 		return Optional.empty();
 	}
+
+    @Override
+    public Class<?> findDynamicProjection() {
+        return null;
+    }
 }


### PR DESCRIPTION
spring-data-commons added a new method to the ParameterAccessor class. Implementations in spring-data-elasticsearch nedd to be adapted.