### PR TITLE
DATAES-672 - Introduce SearchHit and SearchHits types to enrich search results

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
@@ -238,7 +238,7 @@ public class ElasticsearchRestTemplate extends AbstractElasticsearchTemplate {
 	}
 
 	@Override
-	public <T> AggregatedPage<T> queryForPage(Query query, Class<T> clazz, IndexCoordinates index) {
+	public <T> AggregatedPage<SearchHit<T>> searchForPage(Query query, Class<T> clazz, IndexCoordinates index) {
 		SearchRequest searchRequest = requestFactory.searchRequest(query, clazz, index);
 		SearchResponse response;
 		try {
@@ -250,18 +250,8 @@ public class ElasticsearchRestTemplate extends AbstractElasticsearchTemplate {
 	}
 
 	@Override
-	public List<String> queryForIds(Query query, Class<?> clazz, IndexCoordinates index) {
-		SearchRequest searchRequest = requestFactory.searchRequest(query, clazz, index);
-		try {
-			SearchResponse response = client.search(searchRequest, RequestOptions.DEFAULT);
-			return extractIds(response);
-		} catch (IOException e) {
-			throw new ElasticsearchException("Error for search request: " + searchRequest.toString(), e);
-		}
-	}
-
-	@Override
-	public <T> ScrolledPage<T> startScroll(long scrollTimeInMillis, Query query, Class<T> clazz, IndexCoordinates index) {
+	public <T> ScrolledPage<SearchHit<T>> searchScrollStart(long scrollTimeInMillis, Query query, Class<T> clazz,
+			IndexCoordinates index) {
 
 		Assert.notNull(query.getPageable(), "Query.pageable is required for scan & scroll");
 
@@ -276,7 +266,9 @@ public class ElasticsearchRestTemplate extends AbstractElasticsearchTemplate {
 		}
 	}
 
-	public <T> ScrolledPage<T> continueScroll(@Nullable String scrollId, long scrollTimeInMillis, Class<T> clazz) {
+	@Override
+	public <T> ScrolledPage<SearchHit<T>> searchScrollContinue(@Nullable String scrollId, long scrollTimeInMillis,
+			Class<T> clazz) {
 		SearchScrollRequest request = new SearchScrollRequest(scrollId);
 		request.scroll(TimeValue.timeValueMillis(scrollTimeInMillis));
 		SearchResponse response;
@@ -289,7 +281,7 @@ public class ElasticsearchRestTemplate extends AbstractElasticsearchTemplate {
 	}
 
 	@Override
-	public void clearScroll(String scrollId) {
+	public void searchScrollClear(String scrollId) {
 		ClearScrollRequest request = new ClearScrollRequest();
 		request.addScrollId(scrollId);
 		try {

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
@@ -203,21 +203,15 @@ public class ElasticsearchTemplate extends AbstractElasticsearchTemplate {
 	}
 
 	@Override
-	public <T> AggregatedPage<T> queryForPage(Query query, Class<T> clazz, IndexCoordinates index) {
+	public <T> AggregatedPage<SearchHit<T>> searchForPage(Query query, Class<T> clazz, IndexCoordinates index) {
 		SearchRequestBuilder searchRequestBuilder = requestFactory.searchRequestBuilder(client, query, clazz, index);
 		SearchResponse response = getSearchResponse(searchRequestBuilder);
 		return elasticsearchConverter.mapResults(SearchDocumentResponse.from(response), clazz, query.getPageable());
 	}
 
 	@Override
-	public List<String> queryForIds(Query query, Class<?> clazz, IndexCoordinates index) {
-		SearchRequestBuilder searchRequestBuilder = requestFactory.searchRequestBuilder(client, query, clazz, index);
-		SearchResponse response = getSearchResponse(searchRequestBuilder);
-		return extractIds(response);
-	}
-
-	@Override
-	public <T> ScrolledPage<T> startScroll(long scrollTimeInMillis, Query query, Class<T> clazz, IndexCoordinates index) {
+	public <T> ScrolledPage<SearchHit<T>> searchScrollStart(long scrollTimeInMillis, Query query, Class<T> clazz,
+			IndexCoordinates index) {
 		Assert.notNull(query.getPageable(), "Query.pageable is required for scan & scroll");
 
 		SearchRequestBuilder searchRequestBuilder = requestFactory.searchRequestBuilder(client, query, clazz, index);
@@ -227,14 +221,15 @@ public class ElasticsearchTemplate extends AbstractElasticsearchTemplate {
 	}
 
 	@Override
-	public <T> ScrolledPage<T> continueScroll(@Nullable String scrollId, long scrollTimeInMillis, Class<T> clazz) {
+	public <T> ScrolledPage<SearchHit<T>> searchScrollContinue(@Nullable String scrollId, long scrollTimeInMillis,
+			Class<T> clazz) {
 		SearchResponse response = getSearchResponseWithTimeout(
 				client.prepareSearchScroll(scrollId).setScroll(TimeValue.timeValueMillis(scrollTimeInMillis)).execute());
 		return elasticsearchConverter.mapResults(SearchDocumentResponse.from(response), clazz, Pageable.unpaged());
 	}
 
 	@Override
-	public void clearScroll(String scrollId) {
+	public void searchScrollClear(String scrollId) {
 		client.prepareClearScroll().addScrollId(scrollId).execute().actionGet();
 	}
 

--- a/src/main/java/org/springframework/data/elasticsearch/core/SearchHit.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/SearchHit.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Encapsulates the found data with additional information from the search.
+ * 
+ * @param <T> the result data class.
+ * @author Peter-Josef Meisch
+ * @since 4.0
+ */
+public class SearchHit<T> {
+
+	private final String id;
+	private final float score;
+	private final T content;
+
+	public SearchHit(@Nullable String id, float score, T content) {
+		this.id = id;
+		this.score = score;
+		this.content = content;
+	}
+
+	@Nullable
+	public String getId() {
+		return id;
+	}
+
+	/**
+	 * @return the score for the hit.
+	 */
+	public float getScore() {
+		return score;
+	}
+
+	/**
+	 * @return the object data from the search.
+	 */
+	public T getContent() {
+		return content;
+	}
+
+	@Override
+	public String toString() {
+		return "SearchHit{" +
+				"id='" + id + '\'' +
+				", score=" + score +
+				", content=" + content +
+				'}';
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/SearchHitSupport.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/SearchHitSupport.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core;
+
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.springframework.data.elasticsearch.core.aggregation.AggregatedPage;
+import org.springframework.data.elasticsearch.core.aggregation.impl.AggregatedPageImpl;
+
+/**
+ * Utility class with helper methods for working with {@link SearchHit}.
+ * 
+ * @author Peter-Josef Meisch
+ * @since 4.0
+ */
+public final class SearchHitSupport {
+
+	private SearchHitSupport() {}
+
+	/**
+	 * unwraps the data contained in a SearchHit for different types containing SearchHits if possible
+	 * 
+	 * @param result the object, list, page or whatever containing SearchHit objects
+	 * @return a corresponding object where the SearchHits are replaced by their content if possible, otherwise the
+	 *         original object
+	 */
+	public static Object unwrapSearchHits(Object result) {
+
+		if (result == null) {
+			return result;
+		}
+
+		if (result instanceof SearchHit<?>) {
+			return ((SearchHit<?>) result).getContent();
+		}
+
+		if (result instanceof List<?>) {
+			return ((List<?>) result).stream() //
+					.map(SearchHitSupport::unwrapSearchHits) //
+					.collect(Collectors.toList());
+		}
+
+		if (result instanceof AggregatedPage<?>) {
+			AggregatedPage<?> page = (AggregatedPage<?>) result;
+			List<?> list = page.getContent().stream().map(o -> unwrapSearchHits(o)).collect(Collectors.toList());
+			return new AggregatedPageImpl<>(list, null, page.getTotalElements(), page.getAggregations(), page.getScrollId(),
+					page.getMaxScore());
+
+		}
+
+		if (result instanceof Stream<?>) {
+			return ((Stream<?>) result).map(SearchHitSupport::unwrapSearchHits);
+		}
+
+		if (result instanceof SearchHits<?>) {
+			SearchHits<?> searchHits = (SearchHits<?>) result;
+			return unwrapSearchHits(searchHits.getSearchHits());
+		}
+
+		if (result instanceof Flux) {
+			Flux<?> flux = (Flux<?>) result;
+			return flux.map(SearchHitSupport::unwrapSearchHits);
+		}
+
+		return result;
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/SearchHits.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/SearchHits.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.springframework.data.util.Streamable;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Encapsulates a list of {@link SearchHit}s with additional information from the search.
+ *
+ * @param <T> the result data class.
+ * @author Peter-Josef Meisch
+ * @since 4.0
+ */
+public class SearchHits<T> implements Streamable<SearchHit<T>> {
+
+	private final List<? extends SearchHit<T>> searchHits;
+	private final long totalHits;
+	private final float maxScore;
+
+	/**
+	 * @param searchHits must not be {@literal null}
+	 * @param totalHits
+	 * @param maxScore
+	 */
+	public SearchHits(List<? extends SearchHit<T>> searchHits, long totalHits, float maxScore) {
+		this.totalHits = totalHits;
+		this.maxScore = maxScore;
+
+		Assert.notNull(searchHits, "searchHits must not be null");
+
+		this.searchHits = searchHits;
+	}
+
+	@Override
+	public Iterator<SearchHit<T>> iterator() {
+		return (Iterator<SearchHit<T>>) searchHits.iterator();
+	}
+
+	// region getter
+	/**
+	 * @return the contained {@link SearchHit}s.
+	 */
+	public List<SearchHit<T>> getSearchHits() {
+		return Collections.unmodifiableList(searchHits);
+	}
+
+	public long getTotalHits() {
+		return totalHits;
+	}
+
+	public float getMaxScore() {
+		return maxScore;
+	}
+	// endregion
+
+	// region SearchHit access
+	/**
+	 * @param index position in List.
+	 * @return the {@link SearchHit} at position {index}
+	 * @throws IndexOutOfBoundsException on invalid index
+	 */
+	public SearchHit<T> getSearchHit(int index) {
+		return searchHits.get(index);
+	}
+	// endregion
+
+	@Override
+	public String toString() {
+		return "SearchHits{" + "totalHits=" + totalHits + ", maxScore=" + maxScore + ", searchHits="
+				+ StringUtils.collectionToCommaDelimitedString(searchHits) + '}';
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/SearchOperations.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/SearchOperations.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.elasticsearch.core;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -67,10 +68,11 @@ public interface SearchOperations {
 	 * @param clazz the entity clazz used for property mapping
 	 * @param index the index to run the query against
 	 * @return the first matching object
+	 * @deprecated since 4.0, use {@link #searchOne(Query, Class, IndexCoordinates)}.
 	 */
+	@Deprecated
 	default <T> T queryForObject(Query query, Class<T> clazz, IndexCoordinates index) {
-		List<T> content = queryForPage(query, clazz, index).getContent();
-		return content.isEmpty() ? null : content.get(0);
+		return (T) SearchHitSupport.unwrapSearchHits(searchOne(query, clazz, index));
 	}
 
 	/**
@@ -80,8 +82,12 @@ public interface SearchOperations {
 	 * @param clazz the entity clazz used for property mapping
 	 * @param index the index to run the query against
 	 * @return a page with aggregations
+	 * @deprecated since 4.0, use {@link #searchForPage(Query, Class, IndexCoordinates)}.
 	 */
-	<T> AggregatedPage<T> queryForPage(Query query, Class<T> clazz, IndexCoordinates index);
+	@Deprecated
+	default <T> AggregatedPage<T> queryForPage(Query query, Class<T> clazz, IndexCoordinates index) {
+		return (AggregatedPage<T>) SearchHitSupport.unwrapSearchHits(searchForPage(query, clazz, index));
+	}
 
 	/**
 	 * Execute the multi-search against elasticsearch and return result as {@link List} of {@link Page}
@@ -90,8 +96,14 @@ public interface SearchOperations {
 	 * @param clazz the entity clazz used for property mapping
 	 * @param index the index to run the query against
 	 * @return list of pages with the results
+	 * @deprecated since 4.0, use {@link #multiSearchForPage(List, Class, IndexCoordinates)}.
 	 */
-	<T> List<Page<T>> queryForPage(List<? extends Query> queries, Class<T> clazz, IndexCoordinates index);
+	@Deprecated
+	default <T> List<Page<T>> queryForPage(List<? extends Query> queries, Class<T> clazz, IndexCoordinates index) {
+		return multiSearchForPage(queries, clazz, index).stream() //
+				.map(page -> (Page<T>) SearchHitSupport.unwrapSearchHits(page)) //
+				.collect(Collectors.toList());
+	}
 
 	/**
 	 * Execute the multi-search against elasticsearch and return result as {@link List} of {@link Page}
@@ -100,8 +112,279 @@ public interface SearchOperations {
 	 * @param classes the entity classes used for the queries
 	 * @param index the index to run the query against
 	 * @return list of pages with the results
+	 * @deprecated since 4.0, use {@link #multiSearchForPage(List, List, IndexCoordinates)}.
 	 */
-	List<Page<?>> queryForPage(List<? extends Query> queries, List<Class<?>> classes, IndexCoordinates index);
+	@Deprecated
+	default List<AggregatedPage<?>> queryForPage(List<? extends Query> queries, List<Class<?>> classes,
+			IndexCoordinates index) {
+		return multiSearchForPage(queries, classes, index).stream() //
+				.map(page -> (AggregatedPage<?>) SearchHitSupport.unwrapSearchHits(page)) //
+				.collect(Collectors.toList());
+	}
+
+	/**
+	 * Executes the given {@link Query} against elasticsearch and return result as {@link CloseableIterator}.
+	 * <p>
+	 *
+	 * @param <T> element return type
+	 * @param query the query to execute
+	 * @param clazz the entity clazz used for property mapping
+	 * @param index the index to run the query against
+	 * @return a {@link CloseableIterator} that wraps an Elasticsearch scroll context that needs to be closed in case of *
+	 *         error.
+	 * @deprecated since 4.0, use {@link #searchForStream(Query, Class, IndexCoordinates)}.
+	 */
+	@Deprecated
+	<T> CloseableIterator<T> stream(Query query, Class<T> clazz, IndexCoordinates index);
+
+	/**
+	 * Execute the criteria query against elasticsearch and return result as {@link List}
+	 *
+	 * @param <T> element return type
+	 * @param query the query to execute
+	 * @param clazz the entity clazz used for property mapping
+	 * @param index the index to run the query against
+	 * @return list of found objects
+	 * @deprecated since 4.0, use {@link #search(Query, Class, IndexCoordinates)}.
+	 */
+	@Deprecated
+	default <T> List<T> queryForList(Query query, Class<T> clazz, IndexCoordinates index) {
+		return (List<T>) SearchHitSupport.unwrapSearchHits(search(query, clazz, index));
+	}
+
+	/**
+	 * Execute the multi search query against elasticsearch and return result as {@link List}
+	 *
+	 * @param queries the queries to execute
+	 * @param clazz the entity clazz used for property mapping
+	 * @param index the index to run the query against
+	 * @param <T> element return type
+	 * @return list of found objects
+	 * @deprecated since 4.0, use {@link #multiSearch(List, Class, IndexCoordinates)}.
+	 */
+	@Deprecated
+	default <T> List<List<T>> queryForList(List<Query> queries, Class<T> clazz, IndexCoordinates index) {
+		return queryForPage(queries, clazz, index).stream().map(Page::getContent).collect(Collectors.toList());
+	}
+
+	/**
+	 * Execute the multi search query against elasticsearch and return result as {@link List}
+	 *
+	 * @param queries the queries to execute
+	 * @param classes the entity classes used for property mapping
+	 * @param index the index to run the query against
+	 * @return list of list of found objects
+	 * @deprecated since 4.0, use {@link #multiSearch(List, List, IndexCoordinates)}.
+	 */
+	@Deprecated
+	default List<List<?>> queryForList(List<Query> queries, List<Class<?>> classes, IndexCoordinates index) {
+		return queryForPage(queries, classes, index).stream().map(Page::getContent).collect(Collectors.toList());
+	}
+
+	/**
+	 * Execute the query against elasticsearch and return ids
+	 *
+	 * @param query the query to execute
+	 * @param clazz the entity clazz used for property mapping
+	 * @param index the index to run the query against
+	 * @return list of found object ids
+	 * @deprecated since 4.0 use {@link #search(Query, Class, IndexCoordinates)} and map the results.
+	 */
+	@Deprecated
+	default List<String> queryForIds(Query query, Class<?> clazz, IndexCoordinates index) {
+		return search(query, clazz, index).map(SearchHit::getId).toList();
+	}
+
+	/**
+	 * Returns scrolled page for given query
+	 *
+	 * @param scrollTimeInMillis duration of the scroll time
+	 * @param query The search query.
+	 * @param clazz The class of entity to retrieve.
+	 * @param index the index to run the query against
+	 * @return scrolled page result
+	 * @deprecated since 4.0, use {@link #searchScrollStart(long, Query, Class, IndexCoordinates)}.
+	 */
+	@Deprecated
+	default <T> ScrolledPage<T> startScroll(long scrollTimeInMillis, Query query, Class<T> clazz,
+			IndexCoordinates index) {
+		return (ScrolledPage<T>) SearchHitSupport
+				.unwrapSearchHits(searchScrollStart(scrollTimeInMillis, query, clazz, index));
+	}
+
+	/**
+	 * Returns next scrolled page.
+	 *
+	 * @param scrollId the scroll id
+	 * @param scrollTimeInMillis duration of the scroll time
+	 * @param clazz The class of entity to retrieve.
+	 * @return scrolled page result
+	 * @deprecated since 4.0, use {@link #searchScrollStart(long, Query, Class, IndexCoordinates)}.
+	 */
+	@Deprecated
+	default <T> ScrolledPage<T> continueScroll(@Nullable String scrollId, long scrollTimeInMillis, Class<T> clazz) {
+		return (ScrolledPage<T>) SearchHitSupport
+				.unwrapSearchHits(searchScrollContinue(scrollId, scrollTimeInMillis, clazz));
+	}
+
+	/**
+	 * Clears the search contexts associated with specified scroll ids.
+	 *
+	 * @param scrollId the scroll id
+	 * @deprecated since 4.0, use {@link #searchScrollClear(String)}.
+	 */
+	@Deprecated
+	default void clearScroll(String scrollId) {
+		searchScrollClear(scrollId);
+	}
+
+	/**
+	 * more like this query to search for documents that are "like" a specific document.
+	 *
+	 * @param <T> element return type
+	 * @param query the query to execute
+	 * @param clazz the entity clazz used for property mapping
+	 * @param index the index to run the query against
+	 * @return page with the results
+	 * @deprecated since 4.0, use {@link #search(MoreLikeThisQuery, Class, IndexCoordinates)}.
+	 */
+	@Deprecated
+	default <T> AggregatedPage<T> moreLikeThis(MoreLikeThisQuery query, Class<T> clazz, IndexCoordinates index) {
+		return (AggregatedPage<T>) SearchHitSupport.unwrapSearchHits(search(query, clazz, index));
+	}
+
+	/**
+	 * Execute the query against elasticsearch and return the first returned object.
+	 *
+	 * @param query the query to execute
+	 * @param clazz the entity clazz used for property mapping
+	 * @param index the index to run the query against
+	 * @return the first found object
+	 */
+	@Nullable
+	default <T> SearchHit<T> searchOne(Query query, Class<T> clazz, IndexCoordinates index) {
+		List<SearchHit<T>> content = searchForPage(query, clazz, index).getContent();
+		return content.isEmpty() ? null : content.get(0);
+	}
+
+	/**
+	 * Execute the query against elasticsearch and return result as {@link AggregatedPage}.
+	 *
+	 * @param query the query to execute
+	 * @param clazz the entity clazz used for property mapping
+	 * @param index the index to run the query against
+	 * @return a page with aggregations
+	 */
+	<T> AggregatedPage<SearchHit<T>> searchForPage(Query query, Class<T> clazz, IndexCoordinates index);
+
+	/**
+	 * Execute the multi-search against elasticsearch and return result as {@link List} of {@link AggregatedPage}
+	 *
+	 * @param queries the queries
+	 * @param clazz the entity clazz used for property mapping
+	 * @param index the index to run the query against
+	 * @return list of pages with the results
+	 */
+	<T> List<AggregatedPage<SearchHit<T>>> multiSearchForPage(List<? extends Query> queries, Class<T> clazz,
+			IndexCoordinates index);
+
+	/**
+	 * Execute the multi-search against elasticsearch and return result as {@link List} of {@link AggregatedPage}
+	 *
+	 * @param queries the queries
+	 * @param classes the entity classes used for the queries
+	 * @param index the index to run the query against
+	 * @return list of pages with the results
+	 */
+	List<AggregatedPage<? extends SearchHit<?>>> multiSearchForPage(List<? extends Query> queries, List<Class<?>> classes,
+			IndexCoordinates index);
+
+	/**
+	 * Execute the criteria query against elasticsearch and return result as {@link SearchHits}
+	 *
+	 * @param <T> element return type
+	 * @param query the query to execute
+	 * @param clazz the entity clazz used for property mapping
+	 * @param index the index to run the query against
+	 * @return SearchHits containing the list of found objects
+	 */
+	default <T> SearchHits<T> search(Query query, Class<T> clazz, IndexCoordinates index) {
+		AggregatedPage<SearchHit<T>> aggregatedPage = searchForPage(query, clazz, index);
+		return new SearchHits<>(aggregatedPage.getContent(), aggregatedPage.getTotalElements(),
+				aggregatedPage.getMaxScore());
+	}
+
+	/**
+	 * Execute the multi search query against elasticsearch and return result as {@link List} of {@link SearchHits}.
+	 *
+	 * @param queries the queries to execute
+	 * @param clazz the entity clazz used for property mapping
+	 * @param index the index to run the query against
+	 * @param <T> element return type
+	 * @return list of SearchHits
+	 */
+	default <T> List<SearchHits<T>> multiSearch(List<Query> queries, Class<T> clazz, IndexCoordinates index) {
+		return multiSearchForPage(queries, clazz, index).stream()
+				.map(page -> new SearchHits<T>(page.getContent(), page.getTotalElements(), page.getMaxScore()))
+				.collect(Collectors.toList());
+	}
+
+	/**
+	 * Execute the multi search query against elasticsearch and return result as {@link List} of {@link SearchHits}.
+	 *
+	 * @param queries the queries to execute
+	 * @param classes the entity classes used for property mapping
+	 * @param index the index to run the query against
+	 * @return list of SearchHits
+	 */
+	default List<SearchHits<?>> multiSearch(List<Query> queries, List<Class<?>> classes, IndexCoordinates index) {
+		List<SearchHits<?>> searchHitsList = new ArrayList<>();
+		multiSearchForPage(queries, classes, index).forEach(page -> {
+			searchHitsList.add(new SearchHits(page.getContent(), page.getTotalElements(), page.getMaxScore()));
+		});
+		return searchHitsList;
+	}
+
+	/**
+	 * more like this query to search for documents that are "like" a specific document.
+	 *
+	 * @param <T> element return type
+	 * @param query the query to execute
+	 * @param clazz the entity clazz used for property mapping
+	 * @param index the index to run the query against
+	 * @return page with the results
+	 */
+	<T> AggregatedPage<SearchHit<T>> search(MoreLikeThisQuery query, Class<T> clazz, IndexCoordinates index);
+
+	/**
+	 * Returns scrolled page for given query
+	 *
+	 * @param scrollTimeInMillis duration of the scroll time
+	 * @param query The search query.
+	 * @param clazz The class of entity to retrieve.
+	 * @param index the index to run the query against
+	 * @return scrolled page result
+	 */
+	<T> ScrolledPage<SearchHit<T>> searchScrollStart(long scrollTimeInMillis, Query query, Class<T> clazz,
+			IndexCoordinates index);
+
+	/**
+	 * Returns next scrolled page
+	 *
+	 * @param scrollId the scroll id
+	 * @param scrollTimeInMillis duration of the scroll time
+	 * @param clazz The class of entity to retrieve.
+	 * @return scrolled page result
+	 */
+	<T> ScrolledPage<SearchHit<T>> searchScrollContinue(@Nullable String scrollId, long scrollTimeInMillis,
+														Class<T> clazz);
+
+	/**
+	 * Clears the search contexts associated with specified scroll ids.
+	 *
+	 * @param scrollId the scroll id
+	 */
+	void searchScrollClear(String scrollId);
 
 	/**
 	 * Executes the given {@link Query} against elasticsearch and return result as {@link CloseableIterator}.
@@ -114,88 +397,11 @@ public interface SearchOperations {
 	 * @return a {@link CloseableIterator} that wraps an Elasticsearch scroll context that needs to be closed in case of *
 	 *         error.
 	 */
-	<T> CloseableIterator<T> stream(Query query, Class<T> clazz, IndexCoordinates index);
-
-	/**
-	 * Execute the criteria query against elasticsearch and return result as {@link List}
-	 *
-	 * @param query the query to execute
-	 * @param clazz the entity clazz used for property mapping
-	 * @param index the index to run the query against
-	 * @param <T> element return type
-	 * @return list of found objects
-	 */
-	<T> List<T> queryForList(Query query, Class<T> clazz, IndexCoordinates index);
-
-	/**
-	 * Execute the multi search query against elasticsearch and return result as {@link List}
-	 *
-	 * @param queries the queries to execute
-	 * @param clazz the entity clazz used for property mapping
-	 * @param index the index to run the query against
-	 * @param <T> element return type
-	 * @return list of found objects
-	 */
-	default <T> List<List<T>> queryForList(List<Query> queries, Class<T> clazz, IndexCoordinates index) {
-		return queryForPage(queries, clazz, index).stream().map(Page::getContent).collect(Collectors.toList());
-	}
-
-	/**
-	 * Execute the multi search query against elasticsearch and return result as {@link List}
-	 *
-	 * @param queries the queries to execute
-	 * @param classes the entity classes used for property mapping
-	 * @param index the index to run the query against
-	 * @return list of list of found objects
-	 */
-	default List<List<?>> queryForList(List<Query> queries, List<Class<?>> classes, IndexCoordinates index) {
-		return queryForPage(queries, classes, index).stream().map(Page::getContent).collect(Collectors.toList());
-	}
-
-	/**
-	 * Execute the query against elasticsearch and return ids
-	 *
-	 * @param query the query to execute
-	 * @param clazz the entity clazz used for property mapping
-	 * @param index the index to run the query against
-	 * @return list of found object ids
-	 */
-	List<String> queryForIds(Query query, Class<?> clazz, IndexCoordinates index);
-
-	/**
-	 * Returns scrolled page for given query
-	 *
-	 * @param scrollTimeInMillis duration of the scroll time
-	 * @param query The search query.
-	 * @param clazz The class of entity to retrieve.
-	 * @param index the index to run the query against
-	 * @return scrolled page result
-	 */
-	<T> ScrolledPage<T> startScroll(long scrollTimeInMillis, Query query, Class<T> clazz, IndexCoordinates index);
-
-	<T> ScrolledPage<T> continueScroll(@Nullable String scrollId, long scrollTimeInMillis, Class<T> clazz);
-
-	/**
-	 * Clears the search contexts associated with specified scroll ids.
-	 *
-	 * @param scrollId the scroll id
-	 */
-	void clearScroll(String scrollId);
-
-	/**
-	 * more like this query to search for documents that are "like" a specific document.
-	 *
-	 * @param query the query to execute
-	 * @param clazz the entity clazz used for property mapping
-	 * @param index the index to run the query against
-	 * @param <T> element return type
-	 * @return page with the results
-	 */
-	<T> Page<T> moreLikeThis(MoreLikeThisQuery query, Class<T> clazz, IndexCoordinates index);
+	<T> CloseableIterator<SearchHit<T>> searchForStream(Query query, Class<T> clazz, IndexCoordinates index);
 
 	/**
 	 * Does a suggest query
-	 * 
+	 *
 	 * @param suggestion the query
 	 * @param index the index to run the query against
 	 * @return the suggest response

--- a/src/main/java/org/springframework/data/elasticsearch/core/aggregation/impl/AggregatedPageImpl.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/aggregation/impl/AggregatedPageImpl.java
@@ -87,25 +87,25 @@ public class AggregatedPageImpl<T> extends PageImpl<T> implements AggregatedPage
 	}
 
 	public AggregatedPageImpl(List<T> content, Pageable pageable, long total, Aggregations aggregations, float maxScore) {
-		this(content, pageable, total, aggregations);
+		this(content, pageableOrUnpaged(pageable), total, aggregations);
 		this.maxScore = maxScore;
 	}
 
 	public AggregatedPageImpl(List<T> content, Pageable pageable, long total, Aggregations aggregations,
 			String scrollId) {
-		this(content, pageable, total, aggregations);
+		this(content, pageableOrUnpaged(pageable), total, aggregations);
 		this.scrollId = scrollId;
 	}
 
 	public AggregatedPageImpl(List<T> content, Pageable pageable, long total, Aggregations aggregations, String scrollId,
 			float maxScore) {
-		this(content, pageable, total, aggregations, scrollId);
+		this(content, pageableOrUnpaged(pageable), total, aggregations, scrollId);
 		this.maxScore = maxScore;
 	}
 
 	public AggregatedPageImpl(List<T> content, Pageable pageable, SearchDocumentResponse response) {
-		this(content, pageable, response.getTotalHits(), response.getAggregations(), response.getScrollId(),
-				response.getMaxScore());
+		this(content, pageableOrUnpaged(pageable), response.getTotalHits(), response.getAggregations(),
+				response.getScrollId(), response.getMaxScore());
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchConverter.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchConverter.java
@@ -19,8 +19,10 @@ import java.util.List;
 
 import org.springframework.data.convert.EntityConverter;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.aggregation.AggregatedPage;
 import org.springframework.data.elasticsearch.core.document.Document;
+import org.springframework.data.elasticsearch.core.document.SearchDocument;
 import org.springframework.data.elasticsearch.core.document.SearchDocumentResponse;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentEntity;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentProperty;
@@ -57,7 +59,8 @@ public interface ElasticsearchConverter
 		return getConversionService().convert(idValue, String.class);
 	}
 
-	<T> AggregatedPage<T> mapResults(SearchDocumentResponse response, Class<T> clazz, Pageable pageable);
+	<T> AggregatedPage<SearchHit<T>> mapResults(SearchDocumentResponse response, Class<T> clazz,
+			@Nullable Pageable pageable);
 
 	/**
 	 * Get the configured {@link ProjectionFactory}. <br />
@@ -72,14 +75,25 @@ public interface ElasticsearchConverter
 	/**
 	 * Map a single {@link Document} to an instance of the given type.
 	 *
-	 * @param document must not be {@literal null}.
+	 * @param document the document to map
 	 * @param type must not be {@literal null}.
 	 * @param <T>
-	 * @return can be {@literal null} if the {@link Document#isEmpty()} is true.
+	 * @return can be {@literal null} if the document is null or {@link Document#isEmpty()} is true.
 	 * @since 4.0
 	 */
 	@Nullable
-	<T> T mapDocument(Document document, Class<T> type);
+	<T> T mapDocument(@Nullable Document document, Class<T> type);
+
+	/**
+	 * builds a {@link SearchHit} from a {@link SearchDocument}.
+	 * 
+	 * @param searchDocument must not be {@literal null}
+	 * @param <T> the clazz of the type, must not be {@literal null}.
+	 * @param type the type of the returned data, must not be {@literal null}.
+	 * @return SearchHit with all available information filled in
+	 * @since 4.0
+	 */
+	<T> SearchHit<T> read(Class<T> type, SearchDocument searchDocument);
 
 	/**
 	 * Map a list of {@link Document}s to alist of instance of the given type.

--- a/src/main/java/org/springframework/data/elasticsearch/core/convert/package-info.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/convert/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.lang.NonNullApi
+package org.springframework.data.elasticsearch.core.convert;

--- a/src/main/java/org/springframework/data/elasticsearch/core/document/SearchDocument.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/document/SearchDocument.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Extension to {@link Document} exposing a search {@link #getScore() score}.
+ * Extension to {@link Document} exposing a search response related data.
  *
  * @author Mark Paluch
  * @author Peter-Josef Meisch

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/SimpleReactiveElasticsearchRepository.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/SimpleReactiveElasticsearchRepository.java
@@ -21,6 +21,7 @@ import reactor.core.publisher.Mono;
 import org.reactivestreams.Publisher;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.elasticsearch.core.ReactiveElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.query.Query;
 import org.springframework.data.elasticsearch.repository.ReactiveElasticsearchRepository;
 import org.springframework.util.Assert;
@@ -48,7 +49,9 @@ public class SimpleReactiveElasticsearchRepository<T, ID> implements ReactiveEla
 	@Override
 	public Flux<T> findAll(Sort sort) {
 
-		return elasticsearchOperations.find(Query.findAll().addSort(sort), entityInformation.getJavaType(), entityInformation.getIndexCoordinates());
+		return elasticsearchOperations
+				.search(Query.findAll().addSort(sort), entityInformation.getJavaType(), entityInformation.getIndexCoordinates())
+				.map(SearchHit::getContent);
 	}
 
 	@Override
@@ -76,7 +79,8 @@ public class SimpleReactiveElasticsearchRepository<T, ID> implements ReactiveEla
 	public Mono<T> findById(ID id) {
 
 		Assert.notNull(id, "Id must not be null!");
-		return elasticsearchOperations.findById(convertId(id), entityInformation.getJavaType(), entityInformation.getIndexCoordinates());
+		return elasticsearchOperations.findById(convertId(id), entityInformation.getJavaType(),
+				entityInformation.getIndexCoordinates());
 	}
 
 	@Override
@@ -90,7 +94,8 @@ public class SimpleReactiveElasticsearchRepository<T, ID> implements ReactiveEla
 	public Mono<Boolean> existsById(ID id) {
 
 		Assert.notNull(id, "Id must not be null!");
-		return elasticsearchOperations.exists(convertId(id), entityInformation.getJavaType(), entityInformation.getIndexCoordinates());
+		return elasticsearchOperations.exists(convertId(id), entityInformation.getJavaType(),
+				entityInformation.getIndexCoordinates());
 	}
 
 	@Override
@@ -103,7 +108,9 @@ public class SimpleReactiveElasticsearchRepository<T, ID> implements ReactiveEla
 	@Override
 	public Flux<T> findAll() {
 
-		return elasticsearchOperations.find(Query.findAll(), entityInformation.getJavaType(), entityInformation.getIndexCoordinates());
+		return elasticsearchOperations
+				.search(Query.findAll(), entityInformation.getJavaType(), entityInformation.getIndexCoordinates())
+				.map(SearchHit::getContent);
 	}
 
 	@Override
@@ -124,14 +131,16 @@ public class SimpleReactiveElasticsearchRepository<T, ID> implements ReactiveEla
 	@Override
 	public Mono<Long> count() {
 
-		return elasticsearchOperations.count(Query.findAll(), entityInformation.getJavaType(), entityInformation.getIndexCoordinates());
+		return elasticsearchOperations.count(Query.findAll(), entityInformation.getJavaType(),
+				entityInformation.getIndexCoordinates());
 	}
 
 	@Override
 	public Mono<Void> deleteById(ID id) {
 
 		Assert.notNull(id, "Id must not be null!");
-		return elasticsearchOperations.deleteById(convertId(id), entityInformation.getJavaType(), entityInformation.getIndexCoordinates()) //
+		return elasticsearchOperations
+				.deleteById(convertId(id), entityInformation.getJavaType(), entityInformation.getIndexCoordinates()) //
 				.then();
 	}
 
@@ -167,7 +176,8 @@ public class SimpleReactiveElasticsearchRepository<T, ID> implements ReactiveEla
 	@Override
 	public Mono<Void> deleteAll() {
 
-		return elasticsearchOperations.deleteBy(Query.findAll(), entityInformation.getJavaType(), entityInformation.getIndexCoordinates()) //
+		return elasticsearchOperations
+				.deleteBy(Query.findAll(), entityInformation.getJavaType(), entityInformation.getIndexCoordinates()) //
 				.then();
 	}
 

--- a/src/test/java/org/springframework/data/elasticsearch/NestedObjectTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/NestedObjectTests.java
@@ -45,6 +45,9 @@ import org.springframework.data.elasticsearch.annotations.FieldType;
 import org.springframework.data.elasticsearch.annotations.InnerField;
 import org.springframework.data.elasticsearch.annotations.MultiField;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.aggregation.AggregatedPage;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.query.GetQuery;
 import org.springframework.data.elasticsearch.core.query.IndexQuery;
@@ -131,7 +134,7 @@ public class NestedObjectTests {
 				boolQuery().must(termQuery("car.name", "saturn")).must(termQuery("car.model", "imprezza")), ScoreMode.None);
 
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(builder).build();
-		List<Person> persons = elasticsearchTemplate.queryForList(searchQuery, Person.class, index);
+		SearchHits<Person> persons = elasticsearchTemplate.search(searchQuery, Person.class, index);
 
 		assertThat(persons).hasSize(1);
 	}
@@ -193,11 +196,11 @@ public class NestedObjectTests {
 
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(builder).build();
 
-		Page<PersonMultipleLevelNested> personIndexed = elasticsearchTemplate.queryForPage(searchQuery,
+		Page<SearchHit<PersonMultipleLevelNested>> personIndexed = elasticsearchTemplate.searchForPage(searchQuery,
 				PersonMultipleLevelNested.class, index);
 		assertThat(personIndexed).isNotNull();
 		assertThat(personIndexed.getTotalElements()).isEqualTo(1);
-		assertThat(personIndexed.getContent().get(0).getId()).isEqualTo("1");
+		assertThat(personIndexed.getContent().get(0).getContent().getId()).isEqualTo("1");
 	}
 
 	private List<IndexQuery> createPerson() {
@@ -330,7 +333,7 @@ public class NestedObjectTests {
 		QueryBuilder builder = nestedQuery("books", boolQuery().must(termQuery("books.name", "java")), ScoreMode.None);
 
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(builder).build();
-		List<Person> persons = elasticsearchTemplate.queryForList(searchQuery, Person.class, index);
+		SearchHits<Person> persons = elasticsearchTemplate.search(searchQuery, Person.class, index);
 
 		// then
 		assertThat(persons).hasSize(1);
@@ -378,10 +381,10 @@ public class NestedObjectTests {
 		// then
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder()
 				.withQuery(nestedQuery("buckets", termQuery("buckets.1", "test3"), ScoreMode.None)).build();
-		Page<Book> books = elasticsearchTemplate.queryForPage(searchQuery, Book.class, index);
+		AggregatedPage<SearchHit<Book>> books = elasticsearchTemplate.searchForPage(searchQuery, Book.class, index);
 
 		assertThat(books.getContent()).hasSize(1);
-		assertThat(books.getContent().get(0).getId()).isEqualTo(book2.getId());
+		assertThat(books.getContent().get(0).getContent().getId()).isEqualTo(book2.getId());
 	}
 
 	@Setter

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
@@ -282,7 +282,7 @@ public abstract class ElasticsearchTemplateTests {
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
 
 		// when
-		Page<SampleEntity> sampleEntities = operations.queryForPage(searchQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> sampleEntities = operations.searchForPage(searchQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(sampleEntities).isNotNull();
@@ -306,8 +306,8 @@ public abstract class ElasticsearchTemplateTests {
 				.withPreference("_local").build();
 
 		// when
-		Page<SampleEntity> sampleEntities = operations.queryForPage(searchQueryWithValidPreference, SampleEntity.class,
-				index);
+		Page<SearchHit<SampleEntity>> sampleEntities = operations.searchForPage(searchQueryWithValidPreference,
+				SampleEntity.class, index);
 
 		// then
 		assertThat(sampleEntities).isNotNull();
@@ -332,7 +332,7 @@ public abstract class ElasticsearchTemplateTests {
 
 		// when
 		assertThatThrownBy(() -> {
-			operations.queryForPage(searchQueryWithInvalidPreference, SampleEntity.class, index);
+			operations.searchForPage(searchQueryWithInvalidPreference, SampleEntity.class, index);
 		}).isInstanceOf(Exception.class);
 	}
 
@@ -352,7 +352,7 @@ public abstract class ElasticsearchTemplateTests {
 		// when
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
 				.withIndicesOptions(IndicesOptions.lenientExpandOpen()).build();
-		Page<SampleEntity> entities = operations.queryForPage(searchQuery, SampleEntity.class,
+		Page<SearchHit<SampleEntity>> entities = operations.searchForPage(searchQuery, SampleEntity.class,
 				IndexCoordinates.of(INDEX_1_NAME, INDEX_2_NAME));
 
 		// then
@@ -384,7 +384,7 @@ public abstract class ElasticsearchTemplateTests {
 
 		// then
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
-		Page<SampleEntity> sampleEntities = operations.queryForPage(searchQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> sampleEntities = operations.searchForPage(searchQuery, SampleEntity.class, index);
 		assertThat(sampleEntities.getTotalElements()).isEqualTo(2);
 	}
 
@@ -439,7 +439,7 @@ public abstract class ElasticsearchTemplateTests {
 
 		// then
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("id", documentId)).build();
-		Page<SampleEntity> sampleEntities = operations.queryForPage(searchQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> sampleEntities = operations.searchForPage(searchQuery, SampleEntity.class, index);
 		assertThat(sampleEntities.getTotalElements()).isEqualTo(0);
 	}
 
@@ -461,7 +461,7 @@ public abstract class ElasticsearchTemplateTests {
 
 		// then
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("id", documentId)).build();
-		Page<SampleEntity> sampleEntities = operations.queryForPage(searchQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> sampleEntities = operations.searchForPage(searchQuery, SampleEntity.class, index);
 		assertThat(sampleEntities.getTotalElements()).isEqualTo(0);
 	}
 
@@ -486,7 +486,7 @@ public abstract class ElasticsearchTemplateTests {
 
 		// then
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("id", documentId)).build();
-		Page<SampleEntity> sampleEntities = operations.queryForPage(searchQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> sampleEntities = operations.searchForPage(searchQuery, SampleEntity.class, index);
 		assertThat(sampleEntities.getTotalElements()).isEqualTo(0);
 	}
 
@@ -574,7 +574,7 @@ public abstract class ElasticsearchTemplateTests {
 				.withFilter(boolQuery().filter(termQuery("id", documentId))).build();
 
 		// when
-		Page<SampleEntity> sampleEntities = operations.queryForPage(searchQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> sampleEntities = operations.searchForPage(searchQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(sampleEntities.getTotalElements()).isEqualTo(1);
@@ -609,11 +609,11 @@ public abstract class ElasticsearchTemplateTests {
 				.withSort(new FieldSortBuilder("rate").order(SortOrder.ASC)).build();
 
 		// when
-		Page<SampleEntity> sampleEntities = operations.queryForPage(searchQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> sampleEntities = operations.searchForPage(searchQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(sampleEntities.getTotalElements()).isEqualTo(3);
-		assertThat(sampleEntities.getContent().get(0).getRate()).isEqualTo(sampleEntity2.getRate());
+		assertThat(sampleEntities.getContent().get(0).getContent().getRate()).isEqualTo(sampleEntity2.getRate());
 	}
 
 	@Test
@@ -646,12 +646,12 @@ public abstract class ElasticsearchTemplateTests {
 				.withSort(new FieldSortBuilder("message").order(SortOrder.ASC)).build();
 
 		// when
-		Page<SampleEntity> sampleEntities = operations.queryForPage(searchQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> sampleEntities = operations.searchForPage(searchQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(sampleEntities.getTotalElements()).isEqualTo(3);
-		assertThat(sampleEntities.getContent().get(0).getRate()).isEqualTo(sampleEntity2.getRate());
-		assertThat(sampleEntities.getContent().get(1).getMessage()).isEqualTo(sampleEntity1.getMessage());
+		assertThat(sampleEntities.getContent().get(0).getContent().getRate()).isEqualTo(sampleEntity2.getRate());
+		assertThat(sampleEntities.getContent().get(1).getContent().getMessage()).isEqualTo(sampleEntity1.getMessage());
 	}
 
 	@Test // DATAES-312
@@ -684,12 +684,12 @@ public abstract class ElasticsearchTemplateTests {
 				.withPageable(PageRequest.of(0, 10, Sort.by(Sort.Order.asc("message").nullsFirst()))).build();
 
 		// when
-		Page<SampleEntity> sampleEntities = operations.queryForPage(searchQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> sampleEntities = operations.searchForPage(searchQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(sampleEntities.getTotalElements()).isEqualTo(3);
-		assertThat(sampleEntities.getContent().get(0).getRate()).isEqualTo(sampleEntity3.getRate());
-		assertThat(sampleEntities.getContent().get(1).getMessage()).isEqualTo(sampleEntity1.getMessage());
+		assertThat(sampleEntities.getContent().get(0).getContent().getRate()).isEqualTo(sampleEntity3.getRate());
+		assertThat(sampleEntities.getContent().get(1).getContent().getMessage()).isEqualTo(sampleEntity1.getMessage());
 	}
 
 	@Test // DATAES-312
@@ -722,12 +722,12 @@ public abstract class ElasticsearchTemplateTests {
 				.withPageable(PageRequest.of(0, 10, Sort.by(Sort.Order.asc("message").nullsLast()))).build();
 
 		// when
-		Page<SampleEntity> sampleEntities = operations.queryForPage(searchQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> sampleEntities = operations.searchForPage(searchQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(sampleEntities.getTotalElements()).isEqualTo(3);
-		assertThat(sampleEntities.getContent().get(0).getRate()).isEqualTo(sampleEntity1.getRate());
-		assertThat(sampleEntities.getContent().get(1).getMessage()).isEqualTo(sampleEntity2.getMessage());
+		assertThat(sampleEntities.getContent().get(0).getContent().getRate()).isEqualTo(sampleEntity1.getRate());
+		assertThat(sampleEntities.getContent().get(1).getContent().getMessage()).isEqualTo(sampleEntity2.getMessage());
 	}
 
 	@Test // DATAES-467, DATAES-657
@@ -748,12 +748,12 @@ public abstract class ElasticsearchTemplateTests {
 				.build();
 
 		// when
-		Page<SampleEntity> page = operations.queryForPage(searchQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> page = operations.searchForPage(searchQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(page.getTotalElements()).isEqualTo(2);
-		assertThat(page.getContent().get(0).getId()).isEqualTo("2");
-		assertThat(page.getContent().get(1).getId()).isEqualTo("1");
+		assertThat(page.getContent().get(0).getContent().getId()).isEqualTo("2");
+		assertThat(page.getContent().get(1).getContent().getId()).isEqualTo("1");
 	}
 
 	@Test
@@ -772,7 +772,7 @@ public abstract class ElasticsearchTemplateTests {
 		StringQuery stringQuery = new StringQuery(matchAllQuery().toString());
 
 		// when
-		Page<SampleEntity> sampleEntities = operations.queryForPage(stringQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> sampleEntities = operations.searchForPage(stringQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(sampleEntities.getTotalElements()).isEqualTo(1);
@@ -803,11 +803,11 @@ public abstract class ElasticsearchTemplateTests {
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).withScriptField(
 				new ScriptField("scriptedRate", new Script(ScriptType.INLINE, "expression", "doc['rate'] * factor", params)))
 				.build();
-		Page<SampleEntity> sampleEntities = operations.queryForPage(searchQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> sampleEntities = operations.searchForPage(searchQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(sampleEntities.getTotalElements()).isEqualTo(1);
-		assertThat(sampleEntities.getContent().get(0).getScriptedRate()).isEqualTo(4.0);
+		assertThat(sampleEntities.getContent().get(0).getContent().getScriptedRate()).isEqualTo(4.0);
 	}
 
 	@Test
@@ -826,7 +826,7 @@ public abstract class ElasticsearchTemplateTests {
 		StringQuery stringQuery = new StringQuery(matchAllQuery().toString(), PageRequest.of(0, 10));
 
 		// when
-		Page<SampleEntity> sampleEntities = operations.queryForPage(stringQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> sampleEntities = operations.searchForPage(stringQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(sampleEntities.getTotalElements()).isGreaterThanOrEqualTo(1);
@@ -853,7 +853,7 @@ public abstract class ElasticsearchTemplateTests {
 				Sort.by(Order.asc("message")));
 
 		// when
-		Page<SampleEntity> sampleEntities = operations.queryForPage(stringQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> sampleEntities = operations.searchForPage(stringQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(sampleEntities.getTotalElements()).isGreaterThanOrEqualTo(1);
@@ -875,11 +875,11 @@ public abstract class ElasticsearchTemplateTests {
 		StringQuery stringQuery = new StringQuery(termQuery("id", documentId).toString());
 
 		// when
-		SampleEntity sampleEntity1 = operations.queryForObject(stringQuery, SampleEntity.class, index);
+		SearchHit<SampleEntity> sampleEntity1 = operations.searchOne(stringQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(sampleEntity1).isNotNull();
-		assertThat(sampleEntity1.getId()).isEqualTo(documentId);
+		assertThat(sampleEntity1.getContent().getId()).isEqualTo(documentId);
 	}
 
 	@Test
@@ -909,7 +909,7 @@ public abstract class ElasticsearchTemplateTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("message").contains("test"));
 
 		// when
-		SampleEntity sampleEntity1 = operations.queryForObject(criteriaQuery, SampleEntity.class, index);
+		SearchHit<SampleEntity> sampleEntity1 = operations.searchOne(criteriaQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(sampleEntity1).isNotNull();
@@ -935,7 +935,7 @@ public abstract class ElasticsearchTemplateTests {
 
 		// then
 		StringQuery stringQuery = new StringQuery(matchAllQuery().toString());
-		List<SampleEntity> sampleEntities = operations.queryForList(stringQuery, SampleEntity.class, index);
+		SearchHits<SampleEntity> sampleEntities = operations.search(stringQuery, SampleEntity.class, index);
 
 		assertThat(sampleEntities).isEmpty();
 	}
@@ -958,12 +958,12 @@ public abstract class ElasticsearchTemplateTests {
 				.build();
 
 		// when
-		Page<SampleEntity> page = operations.queryForPage(searchQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> page = operations.searchForPage(searchQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(page).isNotNull();
 		assertThat(page.getTotalElements()).isEqualTo(1);
-		final SampleEntity actual = page.getContent().get(0);
+		final SampleEntity actual = page.getContent().get(0).getContent();
 		assertThat(actual.message).isEqualTo(message);
 		assertThat(actual.getType()).isNull();
 		assertThat(actual.getLocation()).isNull();
@@ -990,12 +990,12 @@ public abstract class ElasticsearchTemplateTests {
 				.withSourceFilter(sourceFilter.build()).build();
 
 		// when
-		Page<SampleEntity> page = operations.queryForPage(searchQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> page = operations.searchForPage(searchQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(page).isNotNull();
 		assertThat(page.getTotalElements()).isEqualTo(1);
-		assertThat(page.getContent().get(0).getMessage()).isEqualTo(message);
+		assertThat(page.getContent().get(0).getContent().getMessage()).isEqualTo(message);
 	}
 
 	@Test
@@ -1030,11 +1030,13 @@ public abstract class ElasticsearchTemplateTests {
 		moreLikeThisQuery.setMinDocFreq(1);
 
 		// when
-		Page<SampleEntity> sampleEntities = operations.moreLikeThis(moreLikeThisQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> sampleEntities = operations.search(moreLikeThisQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(sampleEntities.getTotalElements()).isEqualTo(1);
-		assertThat(sampleEntities.getContent()).contains(sampleEntity);
+		List<SampleEntity> content = sampleEntities.getContent().stream().map(SearchHit::getContent)
+				.collect(Collectors.toList());
+		assertThat(content).contains(sampleEntity);
 	}
 
 	@Test // DATAES-167
@@ -1051,13 +1053,14 @@ public abstract class ElasticsearchTemplateTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
 		criteriaQuery.setPageable(PageRequest.of(0, 10));
 
-		ScrolledPage<SampleEntity> scroll = operations.startScroll(1000, criteriaQuery, SampleEntity.class, index);
-		List<SampleEntity> sampleEntities = new ArrayList<>();
+		ScrolledPage<SearchHit<SampleEntity>> scroll = operations.searchScrollStart(1000, criteriaQuery, SampleEntity.class,
+				index);
+		List<SearchHit<SampleEntity>> sampleEntities = new ArrayList<>();
 		while (scroll.hasContent()) {
 			sampleEntities.addAll(scroll.getContent());
-			scroll = operations.continueScroll(scroll.getScrollId(), 1000, SampleEntity.class);
+			scroll = operations.searchScrollContinue(scroll.getScrollId(), 1000, SampleEntity.class);
 		}
-		operations.clearScroll(scroll.getScrollId());
+		operations.searchScrollClear(scroll.getScrollId());
 		assertThat(sampleEntities).hasSize(30);
 	}
 
@@ -1076,13 +1079,14 @@ public abstract class ElasticsearchTemplateTests {
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
 				.withPageable(PageRequest.of(0, 10)).build();
 
-		ScrolledPage<SampleEntity> scroll = operations.startScroll(1000, searchQuery, SampleEntity.class, index);
-		List<SampleEntity> sampleEntities = new ArrayList<>();
+		ScrolledPage<SearchHit<SampleEntity>> scroll = operations.searchScrollStart(1000, searchQuery, SampleEntity.class,
+				index);
+		List<SearchHit<SampleEntity>> sampleEntities = new ArrayList<>();
 		while (scroll.hasContent()) {
 			sampleEntities.addAll(scroll.getContent());
-			scroll = operations.continueScroll(scroll.getScrollId(), 1000, SampleEntity.class);
+			scroll = operations.searchScrollContinue(scroll.getScrollId(), 1000, SampleEntity.class);
 		}
-		operations.clearScroll(scroll.getScrollId());
+		operations.searchScrollClear(scroll.getScrollId());
 		assertThat(sampleEntities).hasSize(30);
 	}
 
@@ -1101,15 +1105,16 @@ public abstract class ElasticsearchTemplateTests {
 		criteriaQuery.addFields("message");
 		criteriaQuery.setPageable(PageRequest.of(0, 10));
 
-		ScrolledPage<SampleEntity> scroll = operations.startScroll(1000, criteriaQuery, SampleEntity.class, index);
+		ScrolledPage<SearchHit<SampleEntity>> scroll = operations.searchScrollStart(1000, criteriaQuery, SampleEntity.class,
+				index);
 		String scrollId = scroll.getScrollId();
-		List<SampleEntity> sampleEntities = new ArrayList<>();
+		List<SearchHit<SampleEntity>> sampleEntities = new ArrayList<>();
 		while (scroll.hasContent()) {
 			sampleEntities.addAll(scroll.getContent());
 			scrollId = scroll.getScrollId();
-			scroll = operations.continueScroll(scrollId, 1000, SampleEntity.class);
+			scroll = operations.searchScrollContinue(scrollId, 1000, SampleEntity.class);
 		}
-		operations.clearScroll(scrollId);
+		operations.searchScrollClear(scrollId);
 		assertThat(sampleEntities).hasSize(30);
 	}
 
@@ -1127,15 +1132,16 @@ public abstract class ElasticsearchTemplateTests {
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).withFields("message")
 				.withQuery(matchAllQuery()).withPageable(PageRequest.of(0, 10)).build();
 
-		ScrolledPage<SampleEntity> scroll = operations.startScroll(1000, searchQuery, SampleEntity.class, index);
+		ScrolledPage<SearchHit<SampleEntity>> scroll = operations.searchScrollStart(1000, searchQuery, SampleEntity.class,
+				index);
 		String scrollId = scroll.getScrollId();
-		List<SampleEntity> sampleEntities = new ArrayList<>();
+		List<SearchHit<SampleEntity>> sampleEntities = new ArrayList<>();
 		while (scroll.hasContent()) {
 			sampleEntities.addAll(scroll.getContent());
 			scrollId = scroll.getScrollId();
-			scroll = operations.continueScroll(scrollId, 1000, SampleEntity.class);
+			scroll = operations.searchScrollContinue(scrollId, 1000, SampleEntity.class);
 		}
-		operations.clearScroll(scrollId);
+		operations.searchScrollClear(scrollId);
 		assertThat(sampleEntities).hasSize(30);
 	}
 
@@ -1153,15 +1159,16 @@ public abstract class ElasticsearchTemplateTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
 		criteriaQuery.setPageable(PageRequest.of(0, 10));
 
-		ScrolledPage<SampleEntity> scroll = operations.startScroll(1000, criteriaQuery, SampleEntity.class, index);
+		ScrolledPage<SearchHit<SampleEntity>> scroll = operations.searchScrollStart(1000, criteriaQuery, SampleEntity.class,
+				index);
 		String scrollId = scroll.getScrollId();
-		List<SampleEntity> sampleEntities = new ArrayList<>();
+		List<SearchHit<SampleEntity>> sampleEntities = new ArrayList<>();
 		while (scroll.hasContent()) {
 			sampleEntities.addAll(scroll.getContent());
 			scrollId = scroll.getScrollId();
-			scroll = operations.continueScroll(scrollId, 1000, SampleEntity.class);
+			scroll = operations.searchScrollContinue(scrollId, 1000, SampleEntity.class);
 		}
-		operations.clearScroll(scrollId);
+		operations.searchScrollClear(scrollId);
 		assertThat(sampleEntities).hasSize(30);
 	}
 
@@ -1179,15 +1186,16 @@ public abstract class ElasticsearchTemplateTests {
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
 				.withPageable(PageRequest.of(0, 10)).build();
 
-		ScrolledPage<SampleEntity> scroll = operations.startScroll(1000, searchQuery, SampleEntity.class, index);
+		ScrolledPage<SearchHit<SampleEntity>> scroll = operations.searchScrollStart(1000, searchQuery, SampleEntity.class,
+				index);
 		String scrollId = scroll.getScrollId();
-		List<SampleEntity> sampleEntities = new ArrayList<>();
+		List<SearchHit<SampleEntity>> sampleEntities = new ArrayList<>();
 		while (scroll.hasContent()) {
 			sampleEntities.addAll(scroll.getContent());
 			scrollId = scroll.getScrollId();
-			scroll = operations.continueScroll(scrollId, 1000, SampleEntity.class);
+			scroll = operations.searchScrollContinue(scrollId, 1000, SampleEntity.class);
 		}
-		operations.clearScroll(scrollId);
+		operations.searchScrollClear(scrollId);
 		assertThat(sampleEntities).hasSize(30);
 	}
 
@@ -1205,15 +1213,16 @@ public abstract class ElasticsearchTemplateTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
 		criteriaQuery.setPageable(PageRequest.of(0, 10));
 
-		ScrolledPage<SampleEntity> scroll = operations.startScroll(1000, criteriaQuery, SampleEntity.class, index);
+		ScrolledPage<SearchHit<SampleEntity>> scroll = operations.searchScrollStart(1000, criteriaQuery, SampleEntity.class,
+				index);
 		String scrollId = scroll.getScrollId();
-		List<SampleEntity> sampleEntities = new ArrayList<>();
+		List<SearchHit<SampleEntity>> sampleEntities = new ArrayList<>();
 		while (scroll.hasContent()) {
 			sampleEntities.addAll(scroll.getContent());
 			scrollId = scroll.getScrollId();
-			scroll = operations.continueScroll(scrollId, 1000, SampleEntity.class);
+			scroll = operations.searchScrollContinue(scrollId, 1000, SampleEntity.class);
 		}
-		operations.clearScroll(scrollId);
+		operations.searchScrollClear(scrollId);
 		assertThat(sampleEntities).hasSize(30);
 	}
 
@@ -1231,15 +1240,16 @@ public abstract class ElasticsearchTemplateTests {
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
 				.withPageable(PageRequest.of(0, 10)).build();
 
-		ScrolledPage<SampleEntity> scroll = operations.startScroll(1000, searchQuery, SampleEntity.class, index);
+		ScrolledPage<SearchHit<SampleEntity>> scroll = operations.searchScrollStart(1000, searchQuery, SampleEntity.class,
+				index);
 		String scrollId = scroll.getScrollId();
-		List<SampleEntity> sampleEntities = new ArrayList<>();
+		List<SearchHit<SampleEntity>> sampleEntities = new ArrayList<>();
 		while (scroll.hasContent()) {
 			sampleEntities.addAll(scroll.getContent());
 			scrollId = scroll.getScrollId();
-			scroll = operations.continueScroll(scrollId, 1000, SampleEntity.class);
+			scroll = operations.searchScrollContinue(scrollId, 1000, SampleEntity.class);
 		}
-		operations.clearScroll(scrollId);
+		operations.searchScrollClear(scrollId);
 		assertThat(sampleEntities).hasSize(30);
 	}
 
@@ -1257,8 +1267,9 @@ public abstract class ElasticsearchTemplateTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria());
 		criteriaQuery.setPageable(PageRequest.of(0, 10));
 
-		CloseableIterator<SampleEntity> stream = operations.stream(criteriaQuery, SampleEntity.class, index);
-		List<SampleEntity> sampleEntities = new ArrayList<>();
+		CloseableIterator<SearchHit<SampleEntity>> stream = operations.searchForStream(criteriaQuery, SampleEntity.class,
+				index);
+		List<SearchHit<SampleEntity>> sampleEntities = new ArrayList<>();
 		while (stream.hasNext()) {
 			sampleEntities.add(stream.next());
 		}
@@ -1311,9 +1322,9 @@ public abstract class ElasticsearchTemplateTests {
 		CriteriaQuery singleCriteriaQuery = new CriteriaQuery(new Criteria("message").contains("test"));
 		CriteriaQuery multipleCriteriaQuery = new CriteriaQuery(
 				new Criteria("message").contains("some").and("message").contains("message"));
-		List<SampleEntity> sampleEntitiesForSingleCriteria = operations.queryForList(singleCriteriaQuery,
+		SearchHits<SampleEntity> sampleEntitiesForSingleCriteria = operations.search(singleCriteriaQuery,
 				SampleEntity.class, index);
-		List<SampleEntity> sampleEntitiesForAndCriteria = operations.queryForList(multipleCriteriaQuery, SampleEntity.class,
+		SearchHits<SampleEntity> sampleEntitiesForAndCriteria = operations.search(multipleCriteriaQuery, SampleEntity.class,
 				index);
 		// then
 		assertThat(sampleEntitiesForSingleCriteria).hasSize(2);
@@ -1346,17 +1357,17 @@ public abstract class ElasticsearchTemplateTests {
 		indexOperations.refresh(SampleEntity.class);
 
 		StringQuery stringQuery = new StringQuery(matchAllQuery().toString());
-		List<SampleEntity> sampleEntities = operations.queryForList(stringQuery, SampleEntity.class, index);
+		SearchHits<SampleEntity> sampleEntities = operations.search(stringQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(sampleEntities).hasSize(3);
 	}
 
 	@Test
-	public void shouldPutMappingForGivenEntity() throws Exception {
+	public void shouldPutMappingForGivenEntity() {
 
 		// given
-		Class entity = SampleMappingEntity.class;
+		Class<SampleEntity> entity = SampleEntity.class;
 		indexOperations.deleteIndex(entity);
 		indexOperations.createIndex(entity);
 
@@ -1367,7 +1378,7 @@ public abstract class ElasticsearchTemplateTests {
 	}
 
 	@Test // DATAES-305
-	public void shouldPutMappingWithCustomIndexName() throws Exception {
+	public void shouldPutMappingWithCustomIndexName() {
 
 		// given
 		Class<SampleEntity> entity = SampleEntity.class;
@@ -1510,15 +1521,15 @@ public abstract class ElasticsearchTemplateTests {
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
 				.withIndicesOptions(IndicesOptions.lenientExpandOpen()).build();
 
-		List<SampleEntity> entities = new ArrayList<>();
+		List<SearchHit<SampleEntity>> entities = new ArrayList<>();
 
-		ScrolledPage<SampleEntity> scroll = operations.startScroll(scrollTimeInMillis, searchQuery, SampleEntity.class,
-				index);
+		ScrolledPage<SearchHit<SampleEntity>> scroll = operations.searchScrollStart(scrollTimeInMillis, searchQuery,
+				SampleEntity.class, index);
 
 		entities.addAll(scroll.getContent());
 
 		while (scroll.hasContent()) {
-			scroll = operations.continueScroll(scroll.getScrollId(), scrollTimeInMillis, SampleEntity.class);
+			scroll = operations.searchScrollContinue(scroll.getScrollId(), scrollTimeInMillis, SampleEntity.class);
 
 			entities.addAll(scroll.getContent());
 		}
@@ -1549,8 +1560,9 @@ public abstract class ElasticsearchTemplateTests {
 		queries.add(new NativeSearchQueryBuilder().withQuery(termQuery("message", "ac")).build());
 
 		// then
-		List<Page<SampleEntity>> sampleEntities = operations.queryForPage(queries, SampleEntity.class, index);
-		for (Page<SampleEntity> sampleEntity : sampleEntities) {
+		List<AggregatedPage<SearchHit<SampleEntity>>> sampleEntities = operations.multiSearchForPage(queries,
+				SampleEntity.class, index);
+		for (Page<SearchHit<SampleEntity>> sampleEntity : sampleEntities) {
 			assertThat(sampleEntity.getTotalElements()).isEqualTo(1);
 		}
 	}
@@ -1577,16 +1589,19 @@ public abstract class ElasticsearchTemplateTests {
 		queries.add(new NativeSearchQueryBuilder().withQuery(termQuery("message", "ab")).build());
 		queries.add(new NativeSearchQueryBuilder().withQuery(termQuery("description", "bc")).build());
 
-		List<Page<?>> pages = operations.queryForPage(queries, Lists.newArrayList(SampleEntity.class, clazz),
+		List<AggregatedPage<? extends SearchHit<?>>> pages = operations.multiSearchForPage(queries,
+				Lists.newArrayList(SampleEntity.class, clazz),
 				IndexCoordinates.of(index.getIndexName(), bookIndex.getIndexName()));
 
 		// then
 		Page<?> page0 = pages.get(0);
 		assertThat(page0.getTotalElements()).isEqualTo(1L);
-		assertThat(page0.getContent().get(0).getClass()).isEqualTo(SampleEntity.class);
+		SearchHit<SampleEntity> searchHit0 = (SearchHit<SampleEntity>) page0.getContent().get(0);
+		assertThat(searchHit0.getContent().getClass()).isEqualTo(SampleEntity.class);
 		Page<?> page1 = pages.get(1);
 		assertThat(page1.getTotalElements()).isEqualTo(1L);
-		assertThat(page1.getContent().get(0).getClass()).isEqualTo(clazz);
+		SearchHit<Book> searchHit1 = (SearchHit<Book>) page1.getContent().get(0);
+		assertThat(searchHit1.getContent().getClass()).isEqualTo(clazz);
 	}
 
 	@Test
@@ -1610,7 +1625,7 @@ public abstract class ElasticsearchTemplateTests {
 
 		// then
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("id", documentId)).build();
-		Page<SampleEntity> sampleEntities = operations.queryForPage(searchQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> sampleEntities = operations.searchForPage(searchQuery, SampleEntity.class, index);
 		assertThat(sampleEntities.getTotalElements()).isEqualTo(0);
 	}
 
@@ -1630,10 +1645,10 @@ public abstract class ElasticsearchTemplateTests {
 				.build();
 
 		// then
-		Page<SampleEntity> page = operations.queryForPage(searchQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> page = operations.searchForPage(searchQuery, SampleEntity.class, index);
 		assertThat(page).isNotNull();
 		assertThat(page.getContent()).hasSize(1);
-		assertThat(page.getContent().get(0).getId()).isEqualTo(indexQuery.getId());
+		assertThat(page.getContent().get(0).getContent().getId()).isEqualTo(indexQuery.getId());
 	}
 
 	@Test
@@ -1680,11 +1695,11 @@ public abstract class ElasticsearchTemplateTests {
 				.withQuery(boolQuery().must(wildcardQuery("message", "*a*")).should(wildcardQuery("message", "*b*")))
 				.withMinScore(2.0F).build();
 
-		Page<SampleEntity> page = operations.queryForPage(searchQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> page = operations.searchForPage(searchQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(page.getTotalElements()).isEqualTo(1);
-		assertThat(page.getContent().get(0).getMessage()).isEqualTo("ab");
+		assertThat(page.getContent().get(0).getContent().getMessage()).isEqualTo("ab");
 	}
 
 	@Test // DATAES-462
@@ -1704,7 +1719,7 @@ public abstract class ElasticsearchTemplateTests {
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("message", "xz"))
 				.withSort(SortBuilders.fieldSort("message")).withTrackScores(true).build();
 
-		Page<SampleEntity> page = operations.queryForPage(searchQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> page = operations.searchForPage(searchQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(page).isInstanceOf(AggregatedPage.class);
@@ -1765,12 +1780,12 @@ public abstract class ElasticsearchTemplateTests {
 
 		// then
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
-		Page<SampleEntity> sampleEntities = operations.queryForPage(searchQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> sampleEntities = operations.searchForPage(searchQuery, SampleEntity.class, index);
 		assertThat(sampleEntities.getTotalElements()).isEqualTo(2);
 
-		List<SampleEntity> content = sampleEntities.getContent();
-		assertThat(content.get(0).getId()).isNotNull();
-		assertThat(content.get(1).getId()).isNotNull();
+		List<SearchHit<SampleEntity>> content = sampleEntities.getContent();
+		assertThat(content.get(0).getContent().getId()).isNotNull();
+		assertThat(content.get(1).getContent().getId()).isNotNull();
 	}
 
 	@Test
@@ -1809,12 +1824,12 @@ public abstract class ElasticsearchTemplateTests {
 
 		// then
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
-		Page<Map> sampleEntities = operations.queryForPage(searchQuery, Map.class, index);
+		Page<SearchHit<Map>> sampleEntities = operations.searchForPage(searchQuery, Map.class, index);
 
 		assertThat(sampleEntities.getTotalElements()).isEqualTo(2);
-		List<Map> content = sampleEntities.getContent();
-		assertThat(content.get(0).get("userId")).isEqualTo(person1.get("userId"));
-		assertThat(content.get(1).get("userId")).isEqualTo(person2.get("userId"));
+		List<SearchHit<Map>> content = sampleEntities.getContent();
+		assertThat(content.get(0).getContent().get("userId")).isEqualTo(person1.get("userId"));
+		assertThat(content.get(1).getContent().get("userId")).isEqualTo(person2.get("userId"));
 	}
 
 	@Test // DATAES-523
@@ -1833,7 +1848,7 @@ public abstract class ElasticsearchTemplateTests {
 
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
 		// when
-		Page<GTEVersionEntity> entities = operations.queryForPage(searchQuery, GTEVersionEntity.class, index);
+		Page<SearchHit<GTEVersionEntity>> entities = operations.searchForPage(searchQuery, GTEVersionEntity.class, index);
 		// then
 		assertThat(entities).isNotNull();
 		assertThat(entities.getTotalElements()).isGreaterThanOrEqualTo(1);
@@ -1864,7 +1879,7 @@ public abstract class ElasticsearchTemplateTests {
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
 
 		// when
-		Page<SampleEntity> sampleEntities = operations.queryForPage(searchQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> sampleEntities = operations.searchForPage(searchQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(sampleEntities).isNotNull();
@@ -2241,7 +2256,7 @@ public abstract class ElasticsearchTemplateTests {
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
 
 		// when
-		List<SampleEntity> sampleEntities = operations.queryForList(searchQuery, SampleEntity.class,
+		SearchHits<SampleEntity> sampleEntities = operations.search(searchQuery, SampleEntity.class,
 				IndexCoordinates.of(INDEX_1_NAME, INDEX_2_NAME));
 
 		// then
@@ -2268,7 +2283,7 @@ public abstract class ElasticsearchTemplateTests {
 
 		// when
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
-		Page<ResultAggregator> page = operations.queryForPage(searchQuery, ResultAggregator.class,
+		Page<SearchHit<ResultAggregator>> page = operations.searchForPage(searchQuery, ResultAggregator.class,
 				IndexCoordinates.of(INDEX_1_NAME, INDEX_2_NAME));
 
 		assertThat(page.getTotalElements()).isEqualTo(2);
@@ -2329,9 +2344,9 @@ public abstract class ElasticsearchTemplateTests {
 		// then
 		// document with id "remainingDocumentId" should still be indexed
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
-		Page<SampleEntity> sampleEntities = operations.queryForPage(searchQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> sampleEntities = operations.searchForPage(searchQuery, SampleEntity.class, index);
 		assertThat(sampleEntities.getTotalElements()).isEqualTo(1);
-		assertThat(sampleEntities.getContent().get(0).getId()).isEqualTo(remainingDocumentId);
+		assertThat(sampleEntities.getContent().get(0).getContent().getId()).isEqualTo(remainingDocumentId);
 	}
 
 	@Test // DATAES-525
@@ -2360,9 +2375,9 @@ public abstract class ElasticsearchTemplateTests {
 		// then
 		// document with id "remainingDocumentId" should still be indexed
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
-		Page<SampleEntity> sampleEntities = operations.queryForPage(searchQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> sampleEntities = operations.searchForPage(searchQuery, SampleEntity.class, index);
 		assertThat(sampleEntities.getTotalElements()).isEqualTo(1);
-		assertThat(sampleEntities.getContent().get(0).getId()).isEqualTo(remainingDocumentId);
+		assertThat(sampleEntities.getContent().get(0).getContent().getId()).isEqualTo(remainingDocumentId);
 	}
 
 	@Test // DATAES-525
@@ -2389,9 +2404,9 @@ public abstract class ElasticsearchTemplateTests {
 		// then
 		// document with id "remainingDocumentId" should still be indexed
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
-		Page<SampleEntity> sampleEntities = operations.queryForPage(searchQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> sampleEntities = operations.searchForPage(searchQuery, SampleEntity.class, index);
 		assertThat(sampleEntities.getTotalElements()).isEqualTo(1L);
-		assertThat(sampleEntities.getContent().get(0).getId()).isEqualTo(remainingDocumentId);
+		assertThat(sampleEntities.getContent().get(0).getContent().getId()).isEqualTo(remainingDocumentId);
 	}
 
 	@Test // DATAES-525
@@ -2415,18 +2430,20 @@ public abstract class ElasticsearchTemplateTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("message").contains("message"));
 		criteriaQuery.setPageable(PageRequest.of(0, 10));
 
-		ScrolledPage<SampleEntity> scroll = operations.startScroll(1000, criteriaQuery, SampleEntity.class, index);
-		List<SampleEntity> sampleEntities = new ArrayList<>();
+		ScrolledPage<SearchHit<SampleEntity>> scroll = operations.searchScrollStart(1000, criteriaQuery, SampleEntity.class,
+				index);
+		List<SearchHit<SampleEntity>> sampleEntities = new ArrayList<>();
 		while (scroll.hasContent()) {
 			sampleEntities.addAll(scroll.getContent());
-			scroll = operations.continueScroll(scroll.getScrollId(), 1000, SampleEntity.class);
+			scroll = operations.searchScrollContinue(scroll.getScrollId(), 1000, SampleEntity.class);
 		}
-		operations.clearScroll(scroll.getScrollId());
+		operations.searchScrollClear(scroll.getScrollId());
 
 		// then
 		assertThat(sampleEntities).hasSize(2);
-		assertThat(sampleEntities.stream().map(SampleEntity::getMessage).collect(Collectors.toList()))
-				.doesNotContain(notFindableMessage);
+		assertThat(
+				sampleEntities.stream().map(SearchHit::getContent).map(SampleEntity::getMessage).collect(Collectors.toList()))
+						.doesNotContain(notFindableMessage);
 	}
 
 	@Test // DATAES-525
@@ -2450,18 +2467,20 @@ public abstract class ElasticsearchTemplateTests {
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchQuery("message", "message"))
 				.withPageable(PageRequest.of(0, 10)).build();
 
-		ScrolledPage<SampleEntity> scroll = operations.startScroll(1000, searchQuery, SampleEntity.class, index);
-		List<SampleEntity> sampleEntities = new ArrayList<>();
+		ScrolledPage<SearchHit<SampleEntity>> scroll = operations.searchScrollStart(1000, searchQuery, SampleEntity.class,
+				index);
+		List<SearchHit<SampleEntity>> sampleEntities = new ArrayList<>();
 		while (scroll.hasContent()) {
 			sampleEntities.addAll(scroll.getContent());
-			scroll = operations.continueScroll(scroll.getScrollId(), 1000, SampleEntity.class);
+			scroll = operations.searchScrollContinue(scroll.getScrollId(), 1000, SampleEntity.class);
 		}
-		operations.clearScroll(scroll.getScrollId());
+		operations.searchScrollClear(scroll.getScrollId());
 
 		// then
 		assertThat(sampleEntities).hasSize(2);
-		assertThat(sampleEntities.stream().map(SampleEntity::getMessage).collect(Collectors.toList()))
-				.doesNotContain(notFindableMessage);
+		assertThat(
+				sampleEntities.stream().map(SearchHit::getContent).map(SampleEntity::getMessage).collect(Collectors.toList()))
+						.doesNotContain(notFindableMessage);
 	}
 
 	@Test // DATAES-565
@@ -2480,18 +2499,20 @@ public abstract class ElasticsearchTemplateTests {
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery())
 				.withPageable(PageRequest.of(0, 10)).withSourceFilter(sourceFilter).build();
 
-		ScrolledPage<SampleEntity> scroll = operations.startScroll(1000, searchQuery, SampleEntity.class, index);
-		List<SampleEntity> sampleEntities = new ArrayList<>();
+		ScrolledPage<SearchHit<SampleEntity>> scroll = operations.searchScrollStart(1000, searchQuery, SampleEntity.class,
+				index);
+		List<SearchHit<SampleEntity>> sampleEntities = new ArrayList<>();
 		while (scroll.hasContent()) {
 			sampleEntities.addAll(scroll.getContent());
-			scroll = operations.continueScroll(scroll.getScrollId(), 1000, SampleEntity.class);
+			scroll = operations.searchScrollContinue(scroll.getScrollId(), 1000, SampleEntity.class);
 		}
-		operations.clearScroll(scroll.getScrollId());
+		operations.searchScrollClear(scroll.getScrollId());
 		assertThat(sampleEntities).hasSize(3);
-		assertThat(sampleEntities.stream().map(SampleEntity::getId).collect(Collectors.toList()))
+		assertThat(sampleEntities.stream().map(SearchHit::getContent).map(SampleEntity::getId).collect(Collectors.toList()))
 				.doesNotContain((String) null);
-		assertThat(sampleEntities.stream().map(SampleEntity::getMessage).collect(Collectors.toList()))
-				.containsOnly((String) null);
+		assertThat(
+				sampleEntities.stream().map(SearchHit::getContent).map(SampleEntity::getMessage).collect(Collectors.toList()))
+						.containsOnly((String) null);
 	}
 
 	@Test // DATAES-457
@@ -2524,20 +2545,21 @@ public abstract class ElasticsearchTemplateTests {
 				.withSort(new FieldSortBuilder("message").order(SortOrder.DESC)).withPageable(PageRequest.of(0, 10)).build();
 
 		// when
-		ScrolledPage<SampleEntity> scroll = operations.startScroll(1000, searchQuery, SampleEntity.class, index);
-		List<SampleEntity> sampleEntities = new ArrayList<>();
+		ScrolledPage<SearchHit<SampleEntity>> scroll = operations.searchScrollStart(1000, searchQuery, SampleEntity.class,
+				index);
+		List<SearchHit<SampleEntity>> sampleEntities = new ArrayList<>();
 		while (scroll.hasContent()) {
 			sampleEntities.addAll(scroll.getContent());
-			scroll = operations.continueScroll(scroll.getScrollId(), 1000, SampleEntity.class);
+			scroll = operations.searchScrollContinue(scroll.getScrollId(), 1000, SampleEntity.class);
 		}
 
 		// then
 		assertThat(sampleEntities).hasSize(3);
-		assertThat(sampleEntities.get(0).getRate()).isEqualTo(sampleEntity2.getRate());
-		assertThat(sampleEntities.get(1).getRate()).isEqualTo(sampleEntity3.getRate());
-		assertThat(sampleEntities.get(1).getMessage()).isEqualTo(sampleEntity3.getMessage());
-		assertThat(sampleEntities.get(2).getRate()).isEqualTo(sampleEntity1.getRate());
-		assertThat(sampleEntities.get(2).getMessage()).isEqualTo(sampleEntity1.getMessage());
+		assertThat(sampleEntities.get(0).getContent().getRate()).isEqualTo(sampleEntity2.getRate());
+		assertThat(sampleEntities.get(1).getContent().getRate()).isEqualTo(sampleEntity3.getRate());
+		assertThat(sampleEntities.get(1).getContent().getMessage()).isEqualTo(sampleEntity3.getMessage());
+		assertThat(sampleEntities.get(2).getContent().getRate()).isEqualTo(sampleEntity1.getRate());
+		assertThat(sampleEntities.get(2).getContent().getMessage()).isEqualTo(sampleEntity1.getMessage());
 	}
 
 	@Test // DATAES-457
@@ -2571,20 +2593,21 @@ public abstract class ElasticsearchTemplateTests {
 				.build();
 
 		// when
-		ScrolledPage<SampleEntity> scroll = operations.startScroll(1000, searchQuery, SampleEntity.class, index);
-		List<SampleEntity> sampleEntities = new ArrayList<>();
+		ScrolledPage<SearchHit<SampleEntity>> scroll = operations.searchScrollStart(1000, searchQuery, SampleEntity.class,
+				index);
+		List<SearchHit<SampleEntity>> sampleEntities = new ArrayList<>();
 		while (scroll.hasContent()) {
 			sampleEntities.addAll(scroll.getContent());
-			scroll = operations.continueScroll(scroll.getScrollId(), 1000, SampleEntity.class);
+			scroll = operations.searchScrollContinue(scroll.getScrollId(), 1000, SampleEntity.class);
 		}
 
 		// then
 		assertThat(sampleEntities).hasSize(3);
-		assertThat(sampleEntities.get(0).getRate()).isEqualTo(sampleEntity2.getRate());
-		assertThat(sampleEntities.get(1).getRate()).isEqualTo(sampleEntity3.getRate());
-		assertThat(sampleEntities.get(1).getMessage()).isEqualTo(sampleEntity3.getMessage());
-		assertThat(sampleEntities.get(2).getRate()).isEqualTo(sampleEntity1.getRate());
-		assertThat(sampleEntities.get(2).getMessage()).isEqualTo(sampleEntity1.getMessage());
+		assertThat(sampleEntities.get(0).getContent().getRate()).isEqualTo(sampleEntity2.getRate());
+		assertThat(sampleEntities.get(1).getContent().getRate()).isEqualTo(sampleEntity3.getRate());
+		assertThat(sampleEntities.get(1).getContent().getMessage()).isEqualTo(sampleEntity3.getMessage());
+		assertThat(sampleEntities.get(2).getContent().getRate()).isEqualTo(sampleEntity1.getRate());
+		assertThat(sampleEntities.get(2).getContent().getMessage()).isEqualTo(sampleEntity1.getMessage());
 	}
 
 	@Test // DATAES-593
@@ -2607,14 +2630,14 @@ public abstract class ElasticsearchTemplateTests {
 				.build();
 
 		// when
-		Page<SampleEntity> page = operations.queryForPage(searchQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> page = operations.searchForPage(searchQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(page).isNotNull();
 		assertThat(page.getTotalElements()).isEqualTo(3);
 		assertThat(page.getContent()).hasSize(2);
-		assertThat(page.getContent().get(0).getMessage()).isEqualTo("message 1");
-		assertThat(page.getContent().get(1).getMessage()).isEqualTo("message 2");
+		assertThat(page.getContent().get(0).getContent().getMessage()).isEqualTo("message 1");
+		assertThat(page.getContent().get(1).getContent().getMessage()).isEqualTo("message 2");
 	}
 
 	private IndexQuery getIndexQuery(SampleEntity sampleEntity) {

--- a/src/test/java/org/springframework/data/elasticsearch/core/LogEntityTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/LogEntityTests.java
@@ -25,7 +25,6 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.List;
 
 import org.elasticsearch.ElasticsearchException;
 import org.junit.jupiter.api.BeforeEach;
@@ -90,7 +89,7 @@ public class LogEntityTests {
 
 		// when
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("ip", "10.10.10.1")).build();
-		List<LogEntity> entities = operations.queryForList(searchQuery, LogEntity.class, index);
+		SearchHits<LogEntity> entities = operations.search(searchQuery, LogEntity.class, index);
 
 		// then
 		assertThat(entities).isNotNull().hasSize(1);
@@ -103,7 +102,7 @@ public class LogEntityTests {
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(termQuery("ip", "10.10.10")).build();
 
 		assertThatThrownBy(() -> {
-			List<LogEntity> entities = operations.queryForList(searchQuery, LogEntity.class, index);
+			SearchHits<LogEntity> entities = operations.search(searchQuery, LogEntity.class, index);
 		}).isInstanceOf(ElasticsearchException.class);
 	}
 
@@ -113,7 +112,7 @@ public class LogEntityTests {
 		// when
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder()
 				.withQuery(rangeQuery("ip").from("10.10.10.1").to("10.10.10.3")).build();
-		List<LogEntity> entities = operations.queryForList(searchQuery, LogEntity.class, index);
+		SearchHits<LogEntity> entities = operations.search(searchQuery, LogEntity.class, index);
 
 		// then
 		assertThat(entities).isNotNull().hasSize(3);

--- a/src/test/java/org/springframework/data/elasticsearch/core/ReactiveElasticsearchTemplateUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ReactiveElasticsearchTemplateUnitTests.java
@@ -108,12 +108,12 @@ public class ReactiveElasticsearchTemplateUnitTests {
 	}
 
 	@Test // DATAES-504, DATAES-518
-	public void findShouldFallBackToDefaultIndexOptionsIfNotSet() {
+	public void searchShouldFallBackToDefaultIndexOptionsIfNotSet() {
 
 		ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
 		when(client.search(captor.capture())).thenReturn(Flux.empty());
 
-		template.find(new CriteriaQuery(new Criteria("*")).setPageable(PageRequest.of(0, 10)), SampleEntity.class) //
+		template.search(new CriteriaQuery(new Criteria("*")).setPageable(PageRequest.of(0, 10)), SampleEntity.class) //
 				.as(StepVerifier::create) //
 				.verifyComplete();
 
@@ -121,7 +121,7 @@ public class ReactiveElasticsearchTemplateUnitTests {
 	}
 
 	@Test // DATAES-504, DATAES-518
-	public void findShouldApplyIndexOptionsIfSet() {
+	public void searchShouldApplyIndexOptionsIfSet() {
 
 		ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
 		when(client.search(captor.capture())).thenReturn(Flux.empty());
@@ -129,7 +129,7 @@ public class ReactiveElasticsearchTemplateUnitTests {
 		template.setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
 
 		Query query = new CriteriaQuery(new Criteria("*")).setPageable(PageRequest.of(0, 10));
-		template.find(query, SampleEntity.class, index) //
+		template.search(query, SampleEntity.class, index) //
 				.as(StepVerifier::create) //
 				.verifyComplete();
 
@@ -137,13 +137,13 @@ public class ReactiveElasticsearchTemplateUnitTests {
 	}
 
 	@Test // DATAES-504
-	public void findShouldApplyPaginationIfSet() {
+	public void searchShouldApplyPaginationIfSet() {
 
 		ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
 		when(client.search(captor.capture())).thenReturn(Flux.empty());
 
 		Query query = new CriteriaQuery(new Criteria("*")).setPageable(PageRequest.of(2, 50));
-		template.find(query, SampleEntity.class, index) //
+		template.search(query, SampleEntity.class, index) //
 				.as(StepVerifier::create) //
 				.verifyComplete();
 
@@ -152,12 +152,12 @@ public class ReactiveElasticsearchTemplateUnitTests {
 	}
 
 	@Test // DATAES-504, DATAES-518
-	public void findShouldUseScrollIfPaginationNotSet() {
+	public void searchShouldUseScrollIfPaginationNotSet() {
 
 		ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
 		when(client.scroll(captor.capture())).thenReturn(Flux.empty());
 
-		template.find(new CriteriaQuery(new Criteria("*")).setPageable(Pageable.unpaged()), SampleEntity.class) //
+		template.search(new CriteriaQuery(new Criteria("*")).setPageable(Pageable.unpaged()), SampleEntity.class) //
 				.as(StepVerifier::create) //
 				.verifyComplete();
 

--- a/src/test/java/org/springframework/data/elasticsearch/core/geo/ElasticsearchTemplateGeoTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/geo/ElasticsearchTemplateGeoTests.java
@@ -39,6 +39,8 @@ import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.GeoPointField;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.IndexOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.query.Criteria;
 import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
@@ -139,12 +141,12 @@ public class ElasticsearchTemplateGeoTests {
 				new Criteria("location").within(new GeoPoint(45.7806d, 3.0875d), "20km"));
 
 		// when
-		List<AuthorMarkerEntity> geoAuthorsForGeoCriteria = operations.queryForList(geoLocationCriteriaQuery,
+		SearchHits<AuthorMarkerEntity> geoAuthorsForGeoCriteria = operations.search(geoLocationCriteriaQuery,
 				AuthorMarkerEntity.class, authorMarkerIndex);
 
 		// then
 		assertThat(geoAuthorsForGeoCriteria).hasSize(1);
-		assertThat(geoAuthorsForGeoCriteria.get(0).getName()).isEqualTo("Franck Marchand");
+		assertThat(geoAuthorsForGeoCriteria.getSearchHit(0).getContent().getName()).isEqualTo("Franck Marchand");
 	}
 
 	@Test
@@ -156,12 +158,12 @@ public class ElasticsearchTemplateGeoTests {
 				new Criteria("name").is("Mohsin Husen").and("location").within(new GeoPoint(51.5171d, 0.1062d), "20km"));
 
 		// when
-		List<AuthorMarkerEntity> geoAuthorsForGeoCriteria2 = operations.queryForList(geoLocationCriteriaQuery2,
+		SearchHits<AuthorMarkerEntity> geoAuthorsForGeoCriteria2 = operations.search(geoLocationCriteriaQuery2,
 				AuthorMarkerEntity.class, authorMarkerIndex);
 
 		// then
 		assertThat(geoAuthorsForGeoCriteria2).hasSize(1);
-		assertThat(geoAuthorsForGeoCriteria2.get(0).getName()).isEqualTo("Mohsin Husen");
+		assertThat(geoAuthorsForGeoCriteria2.getSearchHit(0).getContent().getName()).isEqualTo("Mohsin Husen");
 	}
 
 	@Test
@@ -172,7 +174,7 @@ public class ElasticsearchTemplateGeoTests {
 		CriteriaQuery geoLocationCriteriaQuery = new CriteriaQuery(
 				new Criteria("locationAsString").within(new GeoPoint(51.000000, 0.100000), "1km"));
 		// when
-		List<LocationMarkerEntity> geoAuthorsForGeoCriteria = operations.queryForList(geoLocationCriteriaQuery,
+		SearchHits<LocationMarkerEntity> geoAuthorsForGeoCriteria = operations.search(geoLocationCriteriaQuery,
 				LocationMarkerEntity.class, locationMarkerIndex);
 
 		// then
@@ -188,7 +190,7 @@ public class ElasticsearchTemplateGeoTests {
 				new Criteria("locationAsArray").within(new GeoPoint(51.001000, 0.10100), "1km"));
 
 		// when
-		List<LocationMarkerEntity> geoAuthorsForGeoCriteria = operations.queryForList(geoLocationCriteriaQuery,
+		SearchHits<LocationMarkerEntity> geoAuthorsForGeoCriteria = operations.search(geoLocationCriteriaQuery,
 				LocationMarkerEntity.class, locationMarkerIndex);
 
 		// then
@@ -203,7 +205,7 @@ public class ElasticsearchTemplateGeoTests {
 		CriteriaQuery geoLocationCriteriaQuery = new CriteriaQuery(
 				new Criteria("locationAsArray").within("51.001000, 0.10100", "1km"));
 		// when
-		List<LocationMarkerEntity> geoAuthorsForGeoCriteria = operations.queryForList(geoLocationCriteriaQuery,
+		SearchHits<LocationMarkerEntity> geoAuthorsForGeoCriteria = operations.search(geoLocationCriteriaQuery,
 				LocationMarkerEntity.class, locationMarkerIndex);
 
 		// then
@@ -218,7 +220,7 @@ public class ElasticsearchTemplateGeoTests {
 		CriteriaQuery geoLocationCriteriaQuery = new CriteriaQuery(new Criteria("locationAsArray").within("u1044", "3km"));
 
 		// when
-		List<LocationMarkerEntity> geoAuthorsForGeoCriteria = operations.queryForList(geoLocationCriteriaQuery,
+		SearchHits<LocationMarkerEntity> geoAuthorsForGeoCriteria = operations.search(geoLocationCriteriaQuery,
 				LocationMarkerEntity.class, locationMarkerIndex);
 
 		// then
@@ -234,7 +236,7 @@ public class ElasticsearchTemplateGeoTests {
 				.withFilter(QueryBuilders.geoBoundingBoxQuery("locationAsArray").setCorners(52, -1, 50, 1));
 
 		// when
-		List<LocationMarkerEntity> geoAuthorsForGeoCriteria = operations.queryForList(queryBuilder.build(),
+		SearchHits<LocationMarkerEntity> geoAuthorsForGeoCriteria = operations.search(queryBuilder.build(),
 				LocationMarkerEntity.class, locationMarkerIndex);
 
 		// then
@@ -250,12 +252,12 @@ public class ElasticsearchTemplateGeoTests {
 				new Criteria("location").boundedBy(new GeoBox(new GeoPoint(53.5171d, 0), new GeoPoint(49.5171d, 0.2062d))));
 
 		// when
-		List<AuthorMarkerEntity> geoAuthorsForGeoCriteria3 = operations.queryForList(geoLocationCriteriaQuery3,
+		SearchHits<AuthorMarkerEntity> geoAuthorsForGeoCriteria3 = operations.search(geoLocationCriteriaQuery3,
 				AuthorMarkerEntity.class, authorMarkerIndex);
 
 		// then
 		assertThat(geoAuthorsForGeoCriteria3).hasSize(2);
-		assertThat(geoAuthorsForGeoCriteria3.stream().map(AuthorMarkerEntity::getName))
+		assertThat(geoAuthorsForGeoCriteria3.stream().map(SearchHit::getContent).map(AuthorMarkerEntity::getName))
 				.containsExactlyInAnyOrder("Mohsin Husen", "Rizwan Idrees");
 	}
 
@@ -268,12 +270,12 @@ public class ElasticsearchTemplateGeoTests {
 				new Criteria("location").boundedBy(Geohash.stringEncode(0, 53.5171d), Geohash.stringEncode(0.2062d, 49.5171d)));
 
 		// when
-		List<AuthorMarkerEntity> geoAuthorsForGeoCriteria3 = operations.queryForList(geoLocationCriteriaQuery3,
+		SearchHits<AuthorMarkerEntity> geoAuthorsForGeoCriteria3 = operations.search(geoLocationCriteriaQuery3,
 				AuthorMarkerEntity.class, authorMarkerIndex);
 
 		// then
 		assertThat(geoAuthorsForGeoCriteria3).hasSize(2);
-		assertThat(geoAuthorsForGeoCriteria3.stream().map(AuthorMarkerEntity::getName))
+		assertThat(geoAuthorsForGeoCriteria3.stream().map(SearchHit::getContent).map(AuthorMarkerEntity::getName))
 				.containsExactlyInAnyOrder("Mohsin Husen", "Rizwan Idrees");
 	}
 
@@ -286,12 +288,12 @@ public class ElasticsearchTemplateGeoTests {
 				new Criteria("location").boundedBy(new GeoPoint(53.5171d, 0), new GeoPoint(49.5171d, 0.2062d)));
 
 		// when
-		List<AuthorMarkerEntity> geoAuthorsForGeoCriteria3 = operations.queryForList(geoLocationCriteriaQuery3,
+		SearchHits<AuthorMarkerEntity> geoAuthorsForGeoCriteria3 = operations.search(geoLocationCriteriaQuery3,
 				AuthorMarkerEntity.class, authorMarkerIndex);
 
 		// then
 		assertThat(geoAuthorsForGeoCriteria3).hasSize(2);
-		assertThat(geoAuthorsForGeoCriteria3.stream().map(AuthorMarkerEntity::getName))
+		assertThat(geoAuthorsForGeoCriteria3.stream().map(SearchHit::getContent).map(AuthorMarkerEntity::getName))
 				.containsExactlyInAnyOrder("Mohsin Husen", "Rizwan Idrees");
 	}
 
@@ -304,12 +306,12 @@ public class ElasticsearchTemplateGeoTests {
 				new Criteria("location").boundedBy(new Point(53.5171d, 0), new Point(49.5171d, 0.2062d)));
 
 		// when
-		List<AuthorMarkerEntity> geoAuthorsForGeoCriteria3 = operations.queryForList(geoLocationCriteriaQuery3,
+		SearchHits<AuthorMarkerEntity> geoAuthorsForGeoCriteria3 = operations.search(geoLocationCriteriaQuery3,
 				AuthorMarkerEntity.class, authorMarkerIndex);
 
 		// then
 		assertThat(geoAuthorsForGeoCriteria3).hasSize(2);
-		assertThat(geoAuthorsForGeoCriteria3.stream().map(AuthorMarkerEntity::getName))
+		assertThat(geoAuthorsForGeoCriteria3.stream().map(SearchHit::getContent).map(AuthorMarkerEntity::getName))
 				.containsExactlyInAnyOrder("Mohsin Husen", "Rizwan Idrees");
 	}
 
@@ -332,17 +334,17 @@ public class ElasticsearchTemplateGeoTests {
 				.withFilter(QueryBuilders.geoBoundingBoxQuery("locationAsGeoHash").setCorners("u10j46mkfek"));
 
 		// when
-		List<LocationMarkerEntity> result1 = operations.queryForList(location1.build(), LocationMarkerEntity.class,
+		SearchHits<LocationMarkerEntity> result1 = operations.search(location1.build(), LocationMarkerEntity.class,
 				locationMarkerIndex);
-		List<LocationMarkerEntity> result2 = operations.queryForList(location2.build(), LocationMarkerEntity.class,
+		SearchHits<LocationMarkerEntity> result2 = operations.search(location2.build(), LocationMarkerEntity.class,
 				locationMarkerIndex);
-		List<LocationMarkerEntity> result3 = operations.queryForList(location3.build(), LocationMarkerEntity.class,
+		SearchHits<LocationMarkerEntity> result3 = operations.search(location3.build(), LocationMarkerEntity.class,
 				locationMarkerIndex);
-		List<LocationMarkerEntity> result4 = operations.queryForList(location4.build(), LocationMarkerEntity.class,
+		SearchHits<LocationMarkerEntity> result4 = operations.search(location4.build(), LocationMarkerEntity.class,
 				locationMarkerIndex);
-		List<LocationMarkerEntity> result5 = operations.queryForList(location5.build(), LocationMarkerEntity.class,
+		SearchHits<LocationMarkerEntity> result5 = operations.search(location5.build(), LocationMarkerEntity.class,
 				locationMarkerIndex);
-		List<LocationMarkerEntity> result11 = operations.queryForList(location11.build(), LocationMarkerEntity.class,
+		SearchHits<LocationMarkerEntity> result11 = operations.search(location11.build(), LocationMarkerEntity.class,
 				locationMarkerIndex);
 
 		// then

--- a/src/test/java/org/springframework/data/elasticsearch/core/query/CriteriaQueryTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/query/CriteriaQueryTests.java
@@ -42,6 +42,7 @@ import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.Score;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.junit.jupiter.ElasticsearchRestTemplateConfiguration;
 import org.springframework.data.elasticsearch.junit.jupiter.SpringIntegrationTest;
@@ -93,7 +94,7 @@ public class CriteriaQueryTests {
 				new Criteria("message").contains("test").and("message").contains("some"));
 
 		// when
-		SampleEntity sampleEntity1 = operations.queryForObject(criteriaQuery, SampleEntity.class, index);
+		SearchHit<SampleEntity> sampleEntity1 = operations.searchOne(criteriaQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(sampleEntity1).isNotNull();
@@ -136,7 +137,7 @@ public class CriteriaQueryTests {
 				new Criteria("message").contains("some").or("message").contains("test"));
 
 		// when
-		Page<SampleEntity> page = operations.queryForPage(criteriaQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> page = operations.searchForPage(criteriaQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(page).isNotNull();
@@ -167,7 +168,7 @@ public class CriteriaQueryTests {
 
 		// when
 
-		Page<SampleEntity> page = operations.queryForPage(criteriaQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> page = operations.searchForPage(criteriaQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(page).isNotNull();
@@ -198,7 +199,7 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria().or(new Criteria("message").contains("some")));
 
 		// when
-		Page<SampleEntity> page = operations.queryForPage(criteriaQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> page = operations.searchForPage(criteriaQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(page).isNotNull();
@@ -227,7 +228,7 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("message").is("some message"));
 
 		// when
-		Page<SampleEntity> page = operations.queryForPage(criteriaQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> page = operations.searchForPage(criteriaQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(criteriaQuery.getCriteria().getField().getName()).isEqualTo("message");
@@ -269,7 +270,7 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("message").is("some message"));
 
 		// when
-		Page<SampleEntity> page = operations.queryForPage(criteriaQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> page = operations.searchForPage(criteriaQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(criteriaQuery.getCriteria().getField().getName()).isEqualTo("message");
@@ -312,7 +313,7 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(criteria);
 
 		// when
-		SampleEntity sampleEntity = operations.queryForObject(criteriaQuery, SampleEntity.class, index);
+		SearchHit<SampleEntity> sampleEntity = operations.searchOne(criteriaQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(criteriaQuery.getCriteria().getField().getName()).isEqualTo("message");
@@ -354,7 +355,7 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(criteria);
 
 		// when
-		SampleEntity sampleEntity = operations.queryForObject(criteriaQuery, SampleEntity.class, index);
+		SearchHit<SampleEntity> sampleEntity = operations.searchOne(criteriaQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(criteriaQuery.getCriteria().getField().getName()).isEqualTo("message");
@@ -395,7 +396,7 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("message").contains("contains"));
 
 		// when
-		SampleEntity sampleEntity = operations.queryForObject(criteriaQuery, SampleEntity.class, index);
+		SearchHit<SampleEntity> sampleEntity = operations.searchOne(criteriaQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(criteriaQuery.getCriteria().getField().getName()).isEqualTo("message");
@@ -436,7 +437,7 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("message").expression("+elasticsearch || test"));
 
 		// when
-		SampleEntity sampleEntity = operations.queryForObject(criteriaQuery, SampleEntity.class, index);
+		SearchHit<SampleEntity> sampleEntity = operations.searchOne(criteriaQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(criteriaQuery.getCriteria().getField().getName()).isEqualTo("message");
@@ -478,7 +479,7 @@ public class CriteriaQueryTests {
 				new Criteria("message").startsWith("some").endsWith("search").contains("message").is("some message search"));
 
 		// when
-		SampleEntity sampleEntity = operations.queryForObject(criteriaQuery, SampleEntity.class, index);
+		SearchHit<SampleEntity> sampleEntity = operations.searchOne(criteriaQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(criteriaQuery.getCriteria().getField().getName()).isEqualTo("message");
@@ -519,12 +520,12 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("message").is("foo").not());
 
 		// when
-		Page<SampleEntity> page = operations.queryForPage(criteriaQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> page = operations.searchForPage(criteriaQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(criteriaQuery.getCriteria().isNegating()).isTrue();
 		assertThat(page).isNotNull();
-		assertThat(page.iterator().next().getMessage()).doesNotContain("foo");
+		assertThat(page.iterator().next().getContent().getMessage()).doesNotContain("foo");
 	}
 
 	@Test
@@ -563,7 +564,7 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("rate").between(100, 150));
 
 		// when
-		SampleEntity sampleEntity = operations.queryForObject(criteriaQuery, SampleEntity.class, index);
+		SearchHit<SampleEntity> sampleEntity = operations.searchOne(criteriaQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(sampleEntity).isNotNull();
@@ -605,7 +606,7 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("rate").between(350, null));
 
 		// when
-		Page<SampleEntity> page = operations.queryForPage(criteriaQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> page = operations.searchForPage(criteriaQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(page).isNotNull();
@@ -648,7 +649,7 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("rate").between(null, 550));
 
 		// when
-		Page<SampleEntity> page = operations.queryForPage(criteriaQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> page = operations.searchForPage(criteriaQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(page).isNotNull();
@@ -691,7 +692,7 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("rate").lessThanEqual(750));
 
 		// when
-		Page<SampleEntity> page = operations.queryForPage(criteriaQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> page = operations.searchForPage(criteriaQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(page).isNotNull();
@@ -734,7 +735,7 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("rate").greaterThanEqual(950));
 
 		// when
-		Page<SampleEntity> page = operations.queryForPage(criteriaQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> page = operations.searchForPage(criteriaQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(page).isNotNull();
@@ -777,7 +778,7 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("message").contains("foo").boost(1));
 
 		// when
-		Page<SampleEntity> page = operations.queryForPage(criteriaQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> page = operations.searchForPage(criteriaQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(page.getTotalElements()).isGreaterThanOrEqualTo(1);
@@ -800,11 +801,11 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(
 				new Criteria("message").contains("a").or(new Criteria("message").contains("b")));
 		criteriaQuery.setMinScore(2.0F);
-		Page<SampleEntity> page = operations.queryForPage(criteriaQuery, SampleEntity.class, index);
+		Page<SearchHit<SampleEntity>> page = operations.searchForPage(criteriaQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(page.getTotalElements()).isEqualTo(1);
-		assertThat(page.getContent().get(0).getMessage()).isEqualTo("ab");
+		assertThat(page.getContent().get(0).getContent().getMessage()).isEqualTo("ab");
 	}
 
 	@Test // DATAES-213
@@ -826,7 +827,7 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("message").is("Hello World!"));
 
 		// when
-		SampleEntity sampleEntity1 = operations.queryForObject(criteriaQuery, SampleEntity.class, index);
+		SearchHit<SampleEntity> sampleEntity1 = operations.searchOne(criteriaQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(sampleEntity1).isNotNull();

--- a/src/test/java/org/springframework/data/elasticsearch/repositories/custommethod/CustomMethodRepositoryBaseTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repositories/custommethod/CustomMethodRepositoryBaseTests.java
@@ -1333,6 +1333,20 @@ public abstract class CustomMethodRepositoryBaseTests {
 		assertThat(stream.count()).isEqualTo(10L);
 	}
 
+	@Test // DATAES-672
+	void streamMethodShouldNotReturnSearchHits() {
+		// given
+		List<SampleEntity> entities = createSampleEntities("abc", 2);
+		repository.saveAll(entities);
+
+		// when
+		Stream<SampleEntity> stream = streamingRepository.findByType("abc");
+
+		// then
+		assertThat(stream).isNotNull();
+		stream.forEach(o -> assertThat(o).isInstanceOf(SampleEntity.class));
+	}
+
 	private List<SampleEntity> createSampleEntities(String type, int numberOfEntities) {
 
 		List<SampleEntity> entities = new ArrayList<>();

--- a/src/test/java/org/springframework/data/elasticsearch/repositories/setting/dynamic/DynamicSettingAndMappingEntityRepositoryTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repositories/setting/dynamic/DynamicSettingAndMappingEntityRepositoryTests.java
@@ -17,7 +17,6 @@ package org.springframework.data.elasticsearch.repositories.setting.dynamic;
 
 import static org.assertj.core.api.Assertions.*;
 
-import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang.RandomStringUtils;
@@ -32,6 +31,7 @@ import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Mapping;
 import org.springframework.data.elasticsearch.annotations.Setting;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.query.NativeSearchQuery;
 import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
@@ -109,13 +109,14 @@ public class DynamicSettingAndMappingEntityRepositoryTests {
 		IndexCoordinates index = IndexCoordinates.of("test-index-dynamic-setting-and-mapping")
 				.withTypes("test-setting-type");
 		long count = operations.count(searchQuery, DynamicSettingAndMappingEntity.class, index);
-		List<DynamicSettingAndMappingEntity> entityList = operations.queryForList(searchQuery,
+		SearchHits<DynamicSettingAndMappingEntity> entityList = operations.search(searchQuery,
 				DynamicSettingAndMappingEntity.class, index);
 
 		// then
 		assertThat(count).isEqualTo(1L);
 		assertThat(entityList).isNotNull().hasSize(1);
-		assertThat(entityList.get(0).getEmail()).isEqualTo(dynamicSettingAndMappingEntity1.getEmail());
+		assertThat(entityList.getSearchHit(0).getContent().getEmail())
+				.isEqualTo(dynamicSettingAndMappingEntity1.getEmail());
 	}
 
 	@Test

--- a/src/test/java/org/springframework/data/elasticsearch/repositories/synonym/SynonymRepositoryTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repositories/synonym/SynonymRepositoryTests.java
@@ -19,8 +19,6 @@ import static org.assertj.core.api.Assertions.*;
 
 import lombok.Data;
 
-import java.util.List;
-
 import org.elasticsearch.index.query.QueryBuilders;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,6 +30,7 @@ import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Mapping;
 import org.springframework.data.elasticsearch.annotations.Setting;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
 import org.springframework.data.elasticsearch.junit.jupiter.ElasticsearchRestTemplateConfiguration;
@@ -77,12 +76,11 @@ public class SynonymRepositoryTests {
 		repository.save(entry1);
 		repository.save(entry2);
 
-		// when
-
+		// whe
 		// then
 		assertThat(repository.count()).isEqualTo(2L);
 
-		List<SynonymEntity> synonymEntities = operations.queryForList(
+		SearchHits<SynonymEntity> synonymEntities = operations.search(
 				new NativeSearchQueryBuilder().withQuery(QueryBuilders.termQuery("text", "british")).build(),
 				SynonymEntity.class, IndexCoordinates.of("test-index-synonym").withTypes("synonym-type"));
 		assertThat(synonymEntities).hasSize(1);


### PR DESCRIPTION
This Draft-PR  introduces `SearchHit<T>` which will be returned from the `SearchOperations` methods instead of a plain `T`. It currently has as additional information the score of the hit, more stuff like highlights, sort etc. will be added later with new issues for that.

Repositories don't return these as it would be impossible to distinguish at runtime of a repository method should return `List<T>` or `List<SearchHit<T>>`. This will be adresses in a separate issue to enable this for repositories by introducing `SearchHits<T>`.

This is a draft PR as these changes are in the non-reactive part currently. I will add the `SearchHit` to the reactive part in the next days probably.