### PR TITLE
DATAES-650 Add support for pathPrefix to configuration classes

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/client/ClientConfiguration.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/ClientConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.http.HttpHeaders;
  *
  * @author Mark Paluch
  * @author Peter-Josef Meisch
+ * @author Huw Ayling-Miller
  * @since 3.2
  */
 public interface ClientConfiguration {
@@ -134,6 +135,14 @@ public interface ClientConfiguration {
 	 * @see io.netty.handler.timeout.WriteTimeoutHandler
 	 */
 	Duration getSocketTimeout();
+
+	/**
+	 * Returns the path prefix that should be prepended to HTTP(s) requests for Elasticsearch behind a proxy.
+	 * 
+	 * @return the path prefix.
+	 * @since 4.0
+	 */
+	String getPathPrefix();
 
 	/**
 	 * @author Christoph Strobl
@@ -266,6 +275,15 @@ public interface ClientConfiguration {
 		 * @return the {@link TerminalClientConfigurationBuilder}
 		 */
 		TerminalClientConfigurationBuilder withBasicAuth(String username, String password);
+
+		/**
+		 * Configure the path prefix that will be prepended to any HTTP(s) requests
+		 * 
+		 * @param pathPrefix the pathPrefix.
+		 * @return the {@link TerminalClientConfigurationBuilder}
+		 * @since 4.0
+		 */
+		TerminalClientConfigurationBuilder withPathPrefix(String pathPrefix);
 
 		/**
 		 * Build the {@link ClientConfiguration} object.

--- a/src/main/java/org/springframework/data/elasticsearch/client/ClientConfigurationBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/ClientConfigurationBuilder.java
@@ -37,6 +37,7 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Peter-Josef Meisch
+ * @author Huw Ayling-Miller
  * @since 3.2
  */
 class ClientConfigurationBuilder
@@ -50,6 +51,7 @@ class ClientConfigurationBuilder
 	private Duration soTimeout = Duration.ofSeconds(5);
 	private String username;
 	private String password;
+	private String pathPrefix;
 
 	/*
 	 * (non-Javadoc)
@@ -156,6 +158,14 @@ class ClientConfigurationBuilder
 		return this;
 	}
 
+	@Override
+	public TerminalClientConfigurationBuilder withPathPrefix(String pathPrefix) {
+
+		this.pathPrefix = pathPrefix;
+
+		return this;
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.elasticsearch.client.ClientConfiguration.ClientConfigurationBuilderWithOptionalDefaultHeaders#build()
@@ -171,7 +181,7 @@ class ClientConfigurationBuilder
 		}
 
 		return new DefaultClientConfiguration(this.hosts, this.headers, this.useSsl, this.sslContext, this.soTimeout,
-				this.connectTimeout);
+				this.connectTimeout, this.pathPrefix);
 	}
 
 	private static InetSocketAddress parse(String hostAndPort) {

--- a/src/main/java/org/springframework/data/elasticsearch/client/DefaultClientConfiguration.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/DefaultClientConfiguration.java
@@ -32,6 +32,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Mark Paluch
  * @author Christoph Strobl
+ * @author Huw Ayling-Miller
  * @since 3.2
  */
 class DefaultClientConfiguration implements ClientConfiguration {
@@ -42,9 +43,10 @@ class DefaultClientConfiguration implements ClientConfiguration {
 	private final @Nullable SSLContext sslContext;
 	private final Duration soTimeout;
 	private final Duration connectTimeout;
+	private final String pathPrefix;
 
 	DefaultClientConfiguration(List<InetSocketAddress> hosts, HttpHeaders headers, boolean useSsl,
-			@Nullable SSLContext sslContext, Duration soTimeout, Duration connectTimeout) {
+			@Nullable SSLContext sslContext, Duration soTimeout, Duration connectTimeout, @Nullable String pathPrefix) {
 
 		this.hosts = Collections.unmodifiableList(new ArrayList<>(hosts));
 		this.headers = new HttpHeaders(headers);
@@ -52,6 +54,7 @@ class DefaultClientConfiguration implements ClientConfiguration {
 		this.sslContext = sslContext;
 		this.soTimeout = soTimeout;
 		this.connectTimeout = connectTimeout;
+		this.pathPrefix = pathPrefix;
 	}
 
 	/*
@@ -106,6 +109,15 @@ class DefaultClientConfiguration implements ClientConfiguration {
 	@Override
 	public Duration getSocketTimeout() {
 		return this.soTimeout;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.elasticsearch.client.ClientConfiguration#getPathPrefix()
+	 */
+	@Override
+	public String getPathPrefix() {
+		return this.pathPrefix;
 	}
 
 }

--- a/src/main/java/org/springframework/data/elasticsearch/client/RestClients.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/RestClients.java
@@ -52,6 +52,7 @@ import org.springframework.util.Assert;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Huw Ayling-Miller
  * @since 3.2
  */
 public final class RestClients {
@@ -75,6 +76,11 @@ public final class RestClients {
 		HttpHost[] httpHosts = formattedHosts(clientConfiguration.getEndpoints(), clientConfiguration.useSsl()).stream()
 				.map(HttpHost::create).toArray(HttpHost[]::new);
 		RestClientBuilder builder = RestClient.builder(httpHosts);
+
+		if (clientConfiguration.getPathPrefix() != null) {
+			builder.setPathPrefix(clientConfiguration.getPathPrefix());
+		}
+
 		HttpHeaders headers = clientConfiguration.getDefaultHeaders();
 
 		if (!headers.isEmpty()) {

--- a/src/main/java/org/springframework/data/elasticsearch/client/reactive/DefaultReactiveElasticsearchClient.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/reactive/DefaultReactiveElasticsearchClient.java
@@ -123,6 +123,7 @@ import org.springframework.web.reactive.function.client.WebClient.RequestBodySpe
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Peter-Josef Meisch
+ * @author Huw Ayling-Miller
  * @since 3.2
  * @see ClientConfiguration
  * @see ReactiveRestClients
@@ -216,6 +217,10 @@ public class DefaultReactiveElasticsearchClient implements ReactiveElasticsearch
 
 		ReactorClientHttpConnector connector = new ReactorClientHttpConnector(httpClient);
 		WebClientProvider provider = WebClientProvider.create(scheme, connector);
+
+		if (clientConfiguration.getPathPrefix() != null) {
+			provider = provider.withPathPrefix(clientConfiguration.getPathPrefix());
+		}
 
 		return provider.withDefaultHeaders(clientConfiguration.getDefaultHeaders());
 	}

--- a/src/main/java/org/springframework/data/elasticsearch/client/reactive/WebClientProvider.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/reactive/WebClientProvider.java
@@ -34,6 +34,7 @@ import org.springframework.web.reactive.function.client.WebClient;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Huw Ayling-Miller
  * @since 3.2
  */
 public interface WebClientProvider {
@@ -97,6 +98,14 @@ public interface WebClientProvider {
 	Consumer<Throwable> getErrorListener();
 
 	/**
+	 * Obtain the {@link String pathPrefix} to be used.
+	 * 
+	 * @return the pathPrefix if set.
+	 * @since 4.0
+	 */
+	String getPathPrefix();
+
+	/**
 	 * Create a new instance of {@link WebClientProvider} applying the given headers by default.
 	 *
 	 * @param headers must not be {@literal null}.
@@ -111,4 +120,13 @@ public interface WebClientProvider {
 	 * @return new instance of {@link WebClientProvider}.
 	 */
 	WebClientProvider withErrorListener(Consumer<Throwable> errorListener);
+
+	/**
+	 * Create a new instance of {@link WebClientProvider} where HTTP requests are called with the given path prefix.
+	 * 
+	 * @param pathPrefix Path prefix to add to requests
+	 * @return new instance of {@link WebClientProvider}
+	 * @since 4.0
+	 */
+	WebClientProvider withPathPrefix(String pathPrefix);
 }

--- a/src/test/java/org/springframework/data/elasticsearch/client/ClientConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/client/ClientConfigurationUnitTests.java
@@ -31,6 +31,7 @@ import org.springframework.http.HttpHeaders;
  *
  * @author Mark Paluch
  * @author Peter-Josef Meisch
+ * @author Huw Ayling-Miller
  */
 public class ClientConfigurationUnitTests {
 
@@ -42,7 +43,7 @@ public class ClientConfigurationUnitTests {
 		assertThat(clientConfiguration.getEndpoints()).containsOnly(InetSocketAddress.createUnresolved("localhost", 9200));
 	}
 
-	@Test // DATAES-488, DATAES-504
+	@Test // DATAES-488, DATAES-504, DATAES-650
 	public void shouldCreateCustomizedConfiguration() {
 
 		HttpHeaders headers = new HttpHeaders();
@@ -52,7 +53,8 @@ public class ClientConfigurationUnitTests {
 				.connectedTo("foo", "bar") //
 				.usingSsl() //
 				.withDefaultHeaders(headers) //
-				.withConnectTimeout(Duration.ofDays(1)).withSocketTimeout(Duration.ofDays(2)).build();
+				.withConnectTimeout(Duration.ofDays(1)).withSocketTimeout(Duration.ofDays(2)) //
+				.withPathPrefix("myPathPrefix").build();
 
 		assertThat(clientConfiguration.getEndpoints()).containsOnly(InetSocketAddress.createUnresolved("foo", 9200),
 				InetSocketAddress.createUnresolved("bar", 9200));
@@ -60,6 +62,7 @@ public class ClientConfigurationUnitTests {
 		assertThat(clientConfiguration.getDefaultHeaders().get("foo")).containsOnly("bar");
 		assertThat(clientConfiguration.getConnectTimeout()).isEqualTo(Duration.ofDays(1));
 		assertThat(clientConfiguration.getSocketTimeout()).isEqualTo(Duration.ofDays(2));
+		assertThat(clientConfiguration.getPathPrefix()).isEqualTo("myPathPrefix");
 	}
 
 	@Test // DATAES-488, DATAES-504

--- a/src/test/java/org/springframework/data/elasticsearch/client/reactive/ReactiveMockClientTestsUtils.java
+++ b/src/test/java/org/springframework/data/elasticsearch/client/reactive/ReactiveMockClientTestsUtils.java
@@ -263,6 +263,16 @@ public class ReactiveMockClientTestsUtils {
 		public WebClientProvider withErrorListener(Consumer<Throwable> errorListener) {
 			throw new UnsupportedOperationException();
 		}
+		
+		@Override
+		public String getPathPrefix() {
+			return null;
+		}
+		
+		@Override
+		public WebClientProvider withPathPrefix(String pathPrefix) {
+			throw new UnsupportedOperationException();
+		}
 
 		public Send when(String host) {
 			InetSocketAddress inetSocketAddress = getInetSocketAddress(host);


### PR DESCRIPTION
Add support for pathPrefix to configuration classes.

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
