### PR TITLE
DATAES-697_-_Query-refactoring-cleanup.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/AbstractElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/AbstractElasticsearchTemplate.java
@@ -34,7 +34,6 @@ import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersiste
 import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
 import org.springframework.data.elasticsearch.core.query.DeleteQuery;
 import org.springframework.data.elasticsearch.core.query.MoreLikeThisQuery;
-import org.springframework.data.elasticsearch.core.query.NativeSearchQuery;
 import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
 import org.springframework.data.elasticsearch.core.query.Query;
 import org.springframework.util.Assert;
@@ -53,6 +52,9 @@ public abstract class AbstractElasticsearchTemplate implements ElasticsearchOper
 	protected ElasticsearchConverter elasticsearchConverter;
 	protected RequestFactory requestFactory;
 
+	/**
+	 * @since 4.0
+	 */
 	public RequestFactory getRequestFactory() {
 		return requestFactory;
 	}
@@ -195,43 +197,6 @@ public abstract class AbstractElasticsearchTemplate implements ElasticsearchOper
 							+ failedDocuments + "]",
 					failedDocuments);
 		}
-	}
-
-	/**
-	 * @param query
-	 * @param clazz
-	 * @deprecated index names and types should not be set in query
-	 */
-	@Deprecated
-	protected void setPersistentEntityIndexAndType(Query query, Class clazz) {
-		if (query.getIndices().isEmpty()) {
-			String[] indices = retrieveIndexNameFromPersistentEntity(clazz);
-
-			if (indices != null) {
-				query.addIndices(indices);
-			}
-		}
-		if (query.getTypes().isEmpty()) {
-			String[] types = retrieveTypeFromPersistentEntity(clazz);
-
-			if (types != null) {
-				query.addTypes(types);
-			}
-		}
-	}
-
-	private String[] retrieveIndexNameFromPersistentEntity(Class clazz) {
-		if (clazz != null) {
-			return new String[] { getPersistentEntityFor(clazz).getIndexName() };
-		}
-		return null;
-	}
-
-	private String[] retrieveTypeFromPersistentEntity(Class clazz) {
-		if (clazz != null) {
-			return new String[] { getPersistentEntityFor(clazz).getIndexType() };
-		}
-		return null;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchOperations.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchOperations.java
@@ -484,11 +484,6 @@ public interface ElasticsearchOperations {
 	ElasticsearchConverter getElasticsearchConverter();
 
 	/**
-	 * @since 4.0
-	 */
-	RequestFactory getRequestFactory();
-
-	/**
 	 * @param clazz
 	 * @return the IndexCoordinates defined on the entity.
 	 * @since 4.0

--- a/src/main/java/org/springframework/data/elasticsearch/core/RequestFactory.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/RequestFactory.java
@@ -604,17 +604,7 @@ class RequestFactory {
 		}
 
 		if (query instanceof NativeSearchQuery) {
-			NativeSearchQuery nativeSearchQuery = (NativeSearchQuery) query;
-
-			if (!nativeSearchQuery.getScriptFields().isEmpty()) {
-				for (ScriptField scriptedField : nativeSearchQuery.getScriptFields()) {
-					sourceBuilder.scriptField(scriptedField.fieldName(), scriptedField.script());
-				}
-			}
-
-			if (nativeSearchQuery.getCollapseBuilder() != null) {
-				sourceBuilder.collapse(nativeSearchQuery.getCollapseBuilder());
-			}
+			prepareNativeSearch((NativeSearchQuery) query, sourceBuilder);
 
 		}
 
@@ -679,6 +669,33 @@ class RequestFactory {
 		}
 
 		return searchRequestBuilder;
+	}
+
+	private void prepareNativeSearch(NativeSearchQuery query, SearchSourceBuilder sourceBuilder) {
+		NativeSearchQuery nativeSearchQuery = query;
+
+		if (!nativeSearchQuery.getScriptFields().isEmpty()) {
+			for (ScriptField scriptedField : nativeSearchQuery.getScriptFields()) {
+				sourceBuilder.scriptField(scriptedField.fieldName(), scriptedField.script());
+			}
+		}
+
+		if (nativeSearchQuery.getCollapseBuilder() != null) {
+			sourceBuilder.collapse(nativeSearchQuery.getCollapseBuilder());
+		}
+
+		if (!isEmpty(nativeSearchQuery.getIndicesBoost())) {
+			for (IndexBoost indexBoost : nativeSearchQuery.getIndicesBoost()) {
+				sourceBuilder.indexBoost(indexBoost.getIndexName(), indexBoost.getBoost());
+			}
+		}
+
+		if (!isEmpty(nativeSearchQuery.getAggregations())) {
+			for (AbstractAggregationBuilder aggregationBuilder : nativeSearchQuery.getAggregations()) {
+				sourceBuilder.aggregation(aggregationBuilder);
+			}
+		}
+
 	}
 
 	private void prepareNativeSearch(SearchRequestBuilder searchRequestBuilder, NativeSearchQuery nativeSearchQuery) {

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/AbstractQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/AbstractQuery.java
@@ -42,8 +42,6 @@ abstract class AbstractQuery implements Query {
 
 	protected Pageable pageable = DEFAULT_PAGE;
 	protected Sort sort;
-	protected List<String> indices = new ArrayList<>();
-	protected List<String> types = new ArrayList<>();
 	protected List<String> fields = new ArrayList<>();
 	protected SourceFilter sourceFilter;
 	protected float minScore;
@@ -82,26 +80,6 @@ abstract class AbstractQuery implements Query {
 	@Override
 	public List<String> getFields() {
 		return fields;
-	}
-
-	@Override
-	public List<String> getIndices() {
-		return indices;
-	}
-
-	@Override
-	public void addIndices(String... indices) {
-		addAll(this.indices, indices);
-	}
-
-	@Override
-	public void addTypes(String... types) {
-		addAll(this.types, types);
-	}
-
-	@Override
-	public List<String> getTypes() {
-		return types;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/MoreLikeThisQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/MoreLikeThisQuery.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.data.elasticsearch.core.query;
 
-import static java.util.Collections.addAll;
+import static java.util.Collections.*;
 import static org.springframework.data.elasticsearch.core.query.AbstractQuery.*;
 
 import java.util.ArrayList;
@@ -28,12 +28,11 @@ import org.springframework.data.domain.Pageable;
  *
  * @author Rizwan Idrees
  * @author Mohsin Husen
+ * @author Peter-Josef Meisch
  */
 public class MoreLikeThisQuery {
 
 	private String id;
-	private String indexName;
-	private String type;
 	private List<String> searchIndices = new ArrayList<>();
 	private List<String> searchTypes = new ArrayList<>();
 	private List<String> fields = new ArrayList<>();
@@ -55,22 +54,6 @@ public class MoreLikeThisQuery {
 
 	public void setId(String id) {
 		this.id = id;
-	}
-
-	public String getIndexName() {
-		return indexName;
-	}
-
-	public void setIndexName(String indexName) {
-		this.indexName = indexName;
-	}
-
-	public String getType() {
-		return type;
-	}
-
-	public void setType(String type) {
-		this.type = type;
 	}
 
 	public List<String> getSearchIndices() {

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/NativeSearchQueryBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/NativeSearchQueryBuilder.java
@@ -42,6 +42,7 @@ import org.springframework.data.domain.Pageable;
  * @author Jean-Baptiste Nizet
  * @author Martin Choraine
  * @author Farid Azaza
+ * @author Peter-Josef Meisch
  */
 public class NativeSearchQueryBuilder {
 
@@ -53,8 +54,6 @@ public class NativeSearchQueryBuilder {
 	private HighlightBuilder highlightBuilder;
 	private HighlightBuilder.Field[] highlightFields;
 	private Pageable pageable = Pageable.unpaged();
-	private String[] indices;
-	private String[] types;
 	private String[] fields;
 	private SourceFilter sourceFilter;
 	private CollapseBuilder collapseBuilder;
@@ -117,16 +116,6 @@ public class NativeSearchQueryBuilder {
 		return this;
 	}
 
-	public NativeSearchQueryBuilder withIndices(String... indices) {
-		this.indices = indices;
-		return this;
-	}
-
-	public NativeSearchQueryBuilder withTypes(String... types) {
-		this.types = types;
-		return this;
-	}
-
 	public NativeSearchQueryBuilder withFields(String... fields) {
 		this.fields = fields;
 		return this;
@@ -183,14 +172,6 @@ public class NativeSearchQueryBuilder {
 
 		nativeSearchQuery.setPageable(pageable);
 		nativeSearchQuery.setTrackScores(trackScores);
-
-		if (indices != null) {
-			nativeSearchQuery.addIndices(indices);
-		}
-
-		if (types != null) {
-			nativeSearchQuery.addTypes(types);
-		}
 
 		if (fields != null) {
 			nativeSearchQuery.addFields(fields);

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/Query.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/Query.java
@@ -82,38 +82,6 @@ public interface Query {
 	Sort getSort();
 
 	/**
-	 * Get Indices to be searched
-	 *
-	 * @return
-	 */
-	@Deprecated
-	List<String> getIndices();
-
-	/**
-	 * Add Indices to be added as part of search request
-	 *
-	 * @param indices
-	 */
-	@Deprecated
-	void addIndices(String... indices);
-
-	/**
-	 * Add types to be searched
-	 *
-	 * @param types
-	 */
-	@Deprecated
-	void addTypes(String... types);
-
-	/**
-	 * Get types to be searched
-	 *
-	 * @return
-	 */
-	@Deprecated
-	List<String> getTypes();
-
-	/**
 	 * Add fields to be added as part of search request
 	 *
 	 * @param fields

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
@@ -344,7 +344,7 @@ public abstract class ElasticsearchTemplateTests {
 
 		// when
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
-				.withIndices(INDEX_1_NAME, INDEX_2_NAME).withIndicesOptions(IndicesOptions.lenientExpandOpen()).build();
+				.withIndicesOptions(IndicesOptions.lenientExpandOpen()).build();
 		Page<SampleEntity> entities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class,
 				IndexCoordinates.of(INDEX_1_NAME, INDEX_2_NAME));
 
@@ -512,9 +512,7 @@ public abstract class ElasticsearchTemplateTests {
 		elasticsearchTemplate.refresh(IndexCoordinates.of(INDEX_2_NAME));
 
 		// then
-		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("message", "foo"))
-				.withIndices(INDEX_1_NAME, INDEX_2_NAME) //
-				.build();
+		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("message", "foo")).build();
 
 		assertThat(elasticsearchTemplate.count(searchQuery, IndexCoordinates.of(INDEX_1_NAME, INDEX_2_NAME))).isEqualTo(0);
 	}
@@ -548,9 +546,7 @@ public abstract class ElasticsearchTemplateTests {
 		elasticsearchTemplate.refresh(IndexCoordinates.of(INDEX_2_NAME));
 
 		// then
-		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("message", "positive"))
-				.withIndices(INDEX_1_NAME, INDEX_2_NAME) //
-				.build();
+		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("message", "positive")).build();
 
 		assertThat(elasticsearchTemplate.count(searchQuery, IndexCoordinates.of("test-index-*"))).isEqualTo(2);
 	}
@@ -953,8 +949,8 @@ public abstract class ElasticsearchTemplateTests {
 
 		elasticsearchTemplate.index(indexQuery, index);
 		elasticsearchTemplate.refresh(SampleEntity.class);
-		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
-				.withIndices(INDEX_NAME_SAMPLE_ENTITY).withTypes(TYPE_NAME).withFields("message").build();
+		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).withFields("message")
+				.build();
 
 		// when
 		Page<SampleEntity> page = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class, index);
@@ -986,7 +982,7 @@ public abstract class ElasticsearchTemplateTests {
 		sourceFilter.withIncludes("message");
 
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
-				.withIndices(INDEX_NAME_SAMPLE_ENTITY).withTypes(TYPE_NAME).withSourceFilter(sourceFilter.build()).build();
+				.withSourceFilter(sourceFilter.build()).build();
 
 		// when
 		Page<SampleEntity> page = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class, index);
@@ -1049,8 +1045,6 @@ public abstract class ElasticsearchTemplateTests {
 
 		// then
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
-		criteriaQuery.addIndices(INDEX_NAME_SAMPLE_ENTITY);
-		criteriaQuery.addTypes(TYPE_NAME);
 		criteriaQuery.setPageable(PageRequest.of(0, 10));
 
 		ScrolledPage<SampleEntity> scroll = elasticsearchTemplate.startScroll(1000, criteriaQuery, SampleEntity.class,
@@ -1077,7 +1071,7 @@ public abstract class ElasticsearchTemplateTests {
 		// then
 
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
-				.withIndices(INDEX_NAME_SAMPLE_ENTITY).withTypes(TYPE_NAME).withPageable(PageRequest.of(0, 10)).build();
+				.withPageable(PageRequest.of(0, 10)).build();
 
 		ScrolledPage<SampleEntity> scroll = elasticsearchTemplate.startScroll(1000, searchQuery, SampleEntity.class, index);
 		List<SampleEntity> sampleEntities = new ArrayList<>();
@@ -1101,8 +1095,6 @@ public abstract class ElasticsearchTemplateTests {
 
 		// then
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
-		criteriaQuery.addIndices(INDEX_NAME_SAMPLE_ENTITY);
-		criteriaQuery.addTypes(TYPE_NAME);
 		criteriaQuery.addFields("message");
 		criteriaQuery.setPageable(PageRequest.of(0, 10));
 
@@ -1130,9 +1122,8 @@ public abstract class ElasticsearchTemplateTests {
 		elasticsearchTemplate.refresh(SampleEntity.class);
 
 		// then
-		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
-				.withIndices(INDEX_NAME_SAMPLE_ENTITY).withTypes(TYPE_NAME).withFields("message").withQuery(matchAllQuery())
-				.withPageable(PageRequest.of(0, 10)).build();
+		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).withFields("message")
+				.withQuery(matchAllQuery()).withPageable(PageRequest.of(0, 10)).build();
 
 		ScrolledPage<SampleEntity> scroll = elasticsearchTemplate.startScroll(1000, searchQuery, SampleEntity.class, index);
 		String scrollId = scroll.getScrollId();
@@ -1158,8 +1149,6 @@ public abstract class ElasticsearchTemplateTests {
 
 		// then
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
-		criteriaQuery.addIndices(INDEX_NAME_SAMPLE_ENTITY);
-		criteriaQuery.addTypes(TYPE_NAME);
 		criteriaQuery.setPageable(PageRequest.of(0, 10));
 
 		ScrolledPage<SampleEntity> scroll = elasticsearchTemplate.startScroll(1000, criteriaQuery, SampleEntity.class,
@@ -1187,7 +1176,7 @@ public abstract class ElasticsearchTemplateTests {
 
 		// then
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
-				.withIndices(INDEX_NAME_SAMPLE_ENTITY).withTypes(TYPE_NAME).withPageable(PageRequest.of(0, 10)).build();
+				.withPageable(PageRequest.of(0, 10)).build();
 
 		ScrolledPage<SampleEntity> scroll = elasticsearchTemplate.startScroll(1000, searchQuery, SampleEntity.class, index);
 		String scrollId = scroll.getScrollId();
@@ -1266,8 +1255,6 @@ public abstract class ElasticsearchTemplateTests {
 
 		// then
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
-		criteriaQuery.addIndices(INDEX_NAME_SAMPLE_ENTITY);
-		criteriaQuery.addTypes(TYPE_NAME);
 		criteriaQuery.setPageable(PageRequest.of(0, 10));
 
 		CloseableIterator<SampleEntity> stream = elasticsearchTemplate.stream(criteriaQuery, SampleEntity.class, index);
@@ -1456,8 +1443,8 @@ public abstract class ElasticsearchTemplateTests {
 				.withUpdateRequest(updateRequest).build();
 
 		// when
-		UpdateRequest request = elasticsearchTemplate.getRequestFactory().updateRequest(updateQuery,
-				IndexCoordinates.of("index"));
+		UpdateRequest request = ((AbstractElasticsearchTemplate) elasticsearchTemplate).getRequestFactory()
+				.updateRequest(updateQuery, IndexCoordinates.of("index"));
 
 		// then
 		assertThat(request).isNotNull();
@@ -1478,8 +1465,8 @@ public abstract class ElasticsearchTemplateTests {
 				.withUpdateRequest(updateRequest).build();
 
 		// when
-		UpdateRequest request = elasticsearchTemplate.getRequestFactory().updateRequest(updateQuery,
-				IndexCoordinates.of("index"));
+		UpdateRequest request = ((AbstractElasticsearchTemplate) elasticsearchTemplate).getRequestFactory()
+				.updateRequest(updateQuery, IndexCoordinates.of("index"));
 
 		// then
 		assertThat(request).isNotNull();
@@ -1524,7 +1511,7 @@ public abstract class ElasticsearchTemplateTests {
 
 		// when
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
-				.withIndices(INDEX_1_NAME, INDEX_2_NAME).withIndicesOptions(IndicesOptions.lenientExpandOpen()).build();
+				.withIndicesOptions(IndicesOptions.lenientExpandOpen()).build();
 
 		List<SampleEntity> entities = new ArrayList<>();
 
@@ -1643,7 +1630,7 @@ public abstract class ElasticsearchTemplateTests {
 		elasticsearchTemplate.index(indexQuery, IndexCoordinates.of(INDEX_NAME_SAMPLE_ENTITY).withTypes(TYPE_NAME));
 		elasticsearchTemplate.refresh(SampleEntity.class);
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("id", indexQuery.getId()))
-				.withIndices(INDEX_NAME_SAMPLE_ENTITY).withTypes(TYPE_NAME).build();
+				.build();
 
 		// then
 		Page<SampleEntity> page = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class, index);
@@ -1672,7 +1659,7 @@ public abstract class ElasticsearchTemplateTests {
 		elasticsearchTemplate.bulkIndex(entities, index);
 		elasticsearchTemplate.refresh(SampleEntity.class);
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("message", "message"))
-				.withIndices(INDEX_NAME_SAMPLE_ENTITY).withTypes(TYPE_NAME).withPageable(PageRequest.of(0, 100)).build();
+				.withPageable(PageRequest.of(0, 100)).build();
 		// then
 		List<String> ids = elasticsearchTemplate.queryForIds(searchQuery, SampleEntity.class, index);
 		assertThat(ids).hasSize(30);
@@ -1693,7 +1680,7 @@ public abstract class ElasticsearchTemplateTests {
 		// when
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder()
 				.withQuery(boolQuery().must(wildcardQuery("message", "*a*")).should(wildcardQuery("message", "*b*")))
-				.withIndices(INDEX_NAME_SAMPLE_ENTITY).withTypes(TYPE_NAME).withMinScore(2.0F).build();
+				.withMinScore(2.0F).build();
 
 		Page<SampleEntity> page = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class, index);
 
@@ -1823,8 +1810,7 @@ public abstract class ElasticsearchTemplateTests {
 		elasticsearchTemplate.refresh(index);
 
 		// then
-		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withIndices(INDEX_NAME_SAMPLE_ENTITY)
-				.withTypes(TYPE_NAME).withQuery(matchAllQuery()).build();
+		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
 		Page<Map> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, Map.class, index);
 
 		assertThat(sampleEntities.getTotalElements()).isEqualTo(2);
@@ -1847,8 +1833,7 @@ public abstract class ElasticsearchTemplateTests {
 		elasticsearchTemplate.index(indexQueryBuilder.build(), index);
 		elasticsearchTemplate.refresh(index);
 
-		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withIndices(INDEX_NAME_SAMPLE_ENTITY)
-				.withTypes(TYPE_NAME).withQuery(matchAllQuery()).build();
+		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
 		// when
 		Page<GTEVersionEntity> entities = elasticsearchTemplate.queryForPage(searchQuery, GTEVersionEntity.class, index);
 		// then
@@ -1878,8 +1863,7 @@ public abstract class ElasticsearchTemplateTests {
 		elasticsearchTemplate.index(indexQuery, IndexCoordinates.of(INDEX_NAME_SAMPLE_ENTITY).withTypes(TYPE_NAME));
 		elasticsearchTemplate.refresh(IndexCoordinates.of(INDEX_NAME_SAMPLE_ENTITY));
 
-		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withIndices(INDEX_NAME_SAMPLE_ENTITY)
-				.withTypes(TYPE_NAME).withQuery(matchAllQuery()).build();
+		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
 
 		// when
 		Page<SampleEntity> sampleEntities = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class, index);
@@ -1901,7 +1885,6 @@ public abstract class ElasticsearchTemplateTests {
 		elasticsearchTemplate.index(indexQuery, index);
 		elasticsearchTemplate.refresh(SampleEntity.class);
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
-		criteriaQuery.addIndices(INDEX_NAME_SAMPLE_ENTITY);
 
 		// when
 		long count = elasticsearchTemplate.count(criteriaQuery, SampleEntity.class, index);
@@ -1921,8 +1904,7 @@ public abstract class ElasticsearchTemplateTests {
 		IndexQuery indexQuery = getIndexQuery(sampleEntity);
 		elasticsearchTemplate.index(indexQuery, index);
 		elasticsearchTemplate.refresh(SampleEntity.class);
-		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
-				.withIndices(INDEX_NAME_SAMPLE_ENTITY).build();
+		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
 
 		// when
 		long count = elasticsearchTemplate.count(searchQuery, SampleEntity.class, index);
@@ -1943,12 +1925,10 @@ public abstract class ElasticsearchTemplateTests {
 		elasticsearchTemplate.index(indexQuery, index);
 		elasticsearchTemplate.refresh(SampleEntity.class);
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
-		criteriaQuery.addIndices(INDEX_NAME_SAMPLE_ENTITY);
-		criteriaQuery.addTypes(TYPE_NAME);
 
 		// when
-
 		long count = elasticsearchTemplate.count(criteriaQuery, index);
+
 		// then
 		assertThat(count).isEqualTo(1);
 	}
@@ -1964,8 +1944,7 @@ public abstract class ElasticsearchTemplateTests {
 		IndexQuery indexQuery = getIndexQuery(sampleEntity);
 		elasticsearchTemplate.index(indexQuery, index);
 		elasticsearchTemplate.refresh(SampleEntity.class);
-		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
-				.withIndices(INDEX_NAME_SAMPLE_ENTITY).withTypes(TYPE_NAME).build();
+		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
 
 		// when
 		long count = elasticsearchTemplate.count(searchQuery, index);
@@ -1997,7 +1976,6 @@ public abstract class ElasticsearchTemplateTests {
 		elasticsearchTemplate.refresh(IndexCoordinates.of(INDEX_2_NAME));
 
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
-		criteriaQuery.addIndices(INDEX_1_NAME, INDEX_2_NAME);
 
 		// when
 		long count = elasticsearchTemplate.count(criteriaQuery, IndexCoordinates.of(INDEX_1_NAME, INDEX_2_NAME));
@@ -2028,8 +2006,7 @@ public abstract class ElasticsearchTemplateTests {
 		elasticsearchTemplate.refresh(IndexCoordinates.of(INDEX_1_NAME));
 		elasticsearchTemplate.refresh(IndexCoordinates.of(INDEX_2_NAME));
 
-		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
-				.withIndices(INDEX_1_NAME, INDEX_2_NAME).build();
+		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
 
 		// when
 		long count = elasticsearchTemplate.count(searchQuery, IndexCoordinates.of(INDEX_1_NAME, INDEX_2_NAME));
@@ -2096,7 +2073,6 @@ public abstract class ElasticsearchTemplateTests {
 		elasticsearchTemplate.refresh(IndexCoordinates.of(INDEX_2_NAME));
 
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
-		criteriaQuery.addIndices(INDEX_1_NAME);
 
 		// when
 		long count = elasticsearchTemplate.count(criteriaQuery, IndexCoordinates.of(INDEX_1_NAME));
@@ -2127,8 +2103,7 @@ public abstract class ElasticsearchTemplateTests {
 		elasticsearchTemplate.refresh(IndexCoordinates.of(INDEX_1_NAME));
 		elasticsearchTemplate.refresh(IndexCoordinates.of(INDEX_2_NAME));
 
-		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).withIndices(INDEX_1_NAME)
-				.build();
+		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
 
 		// when
 		long count = elasticsearchTemplate.count(searchQuery, IndexCoordinates.of(INDEX_1_NAME));
@@ -2264,8 +2239,7 @@ public abstract class ElasticsearchTemplateTests {
 		elasticsearchTemplate.refresh(IndexCoordinates.of(INDEX_1_NAME));
 		elasticsearchTemplate.refresh(IndexCoordinates.of(INDEX_2_NAME));
 
-		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
-				.withIndices(INDEX_1_NAME, INDEX_2_NAME).build();
+		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
 
 		// when
 		List<SampleEntity> sampleEntities = elasticsearchTemplate.queryForList(searchQuery, SampleEntity.class,
@@ -2294,8 +2268,7 @@ public abstract class ElasticsearchTemplateTests {
 		elasticsearchTemplate.refresh(IndexCoordinates.of(INDEX_2_NAME));
 
 		// when
-		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).withTypes("hetro")
-				.withIndices(INDEX_1_NAME, INDEX_2_NAME).build();
+		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
 		Page<ResultAggregator> page = elasticsearchTemplate.queryForPage(searchQuery, ResultAggregator.class,
 				IndexCoordinates.of(INDEX_1_NAME, INDEX_2_NAME));
 
@@ -2444,8 +2417,6 @@ public abstract class ElasticsearchTemplateTests {
 
 		// when
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("message").contains("message"));
-		criteriaQuery.addIndices(INDEX_NAME_SAMPLE_ENTITY);
-		criteriaQuery.addTypes(TYPE_NAME);
 		criteriaQuery.setPageable(PageRequest.of(0, 10));
 
 		ScrolledPage<SampleEntity> scroll = elasticsearchTemplate.startScroll(1000, criteriaQuery, SampleEntity.class,
@@ -2482,7 +2453,7 @@ public abstract class ElasticsearchTemplateTests {
 
 		// when
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchQuery("message", "message"))
-				.withIndices(INDEX_NAME_SAMPLE_ENTITY).withTypes(TYPE_NAME).withPageable(PageRequest.of(0, 10)).build();
+				.withPageable(PageRequest.of(0, 10)).build();
 
 		ScrolledPage<SampleEntity> scroll = elasticsearchTemplate.startScroll(1000, searchQuery, SampleEntity.class, index);
 		List<SampleEntity> sampleEntities = new ArrayList<>();
@@ -2512,8 +2483,7 @@ public abstract class ElasticsearchTemplateTests {
 		SourceFilter sourceFilter = new FetchSourceFilter(new String[] { "id" }, new String[] {});
 
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
-				.withIndices(INDEX_NAME_SAMPLE_ENTITY).withTypes(TYPE_NAME).withPageable(PageRequest.of(0, 10))
-				.withSourceFilter(sourceFilter).build();
+				.withPageable(PageRequest.of(0, 10)).withSourceFilter(sourceFilter).build();
 
 		ScrolledPage<SampleEntity> scroll = elasticsearchTemplate.startScroll(1000, searchQuery, SampleEntity.class, index);
 		List<SampleEntity> sampleEntities = new ArrayList<>();
@@ -2638,8 +2608,8 @@ public abstract class ElasticsearchTemplateTests {
 		elasticsearchTemplate.bulkIndex(indexQueries, index);
 		elasticsearchTemplate.refresh(SampleEntity.class);
 
-		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
-				.withIndices(INDEX_NAME_SAMPLE_ENTITY).withTypes(TYPE_NAME).withCollapseField("rate").build();
+		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).withCollapseField("rate")
+				.build();
 
 		// when
 		Page<SampleEntity> page = elasticsearchTemplate.queryForPage(searchQuery, SampleEntity.class, index);
@@ -2770,8 +2740,6 @@ public abstract class ElasticsearchTemplateTests {
 
 		NativeSearchQuery query = new NativeSearchQueryBuilder() //
 				.withQuery(matchAllQuery()) //
-				.withIndices(alias) //
-				.withTypes(TYPE_NAME) //
 				.build();
 
 		long count = elasticsearchTemplate.count(query, IndexCoordinates.of(alias));

--- a/src/test/java/org/springframework/data/elasticsearch/core/ReactiveElasticsearchTemplateUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ReactiveElasticsearchTemplateUnitTests.java
@@ -57,6 +57,7 @@ import org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsea
 import org.springframework.data.elasticsearch.core.geo.GeoPoint;
 import org.springframework.data.elasticsearch.core.query.Criteria;
 import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
+import org.springframework.data.elasticsearch.core.query.Query;
 import org.springframework.data.elasticsearch.core.query.StringQuery;
 
 /**
@@ -68,6 +69,8 @@ public class ReactiveElasticsearchTemplateUnitTests {
 
 	@Mock ReactiveElasticsearchClient client;
 	ReactiveElasticsearchTemplate template;
+
+	private IndexCoordinates index = IndexCoordinates.of("index").withTypes("type");
 
 	@BeforeEach
 	public void setUp() {
@@ -81,7 +84,7 @@ public class ReactiveElasticsearchTemplateUnitTests {
 		ArgumentCaptor<IndexRequest> captor = ArgumentCaptor.forClass(IndexRequest.class);
 		when(client.index(captor.capture())).thenReturn(Mono.empty());
 
-		template.save(Collections.singletonMap("key", "value"), "index", "type") //
+		template.save(Collections.singletonMap("key", "value"), index) //
 				.as(StepVerifier::create) //
 				.verifyComplete();
 
@@ -96,7 +99,7 @@ public class ReactiveElasticsearchTemplateUnitTests {
 
 		template.setRefreshPolicy(RefreshPolicy.WAIT_UNTIL);
 
-		template.save(Collections.singletonMap("key", "value"), "index", "type") //
+		template.save(Collections.singletonMap("key", "value"), index) //
 				.as(StepVerifier::create) //
 				.verifyComplete();
 
@@ -124,7 +127,8 @@ public class ReactiveElasticsearchTemplateUnitTests {
 
 		template.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
 
-		template.find(new CriteriaQuery(new Criteria("*")).setPageable(PageRequest.of(0, 10)), SampleEntity.class) //
+		Query query = new CriteriaQuery(new Criteria("*")).setPageable(PageRequest.of(0, 10));
+		template.find(query, SampleEntity.class, index) //
 				.as(StepVerifier::create) //
 				.verifyComplete();
 
@@ -137,7 +141,8 @@ public class ReactiveElasticsearchTemplateUnitTests {
 		ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
 		when(client.search(captor.capture())).thenReturn(Flux.empty());
 
-		template.find(new CriteriaQuery(new Criteria("*")).setPageable(PageRequest.of(2, 50)), SampleEntity.class) //
+		Query query = new CriteriaQuery(new Criteria("*")).setPageable(PageRequest.of(2, 50));
+		template.find(query, SampleEntity.class, index) //
 				.as(StepVerifier::create) //
 				.verifyComplete();
 
@@ -164,7 +169,7 @@ public class ReactiveElasticsearchTemplateUnitTests {
 		ArgumentCaptor<DeleteRequest> captor = ArgumentCaptor.forClass(DeleteRequest.class);
 		when(client.delete(captor.capture())).thenReturn(Mono.empty());
 
-		template.deleteById("id", "index", "type") //
+		template.deleteById("id", index) //
 				.as(StepVerifier::create) //
 				.verifyComplete();
 
@@ -179,7 +184,7 @@ public class ReactiveElasticsearchTemplateUnitTests {
 
 		template.setRefreshPolicy(RefreshPolicy.WAIT_UNTIL);
 
-		template.deleteById("id", "index", "type") //
+		template.deleteById("id", index) //
 				.as(StepVerifier::create) //
 				.verifyComplete();
 
@@ -192,7 +197,7 @@ public class ReactiveElasticsearchTemplateUnitTests {
 		ArgumentCaptor<DeleteByQueryRequest> captor = ArgumentCaptor.forClass(DeleteByQueryRequest.class);
 		when(client.deleteBy(captor.capture())).thenReturn(Mono.empty());
 
-		template.deleteBy(new StringQuery(QueryBuilders.matchAllQuery().toString()), Object.class, "index", "type") //
+		template.deleteBy(new StringQuery(QueryBuilders.matchAllQuery().toString()), Object.class, index) //
 				.as(StepVerifier::create) //
 				.verifyComplete();
 
@@ -207,7 +212,7 @@ public class ReactiveElasticsearchTemplateUnitTests {
 
 		template.setRefreshPolicy(RefreshPolicy.NONE);
 
-		template.deleteBy(new StringQuery(QueryBuilders.matchAllQuery().toString()), Object.class, "index", "type") //
+		template.deleteBy(new StringQuery(QueryBuilders.matchAllQuery().toString()), Object.class, index) //
 				.as(StepVerifier::create) //
 				.verifyComplete();
 
@@ -220,7 +225,7 @@ public class ReactiveElasticsearchTemplateUnitTests {
 		ArgumentCaptor<DeleteByQueryRequest> captor = ArgumentCaptor.forClass(DeleteByQueryRequest.class);
 		when(client.deleteBy(captor.capture())).thenReturn(Mono.empty());
 
-		template.deleteBy(new StringQuery(QueryBuilders.matchAllQuery().toString()), Object.class, "index", "type") //
+		template.deleteBy(new StringQuery(QueryBuilders.matchAllQuery().toString()), Object.class, index) //
 				.as(StepVerifier::create) //
 				.verifyComplete();
 
@@ -235,7 +240,7 @@ public class ReactiveElasticsearchTemplateUnitTests {
 
 		template.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
 
-		template.deleteBy(new StringQuery(QueryBuilders.matchAllQuery().toString()), Object.class, "index", "type") //
+		template.deleteBy(new StringQuery(QueryBuilders.matchAllQuery().toString()), Object.class, index) //
 				.as(StepVerifier::create) //
 				.verifyComplete();
 

--- a/src/test/java/org/springframework/data/elasticsearch/core/aggregation/ElasticsearchTemplateAggregationTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/aggregation/ElasticsearchTemplateAggregationTests.java
@@ -90,7 +90,7 @@ public class ElasticsearchTemplateAggregationTests {
 				.addAuthor(RIZWAN_IDREES).addPublishedYear(YEAR_2002).addPublishedYear(YEAR_2001).addPublishedYear(YEAR_2000)
 				.score(40).buildIndex();
 
-		IndexCoordinates index = IndexCoordinates.of(INDEX_NAME).withTypes( "article");
+		IndexCoordinates index = IndexCoordinates.of(INDEX_NAME).withTypes("article");
 		elasticsearchTemplate.index(article1, index);
 		elasticsearchTemplate.index(article2, index);
 		elasticsearchTemplate.index(article3, index);
@@ -111,7 +111,6 @@ public class ElasticsearchTemplateAggregationTests {
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder() //
 				.withQuery(matchAllQuery()) //
 				.withSearchType(SearchType.DEFAULT) //
-				.withIndices(INDEX_NAME).withTypes("article") //
 				.addAggregation(terms("subjects").field("subject")) //
 				.build();
 		// when

--- a/src/test/java/org/springframework/data/elasticsearch/repositories/spel/SpELEntityTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repositories/spel/SpELEntityTests.java
@@ -70,7 +70,6 @@ public class SpELEntityTests {
 
 		// then
 		NativeSearchQuery nativeSearchQuery = new NativeSearchQuery(QueryBuilders.matchAllQuery());
-		nativeSearchQuery.addIndices("test-index-abz-entity");
 		long count = template.count(nativeSearchQuery, IndexCoordinates.of("test-index-abz-entity"));
 		assertThat(count).isEqualTo(2);
 	}
@@ -86,8 +85,6 @@ public class SpELEntityTests {
 
 		// then
 		NativeSearchQuery nativeSearchQuery = new NativeSearchQuery(QueryBuilders.matchAllQuery());
-		nativeSearchQuery.addIndices("test-index-abz-entity");
-		nativeSearchQuery.addTypes("myType");
 		long count = template.count(nativeSearchQuery, IndexCoordinates.of("test-index-abz-entity"));
 		assertThat(count).isEqualTo(1);
 	}


### PR DESCRIPTION
removed the index names and type names from the different query classes, some cleanup after DATAES-631