### PR TITLE
DATAES-700 - Enable proxy support for RestClient.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,24 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-jre8</artifactId>
+			<version>2.25.1</version>
+			<scope>test</scope>
+			<exclusions>
+				<!-- these exclusions are needed because of Elasticsearch JarHell-->
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.ow2.asm</groupId>
+					<artifactId>asm</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
 		<!-- Upgrade xbean to 4.5 to prevent incompatibilities due to ASM versions -->
 		<dependency>
 			<groupId>org.apache.xbean</groupId>
@@ -259,8 +277,8 @@
 
 		<dependency>
 			<groupId>javax.servlet</groupId>
-			<artifactId>servlet-api</artifactId>
-			<version>3.0-alpha-1</version>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>3.1.0</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/main/java/org/springframework/data/elasticsearch/client/ClientConfiguration.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/ClientConfiguration.java
@@ -154,6 +154,14 @@ public interface ClientConfiguration {
 	String getPathPrefix();
 
 	/**
+	 * returns an optionally set proxy in the form host:port
+	 * 
+	 * @return the optional proxy
+	 * @since 4.0
+	 */
+	Optional<String> getProxy();
+
+	/**
 	 * @author Christoph Strobl
 	 */
 	interface ClientConfigurationBuilderWithRequiredEndpoint {
@@ -221,8 +229,8 @@ public interface ClientConfiguration {
 		TerminalClientConfigurationBuilder usingSsl(SSLContext sslContext);
 
 		/**
-		 * Connect via {@literal https} using the givens {@link SSLContext} and HostnameVerifier {@link HostnameVerifier}  .<br />
-		 *
+		 * Connect via {@literal https} using the givens {@link SSLContext} and HostnameVerifier {@link HostnameVerifier}
+		 * .<br />
 		 * <strong>NOTE</strong> You need to leave out the protocol in
 		 * {@link ClientConfigurationBuilderWithRequiredEndpoint#connectedTo(String)}.
 		 *
@@ -303,6 +311,12 @@ public interface ClientConfiguration {
 		 * @since 4.0
 		 */
 		TerminalClientConfigurationBuilder withPathPrefix(String pathPrefix);
+
+		/**
+		 * @param proxy a proxy formatted as String {@literal host:port}.
+		 * @return the {@link MaybeSecureClientConfigurationBuilder}.
+		 */
+		MaybeSecureClientConfigurationBuilder withProxy(String proxy);
 
 		/**
 		 * Build the {@link ClientConfiguration} object.

--- a/src/main/java/org/springframework/data/elasticsearch/client/ClientConfigurationBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/ClientConfigurationBuilder.java
@@ -55,6 +55,7 @@ class ClientConfigurationBuilder
 	private String username;
 	private String password;
 	private String pathPrefix;
+	private String proxy;
 
 	/*
 	 * (non-Javadoc)
@@ -80,6 +81,13 @@ class ClientConfigurationBuilder
 
 		this.hosts.addAll(Arrays.asList(endpoints));
 
+		return this;
+	}
+
+	@Override
+	public MaybeSecureClientConfigurationBuilder withProxy(String proxy) {
+		Assert.hasLength(proxy, "proxy must not be null or empty");
+		this.proxy = proxy;
 		return this;
 	}
 
@@ -199,8 +207,8 @@ class ClientConfigurationBuilder
 			headers.setBasicAuth(username, password);
 		}
 
-		return new DefaultClientConfiguration(this.hosts, this.headers, this.useSsl, this.sslContext, this.soTimeout,
-				this.connectTimeout, this.pathPrefix, this.hostnameVerifier);
+		return new DefaultClientConfiguration(hosts, headers, useSsl, sslContext, soTimeout, connectTimeout, pathPrefix,
+				hostnameVerifier, proxy);
 	}
 
 	private static InetSocketAddress parse(String hostAndPort) {

--- a/src/main/java/org/springframework/data/elasticsearch/client/DefaultClientConfiguration.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/DefaultClientConfiguration.java
@@ -46,9 +46,11 @@ class DefaultClientConfiguration implements ClientConfiguration {
 	private final Duration connectTimeout;
 	private final String pathPrefix;
 	private final @Nullable HostnameVerifier hostnameVerifier;
+	private final String proxy;
 
 	DefaultClientConfiguration(List<InetSocketAddress> hosts, HttpHeaders headers, boolean useSsl,
-			@Nullable SSLContext sslContext, Duration soTimeout, Duration connectTimeout, @Nullable String pathPrefix, @Nullable HostnameVerifier hostnameVerifier) {
+			@Nullable SSLContext sslContext, Duration soTimeout, Duration connectTimeout, @Nullable String pathPrefix,
+			@Nullable HostnameVerifier hostnameVerifier, String proxy) {
 
 		this.hosts = Collections.unmodifiableList(new ArrayList<>(hosts));
 		this.headers = new HttpHeaders(headers);
@@ -58,6 +60,7 @@ class DefaultClientConfiguration implements ClientConfiguration {
 		this.connectTimeout = connectTimeout;
 		this.pathPrefix = pathPrefix;
 		this.hostnameVerifier = hostnameVerifier;
+		this.proxy = proxy;
 	}
 
 	/*
@@ -132,4 +135,12 @@ class DefaultClientConfiguration implements ClientConfiguration {
 		return this.pathPrefix;
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.elasticsearch.client.ClientConfiguration#getProxy()
+	 */
+	@Override
+	public Optional<String> getProxy() {
+		return Optional.ofNullable(proxy);
+	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/client/RestClients.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/RestClients.java
@@ -124,6 +124,8 @@ public final class RestClients {
 
 			clientBuilder.setDefaultRequestConfig(requestConfigBuilder.build());
 
+			clientConfiguration.getProxy().map(HttpHost::create).ifPresent(clientBuilder::setProxy);
+
 			return clientBuilder;
 		});
 

--- a/src/test/java/org/springframework/data/elasticsearch/client/ClientConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/client/ClientConfigurationUnitTests.java
@@ -45,7 +45,7 @@ public class ClientConfigurationUnitTests {
 		assertThat(clientConfiguration.getEndpoints()).containsOnly(InetSocketAddress.createUnresolved("localhost", 9200));
 	}
 
-	@Test // DATAES-488, DATAES-504, DATAES-650
+	@Test // DATAES-488, DATAES-504, DATAES-650, DATAES-700
 	public void shouldCreateCustomizedConfiguration() {
 
 		HttpHeaders headers = new HttpHeaders();
@@ -56,7 +56,8 @@ public class ClientConfigurationUnitTests {
 				.usingSsl() //
 				.withDefaultHeaders(headers) //
 				.withConnectTimeout(Duration.ofDays(1)).withSocketTimeout(Duration.ofDays(2)) //
-				.withPathPrefix("myPathPrefix").build();
+				.withPathPrefix("myPathPrefix") //
+				.withProxy("localhost:8080").build();
 
 		assertThat(clientConfiguration.getEndpoints()).containsOnly(InetSocketAddress.createUnresolved("foo", 9200),
 				InetSocketAddress.createUnresolved("bar", 9200));
@@ -65,6 +66,7 @@ public class ClientConfigurationUnitTests {
 		assertThat(clientConfiguration.getConnectTimeout()).isEqualTo(Duration.ofDays(1));
 		assertThat(clientConfiguration.getSocketTimeout()).isEqualTo(Duration.ofDays(2));
 		assertThat(clientConfiguration.getPathPrefix()).isEqualTo("myPathPrefix");
+		assertThat(clientConfiguration.getProxy()).contains("localhost:8080");
 	}
 
 	@Test // DATAES-488, DATAES-504

--- a/src/test/java/org/springframework/data/elasticsearch/client/RestClientsTest.java
+++ b/src/test/java/org/springframework/data/elasticsearch/client/RestClientsTest.java
@@ -1,0 +1,47 @@
+package org.springframework.data.elasticsearch.client;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
+import java.io.IOException;
+
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+/**
+ * @author Peter-Josef Meisch
+ */
+public class RestClientsTest {
+
+	@Test // DATAES-700
+	void shouldUseConfiguredProxy() throws IOException {
+
+		WireMockServer wireMockServer = new WireMockServer(options() //
+				.dynamicPort() //
+				.usingFilesUnderDirectory("src/test/resources/wiremock-mappings")); // needed, otherwise Wiremock goes to
+																					// test/resources/mappings
+		wireMockServer.start();
+		try {
+			WireMock.configureFor(wireMockServer.port());
+
+			ClientConfigurationBuilder configurationBuilder = new ClientConfigurationBuilder();
+			ClientConfiguration clientConfiguration = configurationBuilder //
+					.connectedTo("localhost:9200")//
+					.withProxy("localhost:" + wireMockServer.port()) //
+					.build();
+
+			RestHighLevelClient restClient = RestClients.create(clientConfiguration).rest();
+			restClient.ping(RequestOptions.DEFAULT);
+
+			verify(headRequestedFor(urlEqualTo("/")));
+
+		} finally {
+			wireMockServer.shutdown();
+		}
+	}
+
+}


### PR DESCRIPTION
This PR enables proxy support for the non-reactive RestClient