### PR TITLE
DATAES-316 - Revert: NodeClientFactoryBean doesn't shutdown ES on des…

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/client/NodeClientFactoryBean.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/NodeClientFactoryBean.java
@@ -152,9 +152,12 @@ public class NodeClientFactoryBean implements FactoryBean<Client>, InitializingB
 		try {
 			// NodeClient.close() is a noop, no need to call it here
 			logger.info("Closing elasticSearch node");
-			if (node != null) {
-				node.close();
-			}
+			// closing the Node causes tests to fail in the pipeline build and on some
+			// "mvn test" runs, there seem still to be tests relying on a running instance that
+			// is not properly set up.
+//			if (node != null) {
+//				node.close();
+//			}
 		} catch (final Exception e) {
 			logger.error("Error closing ElasticSearch client: ", e);
 		}


### PR DESCRIPTION
…troy life-cycle.

this seems to break builds in the pipeline that fail with
java.net.ConnectException: Connection refused
So this needs further investigation