### PR TITLE
DATAES-714 - Sort results should be returned in the SearchHits.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/SearchHit.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/SearchHit.java
@@ -15,6 +15,11 @@
  */
 package org.springframework.data.elasticsearch.core;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.springframework.lang.Nullable;
 
 /**
@@ -28,11 +33,13 @@ public class SearchHit<T> {
 
 	private final String id;
 	private final float score;
+	private final List<Object> sortValues;
 	private final T content;
 
-	public SearchHit(@Nullable String id, float score, T content) {
+	public SearchHit(@Nullable String id, float score, Object[] sortValues, T content) {
 		this.id = id;
 		this.score = score;
+		this.sortValues = (sortValues != null) ? Arrays.asList(sortValues) : new ArrayList<>();
 		this.content = content;
 	}
 
@@ -55,12 +62,16 @@ public class SearchHit<T> {
 		return content;
 	}
 
+	/**
+	 * @return the sort values if the query had a sort criterion.
+	 */
+	public List<Object> getSortValues() {
+		return Collections.unmodifiableList(sortValues);
+	}
+
 	@Override
 	public String toString() {
-		return "SearchHit{" +
-				"id='" + id + '\'' +
-				", score=" + score +
-				", content=" + content +
-				'}';
+		return "SearchHit{" + "id='" + id + '\'' + ", score=" + score + ", sortValues=" + sortValues + ", content="
+				+ content + '}';
 	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/convert/MappingElasticsearchConverter.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/convert/MappingElasticsearchConverter.java
@@ -601,9 +601,10 @@ public class MappingElasticsearchConverter
 	public <T> SearchHit<T> read(Class<T> type, SearchDocument searchDocument) {
 		String id = searchDocument.hasId() ? searchDocument.getId() : null;
 		float score = searchDocument.getScore();
+		Object[] sortValues = searchDocument.getSortValues();
 		T content = mapDocument(searchDocument, type);
 
-		return new SearchHit<T>(id, score, content);
+		return new SearchHit<T>(id, score, sortValues, content);
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/elasticsearch/core/document/DocumentAdapters.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/document/DocumentAdapters.java
@@ -142,7 +142,7 @@ public class DocumentAdapters {
 		BytesReference sourceRef = source.getSourceRef();
 
 		if (sourceRef == null || sourceRef.length() == 0) {
-			return new SearchDocumentAdapter(source.getScore(), source.getFields(),
+			return new SearchDocumentAdapter(source.getScore(), source.getSortValues(), source.getFields(),
 					fromDocumentFields(source, source.getId(), source.getVersion()));
 		}
 
@@ -153,7 +153,7 @@ public class DocumentAdapters {
 			document.setVersion(source.getVersion());
 		}
 
-		return new SearchDocumentAdapter(source.getScore(), source.getFields(), document);
+		return new SearchDocumentAdapter(source.getScore(), source.getSortValues(), source.getFields(), document);
 	}
 
 	/**
@@ -438,11 +438,13 @@ public class DocumentAdapters {
 	static class SearchDocumentAdapter implements SearchDocument {
 
 		private final float score;
+		private final Object[] sortValues;
 		private final Map<String, List<Object>> fields = new HashMap<>();
 		private final Document delegate;
 
-		SearchDocumentAdapter(float score, Map<String, DocumentField> fields, Document delegate) {
+		SearchDocumentAdapter(float score, Object[] sortValues, Map<String, DocumentField> fields, Document delegate) {
 			this.score = score;
+			this.sortValues = sortValues;
 			this.delegate = delegate;
 			fields.forEach((name, documentField) -> this.fields.put(name, documentField.getValues()));
 		}
@@ -474,6 +476,15 @@ public class DocumentAdapters {
 		@Override
 		public Map<String, List<Object>> getFields() {
 			return fields;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.elasticsearch.core.document.SearchDocument#getSortValues()
+		 */
+		@Override
+		public Object[] getSortValues() {
+			return sortValues;
 		}
 
 		/*

--- a/src/main/java/org/springframework/data/elasticsearch/core/document/SearchDocument.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/document/SearchDocument.java
@@ -18,6 +18,8 @@ package org.springframework.data.elasticsearch.core.document;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.lang.Nullable;
+
 /**
  * Extension to {@link Document} exposing a search response related data.
  *
@@ -45,11 +47,20 @@ public interface SearchDocument extends Document {
 	 * 
 	 * @param name the field name
 	 */
+	@Nullable
 	default <V> V getFieldValue(final String name) {
 		List<Object> values = getFields().get(name);
 		if (values == null || values.isEmpty()) {
 			return null;
 		}
 		return (V) values.get(0);
+	}
+
+	/**
+	 * @return the sort values for the search hit
+	 */
+	@Nullable
+	default Object[] getSortValues() {
+		return null;
 	}
 }


### PR DESCRIPTION
Adding the sortValues returned with a search to the `SearchHit<T>` instance that we now return for searches.