### PR TITLE
DATAES-699 - Fix count implementation.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
@@ -598,6 +598,7 @@ public class ElasticsearchRestTemplate extends AbstractElasticsearchTemplate
 		if (elasticsearchQuery != null) {
 			sourceBuilder.query(elasticsearchQuery);
 		}
+		sourceBuilder.size(0);
 		countRequest.source(sourceBuilder);
 
 		try {
@@ -616,6 +617,7 @@ public class ElasticsearchRestTemplate extends AbstractElasticsearchTemplate
 		if (elasticsearchFilter != null) {
 			searchRequest.source().postFilter(elasticsearchFilter);
 		}
+		searchRequest.source().size(0);
 		SearchResponse response;
 		try {
 			response = client.search(searchRequest, RequestOptions.DEFAULT);

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
@@ -508,6 +508,7 @@ public class ElasticsearchTemplate extends AbstractElasticsearchTemplate
 		if (elasticsearchQuery != null) {
 			countRequestBuilder.setQuery(elasticsearchQuery);
 		}
+		countRequestBuilder.setSize(0);
 		return countRequestBuilder.execute().actionGet().getHits().getTotalHits();
 	}
 
@@ -521,6 +522,7 @@ public class ElasticsearchTemplate extends AbstractElasticsearchTemplate
 		if (elasticsearchFilter != null) {
 			searchRequestBuilder.setPostFilter(elasticsearchFilter);
 		}
+		searchRequestBuilder.setSize(0);
 		return searchRequestBuilder.execute().actionGet().getHits().getTotalHits();
 	}
 


### PR DESCRIPTION
This PR fixes the count() implementations returning the whole data instead of only the necessary metadata