### PR TITLE
DATAES-643: Added searchType to prepareSearch() in RestTemplate

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
@@ -140,6 +140,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author Martin Choraine
  * @author Farid Azaza
  * @author Peter-Josef Meisch
+ * @author Mathias Teier
  */
 public class ElasticsearchRestTemplate
 		implements ElasticsearchOperations, EsClient<RestHighLevelClient>, ApplicationContextAware {
@@ -1326,6 +1327,10 @@ public class ElasticsearchRestTemplate
 
 		if (query.getPreference() != null) {
 			request.preference(query.getPreference());
+		}
+
+		if (query.getSearchType() != null) {
+			request.searchType(query.getSearchType());
 		}
 
 		request.source(sourceBuilder);

--- a/src/main/java/org/springframework/data/elasticsearch/core/ReactiveElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ReactiveElasticsearchTemplate.java
@@ -78,6 +78,7 @@ import org.springframework.util.Assert;
  * @author Farid Azaza
  * @author Martin Choraine
  * @author Peter-Josef Meisch
+ * @author Mathias Teier
  * @since 3.2
  */
 public class ReactiveElasticsearchTemplate implements ReactiveElasticsearchOperations {
@@ -281,6 +282,10 @@ public class ReactiveElasticsearchTemplate implements ReactiveElasticsearchOpera
 
 			if (query.getPreference() != null) {
 				request.preference(query.getPreference());
+			}
+
+			if (query.getSearchType() != null) {
+				request.searchType(query.getSearchType());
 			}
 
 			Pageable pageable = query.getPageable();


### PR DESCRIPTION


- [ x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [x ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
