### PR TITLE
DATAES-652 - Send if_seq_no and if_primary_term parameters when index…

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/client/util/RequestConverters.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/util/RequestConverters.java
@@ -81,6 +81,7 @@ import org.elasticsearch.index.reindex.AbstractBulkByScrollRequest;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 import org.elasticsearch.index.reindex.ReindexRequest;
 import org.elasticsearch.index.reindex.UpdateByQueryRequest;
+import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.tasks.TaskId;
 import org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsearchClient;
@@ -315,6 +316,8 @@ public class RequestConverters {
 		parameters.withTimeout(indexRequest.timeout());
 		parameters.withVersion(indexRequest.version());
 		parameters.withVersionType(indexRequest.versionType());
+		parameters.withIfSeqNo(indexRequest.ifSeqNo());
+		parameters.withIfPrimaryTerm(indexRequest.ifPrimaryTerm());
 		parameters.withPipeline(indexRequest.getPipeline());
 		parameters.withRefreshPolicy(indexRequest.getRefreshPolicy());
 		parameters.withWaitForActiveShards(indexRequest.waitForActiveShards());
@@ -913,6 +916,20 @@ public class RequestConverters {
 		Params withVersionType(VersionType versionType) {
 			if (versionType != VersionType.INTERNAL) {
 				return putParam("version_type", versionType.name().toLowerCase(Locale.ROOT));
+			}
+			return this;
+		}
+
+		Params withIfSeqNo(long seqNo) {
+			if (seqNo != SequenceNumbers.UNASSIGNED_SEQ_NO) {
+				return putParam("if_seq_no", Long.toString(seqNo));
+			}
+			return this;
+		}
+
+		Params withIfPrimaryTerm(long primaryTerm) {
+			if (primaryTerm != SequenceNumbers.UNASSIGNED_PRIMARY_TERM) {
+				return putParam("if_primary_term", Long.toString(primaryTerm));
 			}
 			return this;
 		}

--- a/src/main/java/org/springframework/data/elasticsearch/client/util/RequestConverters.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/util/RequestConverters.java
@@ -117,6 +117,8 @@ public class RequestConverters {
 		parameters.withTimeout(deleteRequest.timeout());
 		parameters.withVersion(deleteRequest.version());
 		parameters.withVersionType(deleteRequest.versionType());
+		parameters.withIfSeqNo(deleteRequest.ifSeqNo());
+		parameters.withIfPrimaryTerm(deleteRequest.ifPrimaryTerm());
 		parameters.withRefreshPolicy(deleteRequest.getRefreshPolicy());
 		parameters.withWaitForActiveShards(deleteRequest.waitForActiveShards());
 		return request;

--- a/src/test/java/org/springframework/data/elasticsearch/client/util/RequestConvertersTest.java
+++ b/src/test/java/org/springframework/data/elasticsearch/client/util/RequestConvertersTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertThat;
 
 import java.util.HashMap;
 
+import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.client.Request;
 import org.junit.Test;
@@ -59,6 +60,32 @@ public class RequestConvertersTest {
 		request.setIfPrimaryTerm(4);
 
 		Request result = RequestConverters.index(request);
+
+		assertThat(result.getParameters(), hasEntry("if_seq_no", "3"));
+		assertThat(result.getParameters(), hasEntry("if_primary_term", "4"));
+	}
+
+	@Test // DATAES-652
+	public void shouldNotAddIfSeqNoAndIfPrimaryTermToResultIfInputDoesNotcontainThemWhenConvertingDeleteRequest() {
+		DeleteRequest request = createMinimalDeleteRequest();
+
+		Request result = RequestConverters.delete(request);
+
+		assertThat(result.getParameters(), not(hasKey("if_seq_no")));
+		assertThat(result.getParameters(), not(hasKey("if_primary_term")));
+	}
+
+	private DeleteRequest createMinimalDeleteRequest() {
+		return new DeleteRequest("the-index", "the-type", "id");
+	}
+
+	@Test // DATAES-652
+	public void shouldAddIfSeqNoAndIfPrimaryTermToResultIfInputcontainsThemWhenConvertingDeleteRequest() {
+		DeleteRequest request = createMinimalDeleteRequest();
+		request.setIfSeqNo(3);
+		request.setIfPrimaryTerm(4);
+
+		Request result = RequestConverters.delete(request);
 
 		assertThat(result.getParameters(), hasEntry("if_seq_no", "3"));
 		assertThat(result.getParameters(), hasEntry("if_primary_term", "4"));

--- a/src/test/java/org/springframework/data/elasticsearch/client/util/RequestConvertersTest.java
+++ b/src/test/java/org/springframework/data/elasticsearch/client/util/RequestConvertersTest.java
@@ -53,7 +53,7 @@ public class RequestConvertersTest {
 	}
 
 	@Test // DATAES-652
-	public void shouldAddIfSeqNoAndIfPrimaryTermToResultIfInputcontainsThemWhenConvertingIndex() {
+	public void shouldAddIfSeqNoAndIfPrimaryTermToResultIfInputcontainsThemWhenConvertingIndexRequest() {
 		IndexRequest request = createMinimalIndexRequest();
 		request.setIfSeqNo(3);
 		request.setIfPrimaryTerm(4);

--- a/src/test/java/org/springframework/data/elasticsearch/client/util/RequestConvertersTest.java
+++ b/src/test/java/org/springframework/data/elasticsearch/client/util/RequestConvertersTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
  */
 public class RequestConvertersTest {
 	@Test // DATAES-652
-	public void shouldNotAddIfSeqNoAndIfPrimaryTermToResultIfInputDoesNotcontainThemWhenConvertingIndex() {
+	public void shouldNotAddIfSeqNoAndIfPrimaryTermToResultIfInputDoesNotcontainThemWhenConvertingIndexRequest() {
 		IndexRequest request = createMinimalIndexRequest();
 
 		Request result = RequestConverters.index(request);

--- a/src/test/java/org/springframework/data/elasticsearch/client/util/RequestConvertersTest.java
+++ b/src/test/java/org/springframework/data/elasticsearch/client/util/RequestConvertersTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.client.util;
+
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.util.HashMap;
+
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.client.Request;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link RequestConverters}.
+ *
+ * @author Roman Puchkovskiy
+ */
+public class RequestConvertersTest {
+	@Test // DATAES-652
+	public void shouldNotAddIfSeqNoAndIfPrimaryTermToResultIfInputDoesNotcontainThemWhenConvertingIndex() {
+		IndexRequest request = createMinimalIndexRequest();
+
+		Request result = RequestConverters.index(request);
+
+		assertThat(result.getParameters(), not(hasKey("if_seq_no")));
+		assertThat(result.getParameters(), not(hasKey("if_primary_term")));
+	}
+
+	private IndexRequest createMinimalIndexRequest() {
+		IndexRequest request = new IndexRequest("the-index", "the-type", "id");
+		request.source(new HashMap<String, String>() {
+			{
+				put("test", "test");
+			}
+		});
+		return request;
+	}
+
+	@Test // DATAES-652
+	public void shouldAddIfSeqNoAndIfPrimaryTermToResultIfInputcontainsThemWhenConvertingIndex() {
+		IndexRequest request = createMinimalIndexRequest();
+		request.setIfSeqNo(3);
+		request.setIfPrimaryTerm(4);
+
+		Request result = RequestConverters.index(request);
+
+		assertThat(result.getParameters(), hasEntry("if_seq_no", "3"));
+		assertThat(result.getParameters(), hasEntry("if_primary_term", "4"));
+	}
+}


### PR DESCRIPTION
Current RequestConveters.index() does not respect ifSeqNo and ifPrimaryTerm (it just ignores them).

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

JIRA ticket: https://jira.spring.io/browse/DATAES-652

I didn't add myself as an author of `RequestConverters` because there was no `@author` tags at all, and I don't want to lie that I'm the only author :)