### PR TITLE
DATAES-647: Use terms-query instead of multiple should-queries for In and NotIn

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/CriteriaQueryProcessor.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/CriteriaQueryProcessor.java
@@ -19,6 +19,7 @@ import static org.elasticsearch.index.query.Operator.AND;
 import static org.elasticsearch.index.query.QueryBuilders.*;
 import static org.springframework.data.elasticsearch.core.query.Criteria.*;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -36,6 +37,7 @@ import org.springframework.util.Assert;
  * @author Mohsin Husen
  * @author Franck Marchand
  * @author Artur Konczak
+ * @author Rasmus Faber-Espensen
  */
 class CriteriaQueryProcessor {
 
@@ -142,8 +144,6 @@ class CriteriaQueryProcessor {
 
 		String searchText = StringUtils.toString(value);
 
-		Iterable<Object> collection = null;
-
 		switch (key) {
 			case EQUALS:
 				query = queryStringQuery(searchText).field(fieldName).defaultOperator(AND);
@@ -180,21 +180,21 @@ class CriteriaQueryProcessor {
 				query = fuzzyQuery(fieldName, searchText);
 				break;
 			case IN:
-				query = boolQuery();
-				collection = (Iterable<Object>) value;
-				for (Object item : collection) {
-					((BoolQueryBuilder) query).should(queryStringQuery(item.toString()).field(fieldName));
-				}
+				query = boolQuery().must(termsQuery(fieldName, toStringList((Iterable<Object>) value)));
 				break;
 			case NOT_IN:
-				query = boolQuery();
-				collection = (Iterable<Object>) value;
-				for (Object item : collection) {
-					((BoolQueryBuilder) query).mustNot(queryStringQuery(item.toString()).field(fieldName));
-				}
+				query = boolQuery().mustNot(termsQuery(fieldName, toStringList((Iterable<Object>) value)));
 				break;
 		}
 		return query;
+	}
+
+	private static List<String> toStringList(Iterable<?> iterable){
+		List<String> list = new ArrayList<>();
+		for (Object item : iterable) {
+			list.add(StringUtils.toString(item));
+		}
+		return list;
 	}
 
 	private void addBoost(QueryBuilder query, float boost) {

--- a/src/test/java/org/springframework/data/elasticsearch/repositories/custommethod/CustomMethodRepositoryBaseTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repositories/custommethod/CustomMethodRepositoryBaseTests.java
@@ -331,6 +331,68 @@ public abstract class CustomMethodRepositoryBaseTests {
 		assertThat(page.getContent().get(0).getId()).isEqualTo(documentId2);
 	}
 
+	@Test // DATAES-647
+	public void shouldHandleManyValuesQueryingIn() {
+
+		// given
+		String documentId1 = randomNumeric(32);
+		SampleEntity sampleEntity1 = new SampleEntity();
+		sampleEntity1.setId(documentId1);
+		sampleEntity1.setKeyword("foo");
+		repository.save(sampleEntity1);
+
+		String documentId2 = randomNumeric(32);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId2);
+		sampleEntity2.setKeyword("bar");
+		repository.save(sampleEntity2);
+
+		List<String> keywords = new ArrayList<>();
+		keywords.add("foo");
+
+		for (int i = 0; i < 1025; i++) {
+			keywords.add(randomNumeric(32));
+		}
+
+		// when
+		List<SampleEntity> list = repository.findByKeywordIn(keywords);
+
+		// then
+		assertThat(list.size()).isEqualTo(1L);
+		assertThat(list.get(0).getId()).isEqualTo(documentId1);
+	}
+
+	@Test // DATAES-647
+	public void shouldHandleManyValuesQueryingNotIn() {
+
+		// given
+		String documentId1 = randomNumeric(32);
+		SampleEntity sampleEntity1 = new SampleEntity();
+		sampleEntity1.setId(documentId1);
+		sampleEntity1.setKeyword("foo");
+		repository.save(sampleEntity1);
+
+		String documentId2 = randomNumeric(32);
+		SampleEntity sampleEntity2 = new SampleEntity();
+		sampleEntity2.setId(documentId2);
+		sampleEntity2.setKeyword("bar");
+		repository.save(sampleEntity2);
+
+		List<String> keywords = new ArrayList<>();
+		keywords.add("foo");
+
+		for (int i = 0; i < 1025; i++) {
+			keywords.add(randomNumeric(32));
+		}
+
+		// when
+		List<SampleEntity> list = repository.findByKeywordNotIn(keywords);
+
+		// then
+		assertThat(list.size()).isEqualTo(1L);
+		assertThat(list.get(0).getId()).isEqualTo(documentId2);
+	}
+
 	@Test
 	public void shouldExecuteCustomMethodForTrue() {
 
@@ -1296,6 +1358,7 @@ public abstract class CustomMethodRepositoryBaseTests {
 		@Id private String id;
 		@Field(type = Text, store = true, fielddata = true) private String type;
 		@Field(type = Text, store = true, fielddata = true) private String message;
+		@Field(type = Keyword) private String keyword;
 		private int rate;
 		private boolean available;
 		private GeoPoint location;
@@ -1336,6 +1399,10 @@ public abstract class CustomMethodRepositoryBaseTests {
 		Page<SampleEntity> findByMessageContaining(String message, Pageable pageable);
 
 		Page<SampleEntity> findByIdIn(List<String> ids, Pageable pageable);
+
+		List<SampleEntity> findByKeywordIn(List<String> keywords);
+
+		List<SampleEntity> findByKeywordNotIn(List<String> keywords);
 
 		Page<SampleEntity> findByIdNotIn(List<String> ids, Pageable pageable);
 


### PR DESCRIPTION
This pull request is against 4.0.x as requested (sorry, I don't think I can update the other pull request).

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
