### PR TITLE
DATAES-252 - fix Offset calculation logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 
+dist: trusty
+
 jdk:
   - oraclejdk8
 

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
@@ -143,6 +143,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author Peter-Josef Meisch
  * @author Mathias Teier
  * @author Gyula Attila Csorogi
+ * @author Guillaume Hiron
  */
 public class ElasticsearchRestTemplate extends AbstractElasticsearchTemplate
 		implements ElasticsearchOperations, EsClient<RestHighLevelClient>, ApplicationContextAware {
@@ -1338,7 +1339,7 @@ public class ElasticsearchRestTemplate extends AbstractElasticsearchTemplate
 		}
 
 		if (query.getPageable().isPaged()) {
-			startRecord = query.getPageable().getPageNumber() * query.getPageable().getPageSize();
+			startRecord = query.getPageable().getOffset();
 			sourceBuilder.size(query.getPageable().getPageSize());
 		}
 		sourceBuilder.from(startRecord);


### PR DESCRIPTION
Currently startRecord is calculated by multiplying page number to page size. Should use PageRequest.getOffset method

