### PR TITLE
DATAES-628 - Introduce Document API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-elasticsearch</artifactId>
-	<version>4.0.0.BUILD-SNAPSHOT</version>
+	<version>4.0.0.DATAES-628-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.data.build</groupId>

--- a/src/main/java/org/springframework/data/elasticsearch/Document.java
+++ b/src/main/java/org/springframework/data/elasticsearch/Document.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.BooleanSupplier;
+import java.util.function.Function;
+import java.util.function.IntSupplier;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * A representation of a Elasticsearch document as extended {@link Map} with {@link String} keys. All iterators preserve
+ * original insertion order.
+ * <p>
+ * Document does not allow {@code null} keys. It allows {@literal null} values.
+ * <p>
+ * Implementing classes can bei either mutable or immutable. In case a subclass is immutable, its methods may throw
+ * {@link UnsupportedOperationException} when calling modifying methods.
+ *
+ * @author Mark Paluch
+ * @since 4.0
+ */
+public interface Document extends Map<String, Object> {
+
+	/**
+	 * Create a new mutable {@link Document}.
+	 *
+	 * @return a new {@link Document}.
+	 */
+	static Document create() {
+		return new MapDocument();
+	}
+
+	/**
+	 * Create a {@link Document} from a {@link Map} containing key-value pairs and sub-documents.
+	 *
+	 * @param map source map containing key-value pairs and sub-documents.
+	 * @return a new {@link Document}.
+	 */
+	static Document from(Map<String, Object> map) {
+
+		Assert.notNull(map, "Map must not be null");
+
+		if (map instanceof LinkedHashMap) {
+			return new MapDocument(map);
+		}
+
+		return new MapDocument(new LinkedHashMap<>(map));
+	}
+
+	/**
+	 * Parse JSON to {@link Document}.
+	 *
+	 * @param json must not be {@literal null}.
+	 * @return the parsed {@link Document}.
+	 */
+	static Document parse(String json) {
+		try {
+			return new MapDocument(MapDocument.OBJECT_MAPPER.readerFor(Map.class).readValue(json));
+		} catch (IOException e) {
+			throw new ElasticsearchException("Cannot parse JSON", e);
+		}
+	}
+
+	/**
+	 * {@link #put(Object, Object)} the {@code key}/{@code value} tuple and return {@code this} {@link Document}.
+	 *
+	 * @param key key with which the specified value is to be associated.
+	 * @param value value to be associated with the specified key.
+	 * @return {@code this} {@link Document}.
+	 */
+	default Document append(String key, Object value) {
+		put(key, value);
+		return this;
+	}
+
+	/**
+	 * Return {@literal true} if this {@link Document} is associated with an identifier.
+	 *
+	 * @return {@literal true} if this {@link Document} is associated with an identifier, {@literal false} otherwise.
+	 */
+	default boolean hasId() {
+		return false;
+	}
+
+	/**
+	 * Retrieve the identifier associated with this {@link Document}.
+	 * <p>
+	 * The default implementation throws {@link UnsupportedOperationException}. It's recommended to check {@link #hasId()}
+	 * prior to calling this method.
+	 *
+	 * @return the identifier associated with this {@link Document}.
+	 * @throws IllegalStateException if the underlying implementation supports Id's but no Id was yet associated with the
+	 *           document.
+	 */
+	default String getId() {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Set the identifier for this {@link Document}.
+	 * <p>
+	 * The default implementation throws {@link UnsupportedOperationException}.
+	 */
+	default void setId(String id) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Return {@literal true} if this {@link Document} is associated with a version.
+	 *
+	 * @return {@literal true} if this {@link Document} is associated with a version, {@literal false} otherwise.
+	 */
+	default boolean hasVersion() {
+		return false;
+	}
+
+	/**
+	 * Retrieve the version associated with this {@link Document}.
+	 * <p>
+	 * The default implementation throws {@link UnsupportedOperationException}. It's recommended to check
+	 * {@link #hasVersion()} prior to calling this method.
+	 *
+	 * @return the version associated with this {@link Document}.
+	 * @throws IllegalStateException if the underlying implementation supports Id's but no Id was yet associated with the
+	 *           document.
+	 */
+	default long getVersion() {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Set the version for this {@link Document}.
+	 * <p>
+	 * The default implementation throws {@link UnsupportedOperationException}.
+	 */
+	default void setVersion(long version) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Returns the value to which the specified {@code key} is mapped, or {@literal null} if this document contains no
+	 * mapping for the key. The value is casted within the method which makes it useful for calling code as it does not
+	 * require casting on the calling side. If the value type is not assignable to {@code type}, then this method throws
+	 * {@link ClassCastException}.
+	 *
+	 * @param key the key whose associated value is to be returned
+	 * @param type the expected return value type.
+	 * @param <T> expected return type.
+	 * @return the value to which the specified key is mapped, or {@literal null} if this document contains no mapping for
+	 *         the key.
+	 * @throws ClassCastException if the value of the given key is not of {@code type T}.
+	 */
+	@Nullable
+	default <T> T get(Object key, Class<T> type) {
+
+		Assert.notNull(key, "Key must not be null");
+		Assert.notNull(type, "Type must not be null");
+
+		return type.cast(get(key));
+	}
+
+	/**
+	 * Returns the value to which the specified {@code key} is mapped, or {@literal null} if this document contains no
+	 * mapping for the key. If the value type is not a {@link Boolean}, then this method throws
+	 * {@link ClassCastException}.
+	 *
+	 * @param key the key whose associated value is to be returned
+	 * @return the value to which the specified key is mapped, or {@literal null} if this document contains no mapping for
+	 *         the key.
+	 * @throws ClassCastException if the value of the given key is not a {@link Boolean}.
+	 */
+	@Nullable
+	default Boolean getBoolean(String key) {
+		return get(key, Boolean.class);
+	}
+
+	/**
+	 * Returns the value to which the specified {@code key} is mapped or {@code defaultValue} if this document contains no
+	 * mapping for the key. If the value type is not a {@link Boolean}, then this method throws
+	 * {@link ClassCastException}.
+	 *
+	 * @param key the key whose associated value is to be returned
+	 * @return the value to which the specified key is mapped or {@code defaultValue} if this document contains no mapping
+	 *         for the key.
+	 * @throws ClassCastException if the value of the given key is not a {@link Boolean}.
+	 */
+	default boolean getBooleanOrDefault(String key, boolean defaultValue) {
+		return getBooleanOrDefault(key, () -> defaultValue);
+	}
+
+	/**
+	 * Returns the value to which the specified {@code key} is mapped or the value from {@code defaultValue} if this
+	 * document contains no mapping for the key. If the value type is not a {@link Boolean}, then this method throws
+	 * {@link ClassCastException}.
+	 *
+	 * @param key the key whose associated value is to be returned
+	 * @return the value to which the specified key is mapped or the value from {@code defaultValue} if this document
+	 *         contains no mapping for the key.
+	 * @throws ClassCastException if the value of the given key is not a {@link Boolean}.
+	 * @see BooleanSupplier
+	 */
+	default boolean getBooleanOrDefault(String key, BooleanSupplier defaultValue) {
+
+		Boolean value = getBoolean(key);
+
+		return value == null ? defaultValue.getAsBoolean() : value;
+	}
+
+	/**
+	 * Returns the value to which the specified {@code key} is mapped, or {@literal null} if this document contains no
+	 * mapping for the key. If the value type is not a {@link Integer}, then this method throws
+	 * {@link ClassCastException}.
+	 *
+	 * @param key the key whose associated value is to be returned
+	 * @return the value to which the specified key is mapped, or {@literal null} if this document contains no mapping for
+	 *         the key.
+	 * @throws ClassCastException if the value of the given key is not a {@link Integer}.
+	 */
+	@Nullable
+	default Integer getInt(String key) {
+		return get(key, Integer.class);
+	}
+
+	/**
+	 * Returns the value to which the specified {@code key} is mapped or {@code defaultValue} if this document contains no
+	 * mapping for the key. If the value type is not a {@link Integer}, then this method throws
+	 * {@link ClassCastException}.
+	 *
+	 * @param key the key whose associated value is to be returned
+	 * @return the value to which the specified key is mapped or {@code defaultValue} if this document contains no mapping
+	 *         for the key.
+	 * @throws ClassCastException if the value of the given key is not a {@link Integer}.
+	 */
+	default int getIntOrDefault(String key, int defaultValue) {
+		return getIntOrDefault(key, () -> defaultValue);
+	}
+
+	/**
+	 * Returns the value to which the specified {@code key} is mapped or the value from {@code defaultValue} if this
+	 * document contains no mapping for the key. If the value type is not a {@link Integer}, then this method throws
+	 * {@link ClassCastException}.
+	 *
+	 * @param key the key whose associated value is to be returned
+	 * @return the value to which the specified key is mapped or the value from {@code defaultValue} if this document
+	 *         contains no mapping for the key.
+	 * @throws ClassCastException if the value of the given key is not a {@link Integer}.
+	 * @see IntSupplier
+	 */
+	default int getIntOrDefault(String key, IntSupplier defaultValue) {
+
+		Integer value = getInt(key);
+
+		return value == null ? defaultValue.getAsInt() : value;
+	}
+
+	/**
+	 * Returns the value to which the specified {@code key} is mapped, or {@literal null} if this document contains no
+	 * mapping for the key. If the value type is not a {@link Long}, then this method throws {@link ClassCastException}.
+	 *
+	 * @param key the key whose associated value is to be returned
+	 * @return the value to which the specified key is mapped, or {@literal null} if this document contains no mapping for
+	 *         the key.
+	 * @throws ClassCastException if the value of the given key is not a {@link Long}.
+	 */
+	@Nullable
+	default Long getLong(String key) {
+		return get(key, Long.class);
+	}
+
+	/**
+	 * Returns the value to which the specified {@code key} is mapped or {@code defaultValue} if this document contains no
+	 * mapping for the key. If the value type is not a {@link Long}, then this method throws {@link ClassCastException}.
+	 *
+	 * @param key the key whose associated value is to be returned
+	 * @return the value to which the specified key is mapped or {@code defaultValue} if this document contains no mapping
+	 *         for the key.
+	 * @throws ClassCastException if the value of the given key is not a {@link Long}.
+	 */
+	default long getLongOrDefault(String key, long defaultValue) {
+		return getLongOrDefault(key, () -> defaultValue);
+	}
+
+	/**
+	 * Returns the value to which the specified {@code key} is mapped or the value from {@code defaultValue} if this
+	 * document contains no mapping for the key. If the value type is not a {@link Long}, then this method throws
+	 * {@link ClassCastException}.
+	 *
+	 * @param key the key whose associated value is to be returned
+	 * @return the value to which the specified key is mapped or the value from {@code defaultValue} if this document
+	 *         contains no mapping for the key.
+	 * @throws ClassCastException if the value of the given key is not a {@link Long}.
+	 * @see LongSupplier
+	 */
+	default long getLongOrDefault(String key, LongSupplier defaultValue) {
+
+		Long value = getLong(key);
+
+		return value == null ? defaultValue.getAsLong() : value;
+	}
+
+	/**
+	 * Returns the value to which the specified {@code key} is mapped, or {@literal null} if this document contains no
+	 * mapping for the key. If the value type is not a {@link String}, then this method throws {@link ClassCastException}.
+	 *
+	 * @param key the key whose associated value is to be returned
+	 * @return the value to which the specified key is mapped, or {@literal null} if this document contains no mapping for
+	 *         the key.
+	 * @throws ClassCastException if the value of the given key is not a {@link String}.
+	 */
+	@Nullable
+	default String getString(String key) {
+		return get(key, String.class);
+	}
+
+	/**
+	 * Returns the value to which the specified {@code key} is mapped or {@code defaultValue} if this document contains no
+	 * mapping for the key. If the value type is not a {@link String}, then this method throws {@link ClassCastException}.
+	 *
+	 * @param key the key whose associated value is to be returned
+	 * @return the value to which the specified key is mapped or {@code defaultValue} if this document contains no mapping
+	 *         for the key.
+	 * @throws ClassCastException if the value of the given key is not a {@link String}.
+	 */
+	default String getStringOrDefault(String key, String defaultValue) {
+		return getStringOrDefault(key, () -> defaultValue);
+	}
+
+	/**
+	 * Returns the value to which the specified {@code key} is mapped or the value from {@code defaultValue} if this
+	 * document contains no mapping for the key. If the value type is not a {@link String}, then this method throws
+	 * {@link ClassCastException}.
+	 *
+	 * @param key the key whose associated value is to be returned
+	 * @return the value to which the specified key is mapped or the value from {@code defaultValue} if this document
+	 *         contains no mapping for the key.
+	 * @throws ClassCastException if the value of the given key is not a {@link String}.
+	 * @see Supplier
+	 */
+	default String getStringOrDefault(String key, Supplier<String> defaultValue) {
+
+		String value = getString(key);
+
+		return value == null ? defaultValue.get() : value;
+	}
+
+	/**
+	 * This method allows the application of a function to {@code this} {@link Document}. The function should expect a
+	 * single {@link Document} argument and produce an {@code R} result.
+	 * <p>
+	 * Any exception thrown by the function will be propagated to the caller.
+	 *
+	 * @param transformer functional interface to a apply
+	 * @param <R> class of the result
+	 * @return the result of applying the function to this string
+	 * @see java.util.function.Function
+	 */
+	default <R> R transform(Function<? super Document, ? extends R> transformer) {
+		return transformer.apply(this);
+	}
+
+	/**
+	 * Render this {@link Document} to JSON. Auxiliary values such as Id and version are not considered within the JSON
+	 * representation.
+	 *
+	 * @return a JSON representation of this document.
+	 */
+	String toJson();
+}

--- a/src/main/java/org/springframework/data/elasticsearch/Document.java
+++ b/src/main/java/org/springframework/data/elasticsearch/Document.java
@@ -37,6 +37,7 @@ import org.springframework.util.Assert;
  * {@link UnsupportedOperationException} when calling modifying methods.
  *
  * @author Mark Paluch
+ * @author Peter-Josef Meisch
  * @since 4.0
  */
 public interface Document extends Map<String, Object> {
@@ -53,7 +54,7 @@ public interface Document extends Map<String, Object> {
 	/**
 	 * Create a {@link Document} from a {@link Map} containing key-value pairs and sub-documents.
 	 *
-	 * @param map source map containing key-value pairs and sub-documents.
+	 * @param map source map containing key-value pairs and sub-documents. must not be {@literal null}.
 	 * @return a new {@link Document}.
 	 */
 	static Document from(Map<String, Object> map) {
@@ -74,6 +75,9 @@ public interface Document extends Map<String, Object> {
 	 * @return the parsed {@link Document}.
 	 */
 	static Document parse(String json) {
+
+		Assert.notNull(json, "JSON must not be null");
+
 		try {
 			return new MapDocument(MapDocument.OBJECT_MAPPER.readerFor(Map.class).readValue(json));
 		} catch (IOException e) {
@@ -84,11 +88,14 @@ public interface Document extends Map<String, Object> {
 	/**
 	 * {@link #put(Object, Object)} the {@code key}/{@code value} tuple and return {@code this} {@link Document}.
 	 *
-	 * @param key key with which the specified value is to be associated.
+	 * @param key key with which the specified value is to be associated. must not be {@literal null}.
 	 * @param value value to be associated with the specified key.
 	 * @return {@code this} {@link Document}.
 	 */
 	default Document append(String key, Object value) {
+
+		Assert.notNull(key, "Key must not be null");
+
 		put(key, value);
 		return this;
 	}
@@ -369,12 +376,15 @@ public interface Document extends Map<String, Object> {
 	 * <p>
 	 * Any exception thrown by the function will be propagated to the caller.
 	 *
-	 * @param transformer functional interface to a apply
+	 * @param transformer functional interface to a apply. must not be {@literal null}.
 	 * @param <R> class of the result
 	 * @return the result of applying the function to this string
 	 * @see java.util.function.Function
 	 */
 	default <R> R transform(Function<? super Document, ? extends R> transformer) {
+
+		Assert.notNull(transformer, "transformer must not be null");
+
 		return transformer.apply(this);
 	}
 

--- a/src/main/java/org/springframework/data/elasticsearch/MapDocument.java
+++ b/src/main/java/org/springframework/data/elasticsearch/MapDocument.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+import org.springframework.lang.Nullable;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * {@link Document} implementation backed by a {@link LinkedHashMap}.
+ *
+ * @author Mark Paluch
+ * @since 4.0
+ */
+class MapDocument implements Document {
+
+	static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+	private final LinkedHashMap<String, Object> documentAsMap;
+
+	private @Nullable String id;
+	private @Nullable Long version;
+
+	MapDocument() {
+		this(new LinkedHashMap<>());
+	}
+
+	MapDocument(Map<String, Object> documentAsMap) {
+		this.documentAsMap = new LinkedHashMap<>(documentAsMap);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.elasticsearch.Document#hasId()
+	 */
+	@Override
+	public boolean hasId() {
+		return this.id != null;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.elasticsearch.Document#getId()
+	 */
+	@Override
+	public String getId() {
+
+		if (!hasId()) {
+			throw new IllegalStateException("No Id associated with this Document");
+		}
+
+		return this.id;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.elasticsearch.Document#setId(java.lang.String)
+	 */
+	@Override
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.elasticsearch.Document#hasVersion()
+	 */
+	@Override
+	public boolean hasVersion() {
+		return this.version != null;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.elasticsearch.Document#getVersion()
+	 */
+	@Override
+	public long getVersion() {
+
+		if (!hasVersion()) {
+			throw new IllegalStateException("No version associated with this Document");
+		}
+
+		return this.version;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.elasticsearch.Document#setVersion(long)
+	 */
+	@Override
+	public void setVersion(long version) {
+		this.version = version;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.util.Map#size()
+	 */
+	@Override
+	public int size() {
+		return documentAsMap.size();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.util.Map#isEmpty()
+	 */
+	@Override
+	public boolean isEmpty() {
+		return documentAsMap.isEmpty();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.util.Map#containsKey(java.lang.Object)
+	 */
+	@Override
+	public boolean containsKey(Object key) {
+		return documentAsMap.containsKey(key);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.util.Map#containsValue(java.lang.Object)
+	 */
+	@Override
+	public boolean containsValue(Object value) {
+		return documentAsMap.containsValue(value);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.util.Map#get(java.lang.Object)
+	 */
+	@Override
+	public Object get(Object key) {
+		return documentAsMap.get(key);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.lang.Object#getOrDefault(java.lang.Object, java.lang.Object)
+	 */
+	@Override
+	public Object getOrDefault(Object key, Object defaultValue) {
+		return documentAsMap.getOrDefault(key, defaultValue);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.util.Map#put(java.lang.Object, java.lang.Object)
+	 */
+	@Override
+	public Object put(String key, Object value) {
+		return documentAsMap.put(key, value);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.util.Map#remove(java.lang.Object)
+	 */
+	@Override
+	public Object remove(Object key) {
+		return documentAsMap.remove(key);
+	}
+
+	/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#putAll(Map)
+		 */
+	@Override
+	public void putAll(Map<? extends String, ?> m) {
+		documentAsMap.putAll(m);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.util.Map#clear()
+	 */
+	@Override
+	public void clear() {
+		documentAsMap.clear();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.util.Map#keySet()
+	 */
+	@Override
+	public Set<String> keySet() {
+		return documentAsMap.keySet();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.util.Map#values()
+	 */
+	@Override
+	public Collection<Object> values() {
+		return documentAsMap.values();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.util.Map#entrySet()
+	 */
+	@Override
+	public Set<Entry<String, Object>> entrySet() {
+		return documentAsMap.entrySet();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(Object o) {
+		return documentAsMap.equals(o);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.lang.Object#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+		return documentAsMap.hashCode();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.util.Map#forEach(java.util.function.BiConsumer)
+	 */
+	@Override
+	public void forEach(BiConsumer<? super String, ? super Object> action) {
+		documentAsMap.forEach(action);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.elasticsearch.Document#toJson()
+	 */
+	@Override
+	public String toJson() {
+		try {
+			return OBJECT_MAPPER.writeValueAsString(this);
+		} catch (JsonProcessingException e) {
+			throw new ElasticsearchException("Cannot render document to JSON", e);
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+
+		String id = hasId() ? getId() : "?";
+		String version = hasVersion() ? Long.toString(getVersion()) : "?";
+
+		return getClass().getSimpleName() + "@" + id + "#" + version + " " + toJson();
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/SearchDocument.java
+++ b/src/main/java/org/springframework/data/elasticsearch/SearchDocument.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch;
+
+/**
+ * Extension to {@link Document} exposing a search {@link #getScore() score}.
+ *
+ * @author Mark Paluch
+ * @since 4.0
+ * @see Document
+ */
+public interface SearchDocument extends Document {
+
+	/**
+	 * Return the search {@code score}.
+	 *
+	 * @return the search {@code score}.
+	 */
+	float getScore();
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/DefaultEntityMapper.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/DefaultEntityMapper.java
@@ -17,11 +17,11 @@ package org.springframework.data.elasticsearch.core;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.springframework.data.annotation.ReadOnlyProperty;
+import org.springframework.data.elasticsearch.Document;
 import org.springframework.data.elasticsearch.core.geo.CustomGeoModule;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentEntity;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentProperty;
@@ -44,6 +44,7 @@ import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
  * @author Petar Tahchiev
  * @author Oliver Gierke
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class DefaultEntityMapper implements EntityMapper {
 
@@ -51,7 +52,7 @@ public class DefaultEntityMapper implements EntityMapper {
 
 	/**
 	 * Creates a new {@link DefaultEntityMapper} using the given {@link MappingContext}.
-	 * 
+	 *
 	 * @param context must not be {@literal null}.
 	 */
 	public DefaultEntityMapper(
@@ -74,7 +75,8 @@ public class DefaultEntityMapper implements EntityMapper {
 	 */
 	@Override
 	public String mapToString(Object object) throws IOException {
-		return objectMapper.writeValueAsString(object);
+		return objectMapper
+				.writeValueAsString(object instanceof Document ? new LinkedHashMap<>((Document) object) : object);
 	}
 
 	/*
@@ -82,10 +84,10 @@ public class DefaultEntityMapper implements EntityMapper {
 	 * @see org.springframework.data.elasticsearch.core.EntityMapper#mapObject(java.lang.Object)
 	 */
 	@Override
-	public Map<String, Object> mapObject(Object source) {
+	public Document mapObject(Object source) {
 
 		try {
-			return objectMapper.readValue(mapToString(source), HashMap.class);
+			return objectMapper.readValue(mapToString(source), Document.class);
 		} catch (IOException e) {
 			throw new MappingException(e.getMessage(), e);
 		}
@@ -105,8 +107,7 @@ public class DefaultEntityMapper implements EntityMapper {
 	 * @see org.springframework.data.elasticsearch.core.EntityMapper#readObject(java.util.Map, java.lang.Class)
 	 */
 	@Override
-	public <T> T readObject (Map<String, Object> source, Class<T> targetType) {
-
+	public <T> T readObject(Document source, Class<T> targetType) {
 		try {
 			return mapToObject(mapToString(source), targetType);
 		} catch (IOException e) {
@@ -126,7 +127,7 @@ public class DefaultEntityMapper implements EntityMapper {
 
 		/**
 		 * Creates a new {@link SpringDataElasticsearchModule} using the given {@link MappingContext}.
-		 * 
+		 *
 		 * @param context must not be {@literal null}.
 		 */
 		public SpringDataElasticsearchModule(
@@ -156,7 +157,7 @@ public class DefaultEntityMapper implements EntityMapper {
 				this.context = context;
 			}
 
-			/* 
+			/*
 			 * (non-Javadoc)
 			 * @see com.fasterxml.jackson.databind.ser.BeanSerializerModifier#changeProperties(com.fasterxml.jackson.databind.SerializationConfig, com.fasterxml.jackson.databind.BeanDescription, java.util.List)
 			 */

--- a/src/main/java/org/springframework/data/elasticsearch/core/DefaultResultMapper.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/DefaultResultMapper.java
@@ -15,11 +15,7 @@
  */
 package org.springframework.data.elasticsearch.core;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 import org.elasticsearch.action.get.GetResponse;
@@ -45,11 +41,6 @@ import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mapping.model.ConvertingPropertyAccessor;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
-
-import com.fasterxml.jackson.core.JsonEncoding;
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonGenerator;
 
 /**
  * @author Artur Konczak
@@ -105,13 +96,7 @@ public class DefaultResultMapper extends AbstractResultMapper {
 		List<T> results = new ArrayList<>();
 		for (SearchHit hit : response.getHits()) {
 			if (hit != null) {
-				T result = null;
-				String hitSourceAsString = hit.getSourceAsString();
-				if (!StringUtils.isEmpty(hitSourceAsString)) {
-					result = mapEntity(hitSourceAsString, clazz);
-				} else {
-					result = mapEntity(hit.getFields().values(), clazz);
-				}
+				T result = mapSearchHit(hit, clazz);
 
 				setPersistentEntityId(result, hit.getId(), clazz);
 				setPersistentEntityVersion(result, hit.getVersion(), clazz);
@@ -149,38 +134,14 @@ public class DefaultResultMapper extends AbstractResultMapper {
 		}
 	}
 
-	private <T> T mapEntity(Collection<DocumentField> values, Class<T> clazz) {
-		return mapEntity(buildJSONFromFields(values), clazz);
-	}
-
-	private String buildJSONFromFields(Collection<DocumentField> values) {
-		JsonFactory nodeFactory = new JsonFactory();
-		try {
-			ByteArrayOutputStream stream = new ByteArrayOutputStream();
-			JsonGenerator generator = nodeFactory.createGenerator(stream, JsonEncoding.UTF8);
-			generator.writeStartObject();
-			for (DocumentField value : values) {
-				if (value.getValues().size() > 1) {
-					generator.writeArrayFieldStart(value.getName());
-					for (Object val : value.getValues()) {
-						generator.writeObject(val);
-					}
-					generator.writeEndArray();
-				} else {
-					generator.writeObjectField(value.getName(), value.getValue());
-				}
-			}
-			generator.writeEndObject();
-			generator.flush();
-			return new String(stream.toByteArray(), Charset.forName("UTF-8"));
-		} catch (IOException e) {
-			return null;
-		}
-	}
-
 	@Override
 	public <T> T mapResult(GetResponse response, Class<T> clazz) {
-		T result = mapEntity(response.getSourceAsString(), clazz);
+
+		if (!response.isExists()) {
+			return null;
+		}
+
+		T result = mapDocument(DocumentAdapters.from(response), clazz);
 		if (result != null) {
 			setPersistentEntityId(result, response.getId(), clazz);
 			setPersistentEntityVersion(result, response.getVersion(), clazz);
@@ -193,7 +154,7 @@ public class DefaultResultMapper extends AbstractResultMapper {
 		List<T> list = new ArrayList<>();
 		for (MultiGetItemResponse response : responses.getResponses()) {
 			if (!response.isFailed() && response.getResponse().isExists()) {
-				T result = mapEntity(response.getResponse().getSourceAsString(), clazz);
+				T result = mapResult(response.getResponse(), clazz);
 				setPersistentEntityId(result, response.getResponse().getId(), clazz);
 				setPersistentEntityVersion(result, response.getResponse().getVersion(), clazz);
 				list.add(result);

--- a/src/main/java/org/springframework/data/elasticsearch/core/DocumentAdapters.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/DocumentAdapters.java
@@ -385,7 +385,7 @@ class DocumentAdapters {
 		 */
 		@Override
 		public String toString() {
-			return getClass().getSimpleName() + "@" + this.id + "#" + this.version + " " + toJson();
+			return getClass().getSimpleName() + '@' + this.id + '#' + this.version + ' ' + toJson();
 		}
 
 		@Nullable

--- a/src/main/java/org/springframework/data/elasticsearch/core/DocumentAdapters.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/DocumentAdapters.java
@@ -44,8 +44,9 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 
 /**
- * Utility class to adapt {@link org.elasticsearch.common.document.DocumentField} to
- * {@link org.springframework.data.elasticsearch.Document}.
+ * Utility class to adapt {@link org.elasticsearch.action.get.GetResponse},
+ * {@link org.elasticsearch.index.get.GetResult}, {@link org.elasticsearch.search.SearchHit},
+ * {@link org.elasticsearch.common.document.DocumentField} to {@link org.springframework.data.elasticsearch.Document}.
  *
  * @author Mark Paluch
  * @since 4.0

--- a/src/main/java/org/springframework/data/elasticsearch/core/DocumentAdapters.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/DocumentAdapters.java
@@ -1,0 +1,674 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.index.get.GetResult;
+import org.elasticsearch.search.SearchHit;
+import org.springframework.data.elasticsearch.Document;
+import org.springframework.data.elasticsearch.ElasticsearchException;
+import org.springframework.data.elasticsearch.SearchDocument;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+
+/**
+ * Utility class to adapt {@link org.elasticsearch.common.document.DocumentField} to
+ * {@link org.springframework.data.elasticsearch.Document}.
+ *
+ * @author Mark Paluch
+ * @since 4.0
+ */
+class DocumentAdapters {
+
+	/**
+	 * Create a {@link Document} from {@link GetResponse}.
+	 * <p>
+	 * Returns a {@link Document} using the source if available.
+	 *
+	 * @param source the source {@link GetResponse}.
+	 * @return the adapted {@link Document}.
+	 */
+	public static Document from(GetResponse source) {
+
+		Assert.notNull(source, "GetResponse must not be null");
+
+		if (source.isSourceEmpty()) {
+			return fromDocumentFields(source, source.getId(), source.getVersion());
+		}
+
+		Document document = Document.from(source.getSourceAsMap());
+		document.setId(source.getId());
+		document.setVersion(source.getVersion());
+
+		return document;
+	}
+
+	/**
+	 * Create a {@link Document} from {@link GetResult}.
+	 * <p>
+	 * Returns a {@link Document} using the source if available.
+	 *
+	 * @param source the source {@link GetResult}.
+	 * @return the adapted {@link Document}.
+	 */
+	public static Document from(GetResult source) {
+
+		Assert.notNull(source, "GetResult must not be null");
+
+		if (source.isSourceEmpty()) {
+			return fromDocumentFields(source, source.getId(), source.getVersion());
+		}
+
+		Document document = Document.from(source.getSource());
+		document.setId(source.getId());
+		document.setVersion(source.getVersion());
+
+		return document;
+	}
+
+	/**
+	 * Create a {@link SearchDocument} from {@link SearchHit}.
+	 * <p>
+	 * Returns a {@link SearchDocument} using the source if available.
+	 *
+	 * @param source the source {@link SearchHit}.
+	 * @return the adapted {@link SearchDocument}.
+	 */
+	public static SearchDocument from(SearchHit source) {
+
+		Assert.notNull(source, "SearchHit must not be null");
+
+		BytesReference sourceRef = source.getSourceRef();
+
+		if (sourceRef == null || sourceRef.length() == 0) {
+			return new SearchDocumentAdapter(source.getScore(),
+					fromDocumentFields(source, source.getId(), source.getVersion()));
+		}
+
+		Document document = Document.from(source.getSourceAsMap());
+		document.setId(source.getId());
+
+		if (source.getVersion() >= 0) {
+			document.setVersion(source.getVersion());
+		}
+
+		return new SearchDocumentAdapter(source.getScore(), document);
+	}
+
+	/**
+	 * Create an unmodifiable {@link Document} from {@link Iterable} of {@link DocumentField}s.
+	 *
+	 * @param documentFields the {@link DocumentField}s backing the {@link Document}.
+	 * @return the adapted {@link Document}.
+	 */
+	public static Document fromDocumentFields(Iterable<DocumentField> documentFields, String id, long version) {
+
+		if (documentFields instanceof Collection) {
+			return new DocumentFieldAdapter((Collection<DocumentField>) documentFields, id, version);
+		}
+
+		List<DocumentField> fields = new ArrayList<>();
+		for (DocumentField documentField : documentFields) {
+			fields.add(documentField);
+		}
+
+		return new DocumentFieldAdapter(fields, id, version);
+	}
+
+	// TODO: Performance regarding keys/values/entry-set
+	static class DocumentFieldAdapter implements Document {
+
+		private final Collection<DocumentField> documentFields;
+		private final String id;
+		private final long version;
+
+		DocumentFieldAdapter(Collection<DocumentField> documentFields, String id, long version) {
+			this.documentFields = documentFields;
+			this.id = id;
+			this.version = version;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.elasticsearch.Document#hasId()
+		 */
+		@Override
+		public boolean hasId() {
+			return id != null;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.elasticsearch.Document#getId()
+		 */
+		@Override
+		public String getId() {
+			return this.id;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.elasticsearch.Document#hasVersion()
+		 */
+		@Override
+		public boolean hasVersion() {
+			return this.version >= 0;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.elasticsearch.Document#getVersion()
+		 */
+		@Override
+		public long getVersion() {
+
+			if (!hasVersion()) {
+				throw new IllegalStateException("No version associated with this Document");
+			}
+
+			return this.version;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#size()
+		 */
+		@Override
+		public int size() {
+			return documentFields.size();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#isEmpty()
+		 */
+		@Override
+		public boolean isEmpty() {
+			return documentFields.isEmpty();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#containsKey(java.lang.Object)
+		 */
+		@Override
+		public boolean containsKey(Object key) {
+
+			for (DocumentField documentField : documentFields) {
+				if (documentField.getName().equals(key)) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#containsValue(java.lang.Object)
+		 */
+		@Override
+		public boolean containsValue(Object value) {
+
+			for (DocumentField documentField : documentFields) {
+
+				Object fieldValue = getValue(documentField);
+				if (fieldValue != null && fieldValue.equals(value) || value == fieldValue) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#get(java.lang.Object)
+		 */
+		@Override
+		public Object get(Object key) {
+
+			for (DocumentField documentField : documentFields) {
+				if (documentField.getName().equals(key)) {
+
+					return getValue(documentField);
+				}
+			}
+
+			return null;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#put(java.lang.Object, java.lang.Object)
+		 */
+		@Override
+		public Object put(String key, Object value) {
+			throw new UnsupportedOperationException();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#remove(java.lang.Object)
+		 */
+		@Override
+		public Object remove(Object key) {
+			throw new UnsupportedOperationException();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#putAll(Map)
+		 */
+		@Override
+		public void putAll(Map<? extends String, ?> m) {
+			throw new UnsupportedOperationException();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#clear()
+		 */
+		@Override
+		public void clear() {
+			throw new UnsupportedOperationException();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#keySet()
+		 */
+		@Override
+		public Set<String> keySet() {
+			return documentFields.stream().map(DocumentField::getName).collect(Collectors.toCollection(LinkedHashSet::new));
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#values()
+		 */
+		@Override
+		public Collection<Object> values() {
+			return documentFields.stream().map(DocumentFieldAdapter::getValue).collect(Collectors.toList());
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#entrySet()
+		 */
+		@Override
+		public Set<Entry<String, Object>> entrySet() {
+			return documentFields.stream().collect(Collectors.toMap(DocumentField::getName, DocumentFieldAdapter::getValue))
+					.entrySet();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#forEach(java.util.function.BiConsumer)
+		 */
+		@Override
+		public void forEach(BiConsumer<? super String, ? super Object> action) {
+
+			Objects.requireNonNull(action);
+
+			documentFields.forEach(field -> {
+				action.accept(field.getName(), getValue(field));
+			});
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.elasticsearch.Document#toJson()
+		 */
+		@Override
+		public String toJson() {
+
+			JsonFactory nodeFactory = new JsonFactory();
+			try {
+				ByteArrayOutputStream stream = new ByteArrayOutputStream();
+				JsonGenerator generator = nodeFactory.createGenerator(stream, JsonEncoding.UTF8);
+				generator.writeStartObject();
+				for (DocumentField value : documentFields) {
+					if (value.getValues().size() > 1) {
+						generator.writeArrayFieldStart(value.getName());
+						for (Object val : value.getValues()) {
+							generator.writeObject(val);
+						}
+						generator.writeEndArray();
+					} else {
+						generator.writeObjectField(value.getName(), value.getValue());
+					}
+				}
+				generator.writeEndObject();
+				generator.flush();
+				return new String(stream.toByteArray(), StandardCharsets.UTF_8);
+			} catch (IOException e) {
+				throw new ElasticsearchException("Cannot render JSON", e);
+			}
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.lang.Object#toString()
+		 */
+		@Override
+		public String toString() {
+			return getClass().getSimpleName() + "@" + this.id + "#" + this.version + " " + toJson();
+		}
+
+		@Nullable
+		private static Object getValue(DocumentField documentField) {
+
+			if (documentField.getValues().isEmpty()) {
+				return null;
+			}
+
+			if (documentField.getValues().size() == 1) {
+				return documentField.getValue();
+			}
+
+			return documentField.getValues();
+		}
+	}
+
+	/**
+	 * Adapter for a {@link SearchDocument}.
+	 */
+	static class SearchDocumentAdapter implements SearchDocument {
+
+		private final float score;
+		private final Document delegate;
+
+		SearchDocumentAdapter(float score, Document delegate) {
+			this.score = score;
+			this.delegate = delegate;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.elasticsearch.Document#append(java.lang.String, java.lang.Object)
+		 */
+		@Override
+		public SearchDocument append(String key, Object value) {
+			delegate.append(key, value);
+
+			return this;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.elasticsearch.SearchDocument#getScore()
+		 */
+		@Override
+		public float getScore() {
+			return score;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.elasticsearch.Document#hasId()
+		 */
+		@Override
+		public boolean hasId() {
+			return delegate.hasId();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.elasticsearch.Document#getId()
+		 */
+		@Override
+		public String getId() {
+			return delegate.getId();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.elasticsearch.Document#setId(java.lang.String)
+		 */
+		@Override
+		public void setId(String id) {
+			delegate.setId(id);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.elasticsearch.Document#hasVersion()
+		 */
+		@Override
+		public boolean hasVersion() {
+			return delegate.hasVersion();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.elasticsearch.Document#getVersion()
+		 */
+		@Override
+		public long getVersion() {
+			return delegate.getVersion();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.elasticsearch.Document#setVersion(long)
+		 */
+		@Override
+		public void setVersion(long version) {
+			delegate.setVersion(version);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.elasticsearch.Document#get(java.lang.Object, java.lang.Class)
+		 */
+		@Override
+		@Nullable
+		public <T> T get(Object key, Class<T> type) {
+			return delegate.get(key, type);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.elasticsearch.Document#toJson()
+		 */
+		@Override
+		public String toJson() {
+			return delegate.toJson();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#size()
+		 */
+		@Override
+		public int size() {
+			return delegate.size();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#isEmpty()
+		 */
+		@Override
+		public boolean isEmpty() {
+			return delegate.isEmpty();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#containsKey(java.lang.Object)
+		 */
+		@Override
+		public boolean containsKey(Object key) {
+			return delegate.containsKey(key);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#containsValue(java.lang.Object)
+		 */
+		@Override
+		public boolean containsValue(Object value) {
+			return delegate.containsValue(value);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#get(java.lang.Object)
+		 */
+		@Override
+		public Object get(Object key) {
+			return delegate.get(key);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#put(java.lang.Object, java.lang.Object)
+		 */
+		@Override
+		public Object put(String key, Object value) {
+			return delegate.put(key, value);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#remove(java.lang.Object)
+		 */
+		@Override
+		public Object remove(Object key) {
+			return delegate.remove(key);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#putAll(Map)
+		 */
+		@Override
+		public void putAll(Map<? extends String, ?> m) {
+			delegate.putAll(m);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#clear()
+		 */
+		@Override
+		public void clear() {
+			delegate.clear();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#keySet()
+		 */
+		@Override
+		public Set<String> keySet() {
+			return delegate.keySet();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#values()
+		 */
+		@Override
+		public Collection<Object> values() {
+			return delegate.values();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#entrySet()
+		 */
+		@Override
+		public Set<Entry<String, Object>> entrySet() {
+			return delegate.entrySet();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.lang.Object#equals(java.lang.Object)
+		 */
+		@Override
+		public boolean equals(Object o) {
+			if (this == o)
+				return true;
+			if (!(o instanceof SearchDocumentAdapter))
+				return false;
+			SearchDocumentAdapter that = (SearchDocumentAdapter) o;
+			return Float.compare(that.score, score) == 0 && delegate.equals(that.delegate);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.lang.Object#hashCode()
+		 */
+		@Override
+		public int hashCode() {
+			return delegate.hashCode();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#forEach(java.util.function.BiConsumer)
+		 */
+		@Override
+		public void forEach(BiConsumer<? super String, ? super Object> action) {
+			delegate.forEach(action);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.util.Map#remove(java.lang.Object, java.lang.Object)
+		 */
+		@Override
+		public boolean remove(Object key, Object value) {
+			return delegate.remove(key, value);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see java.lang.Object#toString()
+		 */
+		@Override
+		public String toString() {
+
+			String id = hasId() ? getId() : "?";
+			String version = hasVersion() ? Long.toString(getVersion()) : "?";
+
+			return getClass().getSimpleName() + "@" + id + "#" + version + " " + toJson();
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/EntityMapper.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/EntityMapper.java
@@ -18,6 +18,7 @@ package org.springframework.data.elasticsearch.core;
 import java.io.IOException;
 import java.util.Map;
 
+import org.springframework.data.elasticsearch.Document;
 import org.springframework.lang.Nullable;
 
 /**
@@ -27,6 +28,7 @@ import org.springframework.lang.Nullable;
  * @author Rizwan Idrees
  * @author Mohsin Husen
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public interface EntityMapper {
 
@@ -41,7 +43,7 @@ public interface EntityMapper {
 	 * @return never {@literal null}
 	 * @since 3.2
 	 */
-	Map<String, Object> mapObject(Object source);
+	Document mapObject(Object source);
 
 	/**
 	 * Map the given {@link Map} into an instance of the {@literal targetType}.
@@ -53,5 +55,5 @@ public interface EntityMapper {
 	 * @since 3.2
 	 */
 	@Nullable
-	<T> T readObject(Map<String, Object> source, Class<T> targetType);
+	<T> T readObject(Document source, Class<T> targetType);
 }

--- a/src/test/java/org/springframework/data/elasticsearch/DocumentUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/DocumentUnitTests.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link Document}.
+ *
+ * @author Mark Paluch
+ */
+public class DocumentUnitTests {
+
+	@Test // DATAES-628
+	public void shouldCreateNewDocument() {
+
+		Document document = Document.create().append("key", "value");
+
+		assertThat(document).containsEntry("key", "value");
+	}
+
+	@Test // DATAES-628
+	public void shouldCreateNewDocumentFromMap() {
+
+		Document document = Document.from(Collections.singletonMap("key", "value"));
+
+		assertThat(document).containsEntry("key", "value");
+	}
+
+	@Test // DATAES-628
+	public void shouldRenderDocumentToJson() {
+
+		Document document = Document.from(Collections.singletonMap("key", "value"));
+
+		assertThat(document.toJson()).isEqualTo("{\"key\":\"value\"}");
+	}
+
+	@Test // DATAES-628
+	public void shouldParseDocumentFromJson() {
+
+		Document document = Document.parse("{\"key\":\"value\"}");
+
+		assertThat(document).containsEntry("key", "value");
+	}
+
+	@Test // DATAES-628
+	public void shouldReturnContainsKey() {
+
+		Document document = Document.create().append("string", "value").append("bool", true).append("int", 43)
+				.append("long", 42L);
+
+		assertThat(document.containsKey("string")).isTrue();
+		assertThat(document.containsKey("not-set")).isFalse();
+	}
+
+	@Test // DATAES-628
+	public void shouldReturnContainsValue() {
+
+		Document document = Document.create().append("string", "value").append("bool", Arrays.asList(true, true, false))
+				.append("int", 43).append("long", 42L);
+
+		assertThat(document.containsValue("value")).isTrue();
+		assertThat(document.containsValue(43)).isTrue();
+		assertThat(document.containsValue(44)).isFalse();
+		assertThat(document.containsValue(Arrays.asList(true, true, false))).isTrue();
+	}
+
+	@Test // DATAES-628
+	public void shouldReturnTypedValue() {
+
+		Document document = Document.create().append("string", "value").append("bool", true).append("int", 43)
+				.append("long", 42L);
+
+		assertThat(document.get("string")).isEqualTo("value");
+		assertThat(document.getString("string")).isEqualTo("value");
+
+		assertThatExceptionOfType(ClassCastException.class).isThrownBy(() -> document.get("long", String.class));
+	}
+
+	@Test // DATAES-628
+	public void shouldReturnTypedValueString() {
+
+		Document document = Document.create().append("string", "value").append("bool", true).append("int", 43)
+				.append("long", 42L);
+
+		assertThat(document.getString("string")).isEqualTo("value");
+		assertThat(document.getStringOrDefault("not-set", "default")).isEqualTo("default");
+		assertThat(document.getStringOrDefault("not-set", () -> "default")).isEqualTo("default");
+
+		assertThatExceptionOfType(ClassCastException.class).isThrownBy(() -> document.getString("long"));
+		assertThatExceptionOfType(ClassCastException.class).isThrownBy(() -> document.get("long", String.class));
+	}
+
+	@Test // DATAES-628
+	public void shouldReturnTypedValueBoolean() {
+
+		Document document = Document.create().append("string", "value").append("bool", true).append("int", 43)
+				.append("long", 42L);
+
+		assertThat(document.getBoolean("bool")).isTrue();
+		assertThat(document.getBooleanOrDefault("not-set", true)).isTrue();
+		assertThat(document.getBooleanOrDefault("not-set", () -> true)).isTrue();
+
+		assertThatExceptionOfType(ClassCastException.class).isThrownBy(() -> document.getString("bool"));
+		assertThatExceptionOfType(ClassCastException.class).isThrownBy(() -> document.get("bool", String.class));
+	}
+
+	@Test // DATAES-628
+	public void shouldReturnTypedValueInt() {
+
+		Document document = Document.create().append("string", "value").append("bool", true).append("int", 43)
+				.append("long", 42L);
+
+		assertThat(document.getInt("int")).isEqualTo(43);
+		assertThat(document.getIntOrDefault("not-set", 44)).isEqualTo(44);
+		assertThat(document.getIntOrDefault("not-set", () -> 44)).isEqualTo(44);
+
+		assertThatExceptionOfType(ClassCastException.class).isThrownBy(() -> document.getString("int"));
+		assertThatExceptionOfType(ClassCastException.class).isThrownBy(() -> document.get("int", String.class));
+	}
+
+	@Test // DATAES-628
+	public void shouldReturnTypedValueLong() {
+
+		Document document = Document.create().append("string", "value").append("bool", true).append("int", 43)
+				.append("long", 42L);
+
+		assertThat(document.getLong("long")).isEqualTo(42);
+		assertThat(document.getLongOrDefault("not-set", 44)).isEqualTo(44);
+		assertThat(document.getLongOrDefault("not-set", () -> 44)).isEqualTo(44);
+
+		assertThatExceptionOfType(ClassCastException.class).isThrownBy(() -> document.getString("long"));
+		assertThatExceptionOfType(ClassCastException.class).isThrownBy(() -> document.get("long", String.class));
+	}
+
+	@Test // DATAES-628
+	public void shouldApplyTransformer() {
+
+		Document document = Document.create();
+		document.setId("value");
+
+		assertThat(document.transform(Document::getId)).isEqualTo("value");
+	}
+
+	@Test // DATAES-628
+	public void shouldSetId() {
+
+		Document document = Document.create();
+
+		assertThat(document.hasId()).isFalse();
+		assertThatIllegalStateException().isThrownBy(document::getId);
+
+		document.setId("foo");
+		assertThat(document.getId()).isEqualTo("foo");
+	}
+
+	@Test // DATAES-628
+	public void shouldSetVersion() {
+
+		Document document = Document.create();
+
+		assertThat(document.hasVersion()).isFalse();
+		assertThatIllegalStateException().isThrownBy(document::getVersion);
+
+		document.setVersion(14);
+		assertThat(document.getVersion()).isEqualTo(14);
+	}
+
+	@Test // DATAES-628
+	public void shouldRenderToString() {
+
+		Document document = Document.from(Collections.singletonMap("key", "value"));
+		document.setId("123");
+		document.setVersion(42);
+
+		assertThat(document).hasToString("MapDocument@123#42 {\"key\":\"value\"}");
+	}
+}

--- a/src/test/java/org/springframework/data/elasticsearch/core/CustomEntityMapper.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/CustomEntityMapper.java
@@ -16,11 +16,13 @@
 package org.springframework.data.elasticsearch.core;
 
 import java.io.IOException;
-import java.util.Map;
+
+import org.springframework.data.elasticsearch.Document;
 
 /**
  * @author Artur Konczak
  * @author Mohsin Husen
+ * @author Mark Paluch
  */
 public class CustomEntityMapper implements EntityMapper {
 
@@ -41,12 +43,12 @@ public class CustomEntityMapper implements EntityMapper {
 	}
 
 	@Override
-	public Map<String, Object> mapObject(Object source) {
+	public Document mapObject(Object source) {
 		return null;
 	}
 
 	@Override
-	public <T> T readObject(Map<String, Object> source, Class<T> targetType) {
+	public <T> T readObject(Document source, Class<T> targetType) {
 		return null;
 	}
 }

--- a/src/test/java/org/springframework/data/elasticsearch/core/DefaultResultMapperTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/DefaultResultMapperTests.java
@@ -30,6 +30,7 @@ import java.lang.Object;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -38,6 +39,7 @@ import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.get.MultiGetItemResponse;
 import org.elasticsearch.action.get.MultiGetResponse;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -172,7 +174,14 @@ public class DefaultResultMapperTests {
 
 		// given
 		GetResponse response = mock(GetResponse.class);
-		when(response.getSourceAsString()).thenReturn(createJsonCar("Ford", "Grat"));
+		when(response.isExists()).thenReturn(true);
+
+		Map<String, Object> sourceAsMap = new HashMap<>();
+		sourceAsMap.put("name", "Ford");
+		sourceAsMap.put("model", "Grat");
+
+		when(response.getSourceAsMap()).thenReturn(sourceAsMap);
+		when(response.getSourceAsBytesRef()).thenReturn(new BytesArray(" "));
 
 		// when
 		Car result = resultMapper.mapResult(response, Car.class);
@@ -188,7 +197,9 @@ public class DefaultResultMapperTests {
 	public void setsIdentifierOnImmutableType() {
 
 		GetResponse response = mock(GetResponse.class);
+		when(response.isExists()).thenReturn(true);
 		when(response.getSourceAsString()).thenReturn("{}");
+		when(response.getSourceAsBytesRef()).thenReturn(new BytesArray("{}"));
 		when(response.getId()).thenReturn("identifier");
 
 		ImmutableEntity result = resultMapper.mapResult(response, ImmutableEntity.class);
@@ -201,6 +212,7 @@ public class DefaultResultMapperTests {
 	public void setsVersionFromGetResponse() {
 
 		GetResponse response = mock(GetResponse.class);
+		when(response.isExists()).thenReturn(true);
 		when(response.getSourceAsString()).thenReturn("{}");
 		when(response.getVersion()).thenReturn(1234L);
 
@@ -214,12 +226,16 @@ public class DefaultResultMapperTests {
 	public void setsVersionFromMultiGetResponse() {
 
 		GetResponse response1 = mock(GetResponse.class);
+		when(response1.isExists()).thenReturn(true);
 		when(response1.getSourceAsString()).thenReturn("{}");
+		when(response1.getSourceAsBytesRef()).thenReturn(new BytesArray("{}"));
 		when(response1.isExists()).thenReturn(true);
 		when(response1.getVersion()).thenReturn(1234L);
 
 		GetResponse response2 = mock(GetResponse.class);
+		when(response2.isExists()).thenReturn(true);
 		when(response2.getSourceAsString()).thenReturn("{}");
+		when(response2.getSourceAsBytesRef()).thenReturn(new BytesArray("{}"));
 		when(response2.isExists()).thenReturn(true);
 		when(response2.getVersion()).thenReturn(5678L);
 
@@ -239,11 +255,11 @@ public class DefaultResultMapperTests {
 	public void setsVersionFromSearchResponse() {
 
 		SearchHit hit1 = mock(SearchHit.class);
-		when(hit1.getSourceAsString()).thenReturn("{}");
+		when(hit1.getSourceRef()).thenReturn(new BytesArray("{}"));
 		when(hit1.getVersion()).thenReturn(1234L);
 
 		SearchHit hit2 = mock(SearchHit.class);
-		when(hit2.getSourceAsString()).thenReturn("{}");
+		when(hit2.getSourceRef()).thenReturn(new BytesArray("{}"));
 		when(hit2.getVersion()).thenReturn(5678L);
 
 		SearchHits searchHits = mock(SearchHits.class);
@@ -272,7 +288,13 @@ public class DefaultResultMapperTests {
 	private SearchHit createCarHit(String name, String model) {
 
 		SearchHit hit = mock(SearchHit.class);
-		when(hit.getSourceAsString()).thenReturn(createJsonCar(name, model));
+		String json = createJsonCar(name, model);
+		when(hit.getSourceAsString()).thenReturn(json);
+		when(hit.getSourceRef()).thenReturn(new BytesArray(json));
+		Map<String, Object> map = new LinkedHashMap<>();
+		map.put("name", name);
+		map.put("model", model);
+		when(hit.getSourceAsMap()).thenReturn(map);
 		return hit;
 	}
 
@@ -281,6 +303,7 @@ public class DefaultResultMapperTests {
 		SearchHit hit = mock(SearchHit.class);
 		when(hit.getSourceAsString()).thenReturn(null);
 		when(hit.getFields()).thenReturn(createCarFields(name, model));
+		when(hit.iterator()).thenReturn(createCarFields(name, model).values().iterator());
 		return hit;
 	}
 

--- a/src/test/java/org/springframework/data/elasticsearch/core/DocumentAdaptersUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/DocumentAdaptersUnitTests.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.common.text.Text;
+import org.elasticsearch.index.get.GetResult;
+import org.elasticsearch.search.SearchHit;
+import org.junit.Test;
+
+import org.springframework.data.elasticsearch.Document;
+import org.springframework.data.elasticsearch.SearchDocument;
+
+/**
+ * Unit tests for {@link DocumentAdapters}.
+ *
+ * @author Mark Paluch
+ */
+public class DocumentAdaptersUnitTests {
+
+	@Test // DATAES-628
+	public void shouldAdaptGetResponse() {
+
+		Map<String, DocumentField> fields = Collections.singletonMap("field",
+				new DocumentField("field", Arrays.asList("value")));
+
+		GetResult getResult = new GetResult("index", "type", "my-id", 1, 0, 42, true, null, fields);
+		GetResponse response = new GetResponse(getResult);
+
+		Document document = DocumentAdapters.from(response);
+
+		assertThat(document.hasId()).isTrue();
+		assertThat(document.getId()).isEqualTo("my-id");
+		assertThat(document.hasVersion()).isTrue();
+		assertThat(document.getVersion()).isEqualTo(42);
+		assertThat(document.get("field")).isEqualTo("value");
+	}
+
+	@Test // DATAES-628
+	public void shouldAdaptGetResponseSource() {
+
+		BytesArray source = new BytesArray("{\"field\":\"value\"}");
+
+		GetResult getResult = new GetResult("index", "type", "my-id", 1, 0, 42, true, source, Collections.emptyMap());
+		GetResponse response = new GetResponse(getResult);
+
+		Document document = DocumentAdapters.from(response);
+
+		assertThat(document.hasId()).isTrue();
+		assertThat(document.getId()).isEqualTo("my-id");
+		assertThat(document.hasVersion()).isTrue();
+		assertThat(document.getVersion()).isEqualTo(42);
+		assertThat(document.get("field")).isEqualTo("value");
+	}
+
+	@Test // DATAES-628
+	public void shouldAdaptSearchResponse() {
+
+		Map<String, DocumentField> fields = Collections.singletonMap("field",
+				new DocumentField("field", Arrays.asList("value")));
+
+		SearchHit searchHit = new SearchHit(123, "my-id", new Text("type"), fields);
+		searchHit.score(42);
+
+		SearchDocument document = DocumentAdapters.from(searchHit);
+
+		assertThat(document.hasId()).isTrue();
+		assertThat(document.getId()).isEqualTo("my-id");
+		assertThat(document.hasVersion()).isFalse();
+		assertThat(document.getScore()).isBetween(42f, 42f);
+		assertThat(document.get("field")).isEqualTo("value");
+	}
+
+	@Test // DATAES-628
+	public void searchResponseShouldReturnContainsKey() {
+
+		Map<String, DocumentField> fields = new LinkedHashMap<>();
+
+		fields.put("string", new DocumentField("string", Arrays.asList("value")));
+		fields.put("bool", new DocumentField("bool", Arrays.asList(true, true, false)));
+
+		SearchHit searchHit = new SearchHit(123, "my-id", new Text("type"), fields);
+
+		SearchDocument document = DocumentAdapters.from(searchHit);
+
+		assertThat(document.containsKey("string")).isTrue();
+		assertThat(document.containsKey("not-set")).isFalse();
+	}
+
+	@Test // DATAES-628
+	public void searchResponseShouldReturnContainsValue() {
+
+		Map<String, DocumentField> fields = new LinkedHashMap<>();
+
+		fields.put("string", new DocumentField("string", Arrays.asList("value")));
+		fields.put("bool", new DocumentField("bool", Arrays.asList(true, true, false)));
+		fields.put("null", new DocumentField("null", Collections.emptyList()));
+
+		SearchHit searchHit = new SearchHit(123, "my-id", new Text("type"), fields);
+
+		SearchDocument document = DocumentAdapters.from(searchHit);
+
+		assertThat(document.containsValue("value")).isTrue();
+		assertThat(document.containsValue(Arrays.asList(true, true, false))).isTrue();
+		assertThat(document.containsValue(null)).isTrue();
+	}
+
+	@Test // DATAES-628
+	public void shouldRenderToJson() {
+
+		Map<String, DocumentField> fields = new LinkedHashMap<>();
+
+		fields.put("string", new DocumentField("string", Arrays.asList("value")));
+		fields.put("bool", new DocumentField("bool", Arrays.asList(true, true, false)));
+
+		SearchHit searchHit = new SearchHit(123, "my-id", new Text("type"), fields);
+
+		SearchDocument document = DocumentAdapters.from(searchHit);
+
+		assertThat(document.toJson()).isEqualTo("{\"string\":\"value\",\"bool\":[true,true,false]}");
+	}
+
+	@Test // DATAES-628
+	public void shouldAdaptSearchResponseSource() {
+
+		BytesArray source = new BytesArray("{\"field\":\"value\"}");
+
+		SearchHit searchHit = new SearchHit(123, "my-id", new Text("type"), Collections.emptyMap());
+		searchHit.sourceRef(source).score(42);
+		searchHit.version(22);
+
+		SearchDocument document = DocumentAdapters.from(searchHit);
+
+		assertThat(document.hasId()).isTrue();
+		assertThat(document.getId()).isEqualTo("my-id");
+		assertThat(document.hasVersion()).isTrue();
+		assertThat(document.getVersion()).isEqualTo(22);
+		assertThat(document.getScore()).isBetween(42f, 42f);
+		assertThat(document.get("field")).isEqualTo("value");
+	}
+}

--- a/src/test/java/org/springframework/data/elasticsearch/core/DocumentAdaptersUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/DocumentAdaptersUnitTests.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.text.Text;
 import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.search.SearchHit;
 import org.junit.Test;
-
 import org.springframework.data.elasticsearch.Document;
 import org.springframework.data.elasticsearch.SearchDocument;
 
@@ -37,6 +36,7 @@ import org.springframework.data.elasticsearch.SearchDocument;
  * Unit tests for {@link DocumentAdapters}.
  *
  * @author Mark Paluch
+ * @author Peter-Josef Meisch
  */
 public class DocumentAdaptersUnitTests {
 
@@ -46,7 +46,7 @@ public class DocumentAdaptersUnitTests {
 		Map<String, DocumentField> fields = Collections.singletonMap("field",
 				new DocumentField("field", Arrays.asList("value")));
 
-		GetResult getResult = new GetResult("index", "type", "my-id", 1, 0, 42, true, null, fields);
+		GetResult getResult = new GetResult("index", "type", "my-id", 1, 1, 42, true, null, fields, null);
 		GetResponse response = new GetResponse(getResult);
 
 		Document document = DocumentAdapters.from(response);
@@ -63,7 +63,7 @@ public class DocumentAdaptersUnitTests {
 
 		BytesArray source = new BytesArray("{\"field\":\"value\"}");
 
-		GetResult getResult = new GetResult("index", "type", "my-id", 1, 0, 42, true, source, Collections.emptyMap());
+		GetResult getResult = new GetResult("index", "type", "my-id", 1, 1, 42, true, source, Collections.emptyMap(), null);
 		GetResponse response = new GetResponse(getResult);
 
 		Document document = DocumentAdapters.from(response);

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchEntityMapperUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchEntityMapperUnitTests.java
@@ -47,7 +47,7 @@ import org.springframework.data.annotation.Transient;
 import org.springframework.data.annotation.TypeAlias;
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
-import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.Document;
 import org.springframework.data.elasticsearch.annotations.GeoPointField;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchCustomConversions;
 import org.springframework.data.elasticsearch.core.geo.GeoPoint;
@@ -58,7 +58,10 @@ import org.springframework.data.geo.Point;
 import org.springframework.data.geo.Polygon;
 
 /**
+ * Unit tests for {@link ElasticsearchEntityMapper}.
+ *
  * @author Christoph Strobl
+ * @author Mark Paluch
  */
 public class ElasticsearchEntityMapperUnitTests {
 
@@ -79,16 +82,16 @@ public class ElasticsearchEntityMapperUnitTests {
 	Address observatoryRoad;
 	Place bigBunsCafe;
 
-	Map<String, Object> sarahAsMap;
-	Map<String, Object> t800AsMap;
-	Map<String, Object> kyleAsMap;
-	Map<String, Object> gratiotAveAsMap;
-	Map<String, Object> locationAsMap;
-	Map<String, Object> gunAsMap;
-	Map<String, Object> grenadeAsMap;
-	Map<String, Object> rifleAsMap;
-	Map<String, Object> shotGunAsMap;
-	Map<String, Object> bigBunsCafeAsMap;
+	Document sarahAsMap;
+	Document t800AsMap;
+	Document kyleAsMap;
+	Document gratiotAveAsMap;
+	Document locationAsMap;
+	Document gunAsMap;
+	Document grenadeAsMap;
+	Document rifleAsMap;
+	Document shotGunAsMap;
+	Document bigBunsCafeAsMap;
 
 	@Before
 	public void init() {
@@ -117,7 +120,7 @@ public class ElasticsearchEntityMapperUnitTests {
 		t800.name = "T-800";
 		t800.gender = Gender.MACHINE;
 
-		t800AsMap = new LinkedHashMap<>();
+		t800AsMap = Document.create();
 		t800AsMap.put("id", "t800");
 		t800AsMap.put("name", "T-800");
 		t800AsMap.put("gender", "MACHINE");
@@ -134,27 +137,27 @@ public class ElasticsearchEntityMapperUnitTests {
 		bigBunsCafe.street = "15 South Fremont Avenue";
 		bigBunsCafe.location = new Point(34.0945637D, -118.1545845D);
 
-		sarahAsMap = new LinkedHashMap<>();
+		sarahAsMap = Document.create();
 		sarahAsMap.put("id", "sarah");
 		sarahAsMap.put("name", "Sarah Connor");
 		sarahAsMap.put("gender", "MAN");
 		sarahAsMap.put("_class", "org.springframework.data.elasticsearch.core.ElasticsearchEntityMapperUnitTests$Person");
 
-		kyleAsMap = new LinkedHashMap<>();
+		kyleAsMap = Document.create();
 		kyleAsMap.put("id", "kyle");
 		kyleAsMap.put("gender", "MAN");
 		kyleAsMap.put("name", "Kyle Reese");
 
-		locationAsMap = new LinkedHashMap<>();
+		locationAsMap = Document.create();
 		locationAsMap.put("lat", 34.118347D);
 		locationAsMap.put("lon", -118.3026284D);
 
-		gratiotAveAsMap = new LinkedHashMap<>();
+		gratiotAveAsMap = Document.create();
 		gratiotAveAsMap.put("city", "Los Angeles");
 		gratiotAveAsMap.put("street", "2800 East Observatory Road");
 		gratiotAveAsMap.put("location", locationAsMap);
 
-		bigBunsCafeAsMap = new LinkedHashMap<>();
+		bigBunsCafeAsMap = Document.create();
 		bigBunsCafeAsMap.put("name", "Big Buns Cafe");
 		bigBunsCafeAsMap.put("city", "Los Angeles");
 		bigBunsCafeAsMap.put("street", "15 South Fremont Avenue");
@@ -164,22 +167,22 @@ public class ElasticsearchEntityMapperUnitTests {
 		bigBunsCafeAsMap.put("_class",
 				"org.springframework.data.elasticsearch.core.ElasticsearchEntityMapperUnitTests$Place");
 
-		gunAsMap = new LinkedHashMap<>();
+		gunAsMap = Document.create();
 		gunAsMap.put("label", "Glock 19");
 		gunAsMap.put("shotsPerMagazine", 33);
 		gunAsMap.put("_class", Gun.class.getName());
 
-		grenadeAsMap = new LinkedHashMap<>();
+		grenadeAsMap = Document.create();
 		grenadeAsMap.put("label", "40 mm");
 		grenadeAsMap.put("_class", Grenade.class.getName());
 
-		rifleAsMap = new LinkedHashMap<>();
+		rifleAsMap = Document.create();
 		rifleAsMap.put("label", "AR-18 Assault Rifle");
 		rifleAsMap.put("weight", 3.17D);
 		rifleAsMap.put("maxShotsPerMagazine", 40);
 		rifleAsMap.put("_class", "rifle");
 
-		shotGunAsMap = new LinkedHashMap<>();
+		shotGunAsMap = Document.create();
 		shotGunAsMap.put("model", "Ithaca 37 Pump Shotgun");
 		shotGunAsMap.put("_class", ShotGun.class.getName());
 	}
@@ -255,7 +258,7 @@ public class ElasticsearchEntityMapperUnitTests {
 		person.gender = Gender.MAN;
 		person.address = observatoryRoad;
 
-		LinkedHashMap<String, Object> sink = writeToMap(person);
+		Map<String, Object> sink = writeToMap(person);
 
 		assertThat(sink.get("address")).isEqualTo(gratiotAveAsMap);
 	}
@@ -269,7 +272,7 @@ public class ElasticsearchEntityMapperUnitTests {
 
 		sarahConnor.coWorkers = Arrays.asList(kyleReese, ginger);
 
-		LinkedHashMap<String, Object> target = writeToMap(sarahConnor);
+		Map<String, Object> target = writeToMap(sarahConnor);
 		assertThat((List) target.get("coWorkers")).hasSize(2).contains(kyleAsMap);
 	}
 
@@ -281,7 +284,7 @@ public class ElasticsearchEntityMapperUnitTests {
 
 		sarahConnor.inventoryList = Arrays.asList(gun, grenade);
 
-		LinkedHashMap<String, Object> target = writeToMap(sarahConnor);
+		Map<String, Object> target = writeToMap(sarahConnor);
 		assertThat((List) target.get("inventoryList")).containsExactly(gunAsMap, grenadeAsMap);
 	}
 
@@ -319,7 +322,7 @@ public class ElasticsearchEntityMapperUnitTests {
 		sarahConnor.shippingAddresses = new LinkedHashMap<>();
 		sarahConnor.shippingAddresses.put("home", observatoryRoad);
 
-		LinkedHashMap<String, Object> target = writeToMap(sarahConnor);
+		Map<String, Object> target = writeToMap(sarahConnor);
 		assertThat(target.get("shippingAddresses")).isInstanceOf(Map.class);
 		assertThat(target.get("shippingAddresses")).isEqualTo(Collections.singletonMap("home", gratiotAveAsMap));
 	}
@@ -331,7 +334,7 @@ public class ElasticsearchEntityMapperUnitTests {
 		sarahConnor.inventoryMap.put("glock19", gun);
 		sarahConnor.inventoryMap.put("40 mm grenade", grenade);
 
-		LinkedHashMap<String, Object> target = writeToMap(sarahConnor);
+		Map<String, Object> target = writeToMap(sarahConnor);
 		assertThat(target.get("inventoryMap")).isInstanceOf(Map.class);
 		assertThat((Map) target.get("inventoryMap")).containsEntry("glock19", gunAsMap).containsEntry("40 mm grenade",
 				grenadeAsMap);
@@ -365,7 +368,7 @@ public class ElasticsearchEntityMapperUnitTests {
 		skynet.objectList.add(t800);
 		skynet.objectList.add(gun);
 
-		LinkedHashMap<String, Object> target = writeToMap(skynet);
+		Map<String, Object> target = writeToMap(skynet);
 
 		assertThat((List<Object>) target.get("objectList")).containsExactly(t800AsMap, gunAsMap);
 	}
@@ -373,7 +376,7 @@ public class ElasticsearchEntityMapperUnitTests {
 	@Test // DATAES-530
 	public void readGenericList() {
 
-		LinkedHashMap<String, Object> source = new LinkedHashMap<>();
+		Document source = Document.create();
 		source.put("objectList", Arrays.asList(t800AsMap, gunAsMap));
 
 		Skynet target = entityMapper.read(Skynet.class, source);
@@ -388,7 +391,7 @@ public class ElasticsearchEntityMapperUnitTests {
 		skynet.objectList = new ArrayList<>();
 		skynet.objectList.add(Arrays.asList(t800, gun));
 
-		LinkedHashMap<String, Object> target = writeToMap(skynet);
+		Map<String, Object> target = writeToMap(skynet);
 
 		assertThat((List<Object>) target.get("objectList")).containsExactly(Arrays.asList(t800AsMap, gunAsMap));
 	}
@@ -396,7 +399,7 @@ public class ElasticsearchEntityMapperUnitTests {
 	@Test // DATAES-530
 	public void readGenericListList() {
 
-		LinkedHashMap<String, Object> source = new LinkedHashMap<>();
+		Document source = Document.create();
 		source.put("objectList", Arrays.asList(Arrays.asList(t800AsMap, gunAsMap)));
 
 		Skynet target = entityMapper.read(Skynet.class, source);
@@ -412,7 +415,7 @@ public class ElasticsearchEntityMapperUnitTests {
 		skynet.objectMap.put("gun", gun);
 		skynet.objectMap.put("grenade", grenade);
 
-		LinkedHashMap<String, Object> target = writeToMap(skynet);
+		Map<String, Object> target = writeToMap(skynet);
 
 		assertThat((Map<String, Object>) target.get("objectMap")).containsEntry("gun", gunAsMap).containsEntry("grenade",
 				grenadeAsMap);
@@ -421,7 +424,7 @@ public class ElasticsearchEntityMapperUnitTests {
 	@Test // DATAES-530
 	public void readGenericMap() {
 
-		LinkedHashMap<String, Object> source = new LinkedHashMap<>();
+		Document source = Document.create();
 		source.put("objectMap", Collections.singletonMap("glock19", gunAsMap));
 
 		Skynet target = entityMapper.read(Skynet.class, source);
@@ -436,7 +439,7 @@ public class ElasticsearchEntityMapperUnitTests {
 		skynet.objectMap = new LinkedHashMap<>();
 		skynet.objectMap.put("inventory", Collections.singletonMap("glock19", gun));
 
-		LinkedHashMap<String, Object> target = writeToMap(skynet);
+		Map<String, Object> target = writeToMap(skynet);
 
 		assertThat((Map<String, Object>) target.get("objectMap")).containsEntry("inventory",
 				Collections.singletonMap("glock19", gunAsMap));
@@ -445,7 +448,7 @@ public class ElasticsearchEntityMapperUnitTests {
 	@Test // DATAES-530
 	public void readGenericMapMap() {
 
-		LinkedHashMap<String, Object> source = new LinkedHashMap<>();
+		Document source = Document.create();
 		source.put("objectMap", Collections.singletonMap("inventory", Collections.singletonMap("glock19", gunAsMap)));
 
 		Skynet target = entityMapper.read(Skynet.class, source);
@@ -466,7 +469,7 @@ public class ElasticsearchEntityMapperUnitTests {
 	@Test // DATAES-530
 	public void readsNestedObjectEntity() {
 
-		LinkedHashMap<String, Object> source = new LinkedHashMap<>();
+		Document source = Document.create();
 		source.put("object", t800AsMap);
 
 		Skynet target = entityMapper.read(Skynet.class, source);
@@ -483,7 +486,7 @@ public class ElasticsearchEntityMapperUnitTests {
 	public void writesNestedAliased() {
 
 		t800.inventoryList = Collections.singletonList(rifle);
-		LinkedHashMap<String, Object> target = writeToMap(t800);
+		Map<String, Object> target = writeToMap(t800);
 
 		assertThat((List) target.get("inventoryList")).contains(rifleAsMap);
 	}
@@ -516,7 +519,7 @@ public class ElasticsearchEntityMapperUnitTests {
 
 		sarahConnor.address = bigBunsCafe;
 
-		LinkedHashMap<String, Object> target = writeToMap(sarahConnor);
+		Map<String, Object> target = writeToMap(sarahConnor);
 
 		assertThat(target.get("address")).isEqualTo(bigBunsCafeAsMap);
 	}
@@ -535,9 +538,9 @@ public class ElasticsearchEntityMapperUnitTests {
 		return String.format(Locale.ENGLISH, "\"%s\":{\"lat\":%.1f,\"lon\":%.1f}", name, point.getX(), point.getY());
 	}
 
-	private LinkedHashMap<String, Object> writeToMap(Object source) {
+	private Map<String, Object> writeToMap(Object source) {
 
-		LinkedHashMap<String, Object> sink = new LinkedHashMap<>();
+		Document sink = Document.create();
 		entityMapper.write(source, sink);
 		return sink;
 	}
@@ -696,7 +699,8 @@ public class ElasticsearchEntityMapperUnitTests {
 	@NoArgsConstructor
 	@AllArgsConstructor
 	@Builder
-	@Document(indexName = "test-index-geo-core-entity-mapper", type = "geo-test-index", shards = 1, replicas = 0,
+	@org.springframework.data.elasticsearch.annotations.Document(indexName = "test-index-geo-core-entity-mapper",
+			type = "geo-test-index", shards = 1, replicas = 0,
 			refreshInterval = "-1")
 	static class GeoEntity {
 


### PR DESCRIPTION
We now expose a Document API to encapsulate data interchanged with Elasticsearch (get responses, search hits, arbitrary maps) for a consistent API.

`Map`-based operations with Id and version fields:

```java
Document document = Document.from(Collections.singletonMap("key", "value"));
document.setId("123");
document.setVersion(42);

```

`GetResponse`

```java
GetResponse response = …;

Document document = DocumentAdapters.from(response);

assertThat(document.hasId()).isTrue();
assertThat(document.getId()).isEqualTo("my-id");
assertThat(document.hasVersion()).isTrue();
assertThat(document.getVersion()).isEqualTo(42);
assertThat(document.get("field")).isEqualTo("value");
```

`SearchHit`
```java
SearchHit searchHit = …;

SearchDocument document = DocumentAdapters.from(searchHit);

assertThat(document.getScore()).isBetween(41.9f, 42.1f);
```

/cc @christophstrobl @sothawo 