### PR TITLE
DATAES-305 - Allow to put mapping built from entity class to different index.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/AbstractElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/AbstractElasticsearchTemplate.java
@@ -1,0 +1,52 @@
+package org.springframework.data.elasticsearch.core;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.elasticsearch.ElasticsearchException;
+import org.springframework.data.elasticsearch.annotations.Mapping;
+import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * AbstractElasticsearchTemplate
+ * 
+ * @author Sascha Woo
+ */
+public abstract class AbstractElasticsearchTemplate {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(AbstractElasticsearchTemplate.class);
+
+	protected ElasticsearchConverter elasticsearchConverter;
+
+	public AbstractElasticsearchTemplate(ElasticsearchConverter elasticsearchConverter) {
+
+		Assert.notNull(elasticsearchConverter, "elasticsearchConverter must not be null.");
+		this.elasticsearchConverter = elasticsearchConverter;
+	}
+
+	protected String buildMapping(Class<?> clazz) {
+
+		// load mapping specified in Mapping annotation if present
+		if (clazz.isAnnotationPresent(Mapping.class)) {
+			String mappingPath = clazz.getAnnotation(Mapping.class).mappingPath();
+			if (!StringUtils.isEmpty(mappingPath)) {
+				String mappings = ResourceUtil.readFileFromClasspath(mappingPath);
+				if (!StringUtils.isEmpty(mappings)) {
+					return mappings;
+				}
+			} else {
+				LOGGER.info("mappingPath in @Mapping has to be defined. Building mappings using @Field");
+			}
+		}
+
+		// build mapping from field annotations
+		try {
+			MappingBuilder mappingBuilder = new MappingBuilder(elasticsearchConverter);
+			return mappingBuilder.buildPropertyMapping(clazz);
+		} catch (Exception e) {
+			throw new ElasticsearchException("Failed to build mapping for " + clazz.getSimpleName(), e);
+		}
+	}
+
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchOperations.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchOperations.java
@@ -105,6 +105,16 @@ public interface ElasticsearchOperations {
 	<T> boolean putMapping(Class<T> clazz);
 
 	/**
+	 * Create mapping for the given class and put the mapping to the given indexName and type.
+	 *
+	 * @param indexName
+	 * @param type
+	 * @param mappings
+	 * @since 3.2
+	 */
+	<T> boolean putMapping(String indexName, String type, Class<T> clazz);
+
+	/**
 	 * Create mapping for a given indexName and type
 	 *
 	 * @param indexName

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.elasticsearch.core;
 import static org.apache.commons.lang.RandomStringUtils.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.elasticsearch.index.query.QueryBuilders.*;
+import static org.hamcrest.CoreMatchers.*;
 import static org.springframework.data.elasticsearch.annotations.FieldType.*;
 import static org.springframework.data.elasticsearch.utils.IndexBuilder.*;
 
@@ -1436,6 +1437,22 @@ public class ElasticsearchTemplateTests {
 
 		// then
 		assertThat(elasticsearchTemplate.putMapping(entity)).isTrue();
+	}
+
+	@Test // DATAES-305
+	public void shouldPutMappingWithCustomIndexName() throws Exception {
+
+		// given
+		Class<SampleEntity> entity = SampleEntity.class;
+		elasticsearchTemplate.deleteIndex(INDEX_1_NAME);
+		elasticsearchTemplate.createIndex(INDEX_1_NAME);
+
+		// when
+		elasticsearchTemplate.putMapping(INDEX_1_NAME, TYPE_NAME, entity);
+
+		// then
+		Map<String, Object> mapping = elasticsearchTemplate.getMapping(INDEX_1_NAME, TYPE_NAME);
+		assertThat(mapping.get("properties")).isNotNull();
 	}
 
 	@Test


### PR DESCRIPTION
There is more than one Jira issue that has called for a change in this area. We are also currently affected by the fact that we want to write an existing entity with its mapping to a different index than the one defined in the `@Document`. I hope this improvement will find its way into the upcoming release and yeap I know it's a little late.

https://jira.spring.io/browse/DATAES-305
https://jira.spring.io/browse/DATAES-253
https://jira.spring.io/browse/DATAES-243

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
