### PR TITLE
DATAES-693 - Support for source fetching in update operations

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
@@ -145,6 +145,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author Peter-Josef Meisch
  * @author Mathias Teier
  * @author Gyula Attila Csorogi
+ * @author Massimiliano Poggi
  */
 public class ElasticsearchRestTemplate extends AbstractElasticsearchTemplate
 		implements EsClient<RestHighLevelClient>, ApplicationContextAware {
@@ -685,7 +686,8 @@ public class ElasticsearchRestTemplate extends AbstractElasticsearchTemplate
 				.setRefreshPolicy(queryUpdateRequest.getRefreshPolicy()) //
 				.waitForActiveShards(queryUpdateRequest.waitForActiveShards()) //
 				.scriptedUpsert(queryUpdateRequest.scriptedUpsert()) //
-				.docAsUpsert(queryUpdateRequest.docAsUpsert());
+				.docAsUpsert(queryUpdateRequest.docAsUpsert()) //
+				.fetchSource(queryUpdateRequest.fetchSource());
 
 		if (query.DoUpsert()) {
 			updateRequest.docAsUpsert(true);


### PR DESCRIPTION
The current ElasticsearchRestTemplate does not copy the fetchSource query parameter when forwarding the call to Elasticsearch. 

The proposed PR copies the fetchSource value when creating the corresponding UpdateRequest.
