### PR TITLE
DATAES-713 - Transfer returned aggregations from the AggregatedPage to the…

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
@@ -226,19 +226,7 @@ public class ElasticsearchRestTemplate extends AbstractElasticsearchTemplate {
 	}
 
 	@Override
-	public <T> T query(Query query, ResultsExtractor<T> resultsExtractor, @Nullable Class<T> clazz,
-			IndexCoordinates index) {
-		SearchRequest searchRequest = requestFactory.searchRequest(query, clazz, index);
-		try {
-			SearchResponse result = client.search(searchRequest, RequestOptions.DEFAULT);
-			return resultsExtractor.extract(result);
-		} catch (IOException e) {
-			throw new ElasticsearchException("Error for search request: " + searchRequest.toString(), e);
-		}
-	}
-
-	@Override
-	public <T> AggregatedPage<SearchHit<T>> searchForPage(Query query, Class<T> clazz, IndexCoordinates index) {
+	public <T> SearchHits<T> search(Query query, Class<T> clazz, IndexCoordinates index) {
 		SearchRequest searchRequest = requestFactory.searchRequest(query, clazz, index);
 		SearchResponse response;
 		try {
@@ -246,7 +234,7 @@ public class ElasticsearchRestTemplate extends AbstractElasticsearchTemplate {
 		} catch (IOException e) {
 			throw new ElasticsearchException("Error for search request: " + searchRequest.toString(), e);
 		}
-		return elasticsearchConverter.mapResults(SearchDocumentResponse.from(response), clazz, query.getPageable());
+		return elasticsearchConverter.read(clazz, SearchDocumentResponse.from(response));
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
@@ -196,17 +196,10 @@ public class ElasticsearchTemplate extends AbstractElasticsearchTemplate {
 	}
 
 	@Override
-	public <T> T query(Query query, ResultsExtractor<T> resultsExtractor, Class<T> clazz, IndexCoordinates index) {
+	public <T> SearchHits<T> search(Query query, Class<T> clazz, IndexCoordinates index) {
 		SearchRequestBuilder searchRequestBuilder = requestFactory.searchRequestBuilder(client, query, clazz, index);
 		SearchResponse response = getSearchResponse(searchRequestBuilder);
-		return resultsExtractor.extract(response);
-	}
-
-	@Override
-	public <T> AggregatedPage<SearchHit<T>> searchForPage(Query query, Class<T> clazz, IndexCoordinates index) {
-		SearchRequestBuilder searchRequestBuilder = requestFactory.searchRequestBuilder(client, query, clazz, index);
-		SearchResponse response = getSearchResponse(searchRequestBuilder);
-		return elasticsearchConverter.mapResults(SearchDocumentResponse.from(response), clazz, query.getPageable());
+		return elasticsearchConverter.read(clazz, SearchDocumentResponse.from(response));
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/elasticsearch/core/ScoredPage.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ScoredPage.java
@@ -22,7 +22,9 @@ import org.springframework.data.domain.Page;
  * 
  * @param <T>
  * @author Sascha Woo
+ * @deprecated since 4.0, use {@link org.springframework.data.elasticsearch.core.SearchHits} to return values.
  */
+@Deprecated
 public interface ScoredPage<T> extends Page<T> {
 
 	float getMaxScore();

--- a/src/main/java/org/springframework/data/elasticsearch/core/SearchHitSupport.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/SearchHitSupport.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.aggregation.AggregatedPage;
 import org.springframework.data.elasticsearch.core.aggregation.impl.AggregatedPageImpl;
 
@@ -80,5 +81,17 @@ public final class SearchHitSupport {
 		}
 
 		return result;
+	}
+
+	/**
+	 * Builds an {@link AggregatedPage} with the {@link SearchHit} objects from a {@link SearchHits} object.
+	 * 
+	 * @param searchHits, must not be {@literal null}.
+	 * @param pageable, must not be {@literal null}.
+	 * @return the created Page
+	 */
+	public static <T> AggregatedPage<SearchHit<T>> page(SearchHits<T> searchHits, Pageable pageable) {
+		return new AggregatedPageImpl<>(searchHits.getSearchHits(), pageable, searchHits.getTotalHits(),
+				searchHits.getAggregations(), searchHits.getScrollId(), searchHits.getMaxScore());
 	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/SearchHits.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/SearchHits.java
@@ -18,9 +18,10 @@ package org.springframework.data.elasticsearch.core;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Stream;
 
+import org.elasticsearch.search.aggregations.Aggregations;
 import org.springframework.data.util.Streamable;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -33,22 +34,28 @@ import org.springframework.util.StringUtils;
  */
 public class SearchHits<T> implements Streamable<SearchHit<T>> {
 
-	private final List<? extends SearchHit<T>> searchHits;
 	private final long totalHits;
 	private final float maxScore;
+	private final String scrollId;
+	private final List<? extends SearchHit<T>> searchHits;
+	private final Aggregations aggregations;
 
 	/**
-	 * @param searchHits must not be {@literal null}
 	 * @param totalHits
 	 * @param maxScore
+	 * @param searchHits must not be {@literal null}
+	 * @param aggregations
 	 */
-	public SearchHits(List<? extends SearchHit<T>> searchHits, long totalHits, float maxScore) {
-		this.totalHits = totalHits;
-		this.maxScore = maxScore;
+	public SearchHits(long totalHits, float maxScore, @Nullable String scrollId,  List<? extends SearchHit<T>> searchHits,
+			@Nullable Aggregations aggregations) {
 
 		Assert.notNull(searchHits, "searchHits must not be null");
 
+		this.totalHits = totalHits;
+		this.maxScore = maxScore;
+		this.scrollId = scrollId;
 		this.searchHits = searchHits;
+		this.aggregations = aggregations;
 	}
 
 	@Override
@@ -56,20 +63,34 @@ public class SearchHits<T> implements Streamable<SearchHit<T>> {
 		return (Iterator<SearchHit<T>>) searchHits.iterator();
 	}
 
+	/**
+	 * @return the number of total hits.
+	 */
 	// region getter
+	public long getTotalHits() {
+		return totalHits;
+	}
+
+	/**
+	 * @return the maximum score
+	 */
+	public float getMaxScore() {
+		return maxScore;
+	}
+
+	/**
+	 * @return the scroll id
+	 */
+	@Nullable
+	public String getScrollId() {
+		return scrollId;
+	}
+
 	/**
 	 * @return the contained {@link SearchHit}s.
 	 */
 	public List<SearchHit<T>> getSearchHits() {
 		return Collections.unmodifiableList(searchHits);
-	}
-
-	public long getTotalHits() {
-		return totalHits;
-	}
-
-	public float getMaxScore() {
-		return maxScore;
 	}
 	// endregion
 
@@ -86,7 +107,30 @@ public class SearchHits<T> implements Streamable<SearchHit<T>> {
 
 	@Override
 	public String toString() {
-		return "SearchHits{" + "totalHits=" + totalHits + ", maxScore=" + maxScore + ", searchHits="
-				+ StringUtils.collectionToCommaDelimitedString(searchHits) + '}';
+		return "SearchHits{" +
+				"totalHits=" + totalHits +
+				", maxScore=" + maxScore +
+				", scrollId='" + scrollId + '\'' +
+				", searchHits=" + StringUtils.collectionToCommaDelimitedString(searchHits) +
+				", aggregations=" + aggregations +
+				'}';
 	}
+
+	/**
+	 * @return true if aggregations are available
+	 */
+	// region aggregations
+	public boolean hasAggregations() {
+		return aggregations != null;
+	}
+
+	/**
+	 * @return the aggregations.
+	 */
+	@Nullable
+	public Aggregations getAggregations() {
+		return aggregations;
+	}
+	// endregion
+
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/aggregation/AggregatedPage.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/aggregation/AggregatedPage.java
@@ -9,7 +9,9 @@ import org.springframework.data.elasticsearch.core.ScrolledPage;
  * @author Petar Tahchiev
  * @author Sascha Woo
  * @author Peter-Josef Meisch
+ * @deprecated since 4.0, use {@link org.springframework.data.elasticsearch.core.SearchHits} to return values.
  */
+@Deprecated
 public interface AggregatedPage<T> extends ScrolledPage<T>, ScoredPage<T> {
 
 	boolean hasAggregations();

--- a/src/main/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchConverter.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchConverter.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.springframework.data.convert.EntityConverter;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.aggregation.AggregatedPage;
 import org.springframework.data.elasticsearch.core.document.Document;
 import org.springframework.data.elasticsearch.core.document.SearchDocument;
@@ -85,11 +86,21 @@ public interface ElasticsearchConverter
 	<T> T mapDocument(@Nullable Document document, Class<T> type);
 
 	/**
-	 * builds a {@link SearchHit} from a {@link SearchDocument}.
-	 * 
-	 * @param searchDocument must not be {@literal null}
+	 * builds a {@link SearchHits} from a {@link SearchDocumentResponse}.
 	 * @param <T> the clazz of the type, must not be {@literal null}.
 	 * @param type the type of the returned data, must not be {@literal null}.
+	 * @param searchDocumentResponse the response to read from, must not be {@literal null}.
+	 * @return a SearchHits object
+	 * @since 4.0
+	 */
+	<T> SearchHits<T> read(Class<T> type, SearchDocumentResponse searchDocumentResponse);
+
+	/**
+	 * builds a {@link SearchHit} from a {@link SearchDocument}.
+	 *
+	 * @param <T> the clazz of the type, must not be {@literal null}.
+	 * @param type the type of the returned data, must not be {@literal null}.
+	 * @param searchDocument must not be {@literal null}
 	 * @return SearchHit with all available information filled in
 	 * @since 4.0
 	 */
@@ -108,7 +119,7 @@ public interface ElasticsearchConverter
 
 	/**
 	 * Map an object to a {@link Document}.
-	 * 
+	 *
 	 * @param source
 	 * @return will not be {@literal null}.
 	 */

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchPartQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchPartQuery.java
@@ -18,6 +18,7 @@ package org.springframework.data.elasticsearch.repository.query;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHitSupport;
+import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentProperty;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
@@ -71,7 +72,8 @@ public class ElasticsearchPartQuery extends AbstractElasticsearchRepositoryQuery
 			elasticsearchOperations.delete(query, clazz, index);
 		} else if (queryMethod.isPageQuery()) {
 			query.setPageable(accessor.getPageable());
-			result = elasticsearchOperations.searchForPage(query, clazz, index);
+			SearchHits<?> searchHits = elasticsearchOperations.search(query, clazz, index);
+			result = SearchHitSupport.page(searchHits, query.getPageable());
 		} else if (queryMethod.isStreamQuery()) {
 			Class<?> entityType = clazz;
 			if (accessor.getPageable().isUnpaged()) {

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchStringQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchStringQuery.java
@@ -21,6 +21,7 @@ import java.util.regex.Pattern;
 import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHitSupport;
+import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.convert.DateTimeConverters;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.query.StringQuery;
@@ -77,7 +78,8 @@ public class ElasticsearchStringQuery extends AbstractElasticsearchRepositoryQue
 
 		if (queryMethod.isPageQuery()) {
 			stringQuery.setPageable(accessor.getPageable());
-			result = elasticsearchOperations.searchForPage(stringQuery, clazz, index);
+			SearchHits<?> searchHits = elasticsearchOperations.search(stringQuery, clazz, index);
+			result = SearchHitSupport.page(searchHits, stringQuery.getPageable());
 		} else if (queryMethod.isCollectionQuery()) {
 			if (accessor.getPageable().isPaged()) {
 				stringQuery.setPageable(accessor.getPageable());

--- a/src/test/java/org/springframework/data/elasticsearch/NestedObjectTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/NestedObjectTests.java
@@ -38,16 +38,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.domain.Page;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 import org.springframework.data.elasticsearch.annotations.InnerField;
 import org.springframework.data.elasticsearch.annotations.MultiField;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
-import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
-import org.springframework.data.elasticsearch.core.aggregation.AggregatedPage;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.query.GetQuery;
 import org.springframework.data.elasticsearch.core.query.IndexQuery;
@@ -196,11 +193,11 @@ public class NestedObjectTests {
 
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(builder).build();
 
-		Page<SearchHit<PersonMultipleLevelNested>> personIndexed = elasticsearchTemplate.searchForPage(searchQuery,
+		SearchHits<PersonMultipleLevelNested> personIndexed = elasticsearchTemplate.search(searchQuery,
 				PersonMultipleLevelNested.class, index);
 		assertThat(personIndexed).isNotNull();
-		assertThat(personIndexed.getTotalElements()).isEqualTo(1);
-		assertThat(personIndexed.getContent().get(0).getContent().getId()).isEqualTo("1");
+		assertThat(personIndexed.getTotalHits()).isEqualTo(1);
+		assertThat(personIndexed.getSearchHit(0).getContent().getId()).isEqualTo("1");
 	}
 
 	private List<IndexQuery> createPerson() {
@@ -381,10 +378,10 @@ public class NestedObjectTests {
 		// then
 		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder()
 				.withQuery(nestedQuery("buckets", termQuery("buckets.1", "test3"), ScoreMode.None)).build();
-		AggregatedPage<SearchHit<Book>> books = elasticsearchTemplate.searchForPage(searchQuery, Book.class, index);
+		SearchHits<Book> books = elasticsearchTemplate.search(searchQuery, Book.class, index);
 
-		assertThat(books.getContent()).hasSize(1);
-		assertThat(books.getContent().get(0).getContent().getId()).isEqualTo(book2.getId());
+		assertThat(books.getSearchHits()).hasSize(1);
+		assertThat(books.getSearchHit(0).getContent().getId()).isEqualTo(book2.getId());
 	}
 
 	@Setter

--- a/src/test/java/org/springframework/data/elasticsearch/core/aggregation/ElasticsearchTemplateAggregationTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/aggregation/ElasticsearchTemplateAggregationTests.java
@@ -42,6 +42,7 @@ import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.InnerField;
 import org.springframework.data.elasticsearch.annotations.MultiField;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.ResultsExtractor;
 import org.springframework.data.elasticsearch.core.query.IndexQuery;
@@ -120,12 +121,9 @@ public class ElasticsearchTemplateAggregationTests {
 				.addAggregation(terms("subjects").field("subject")) //
 				.build();
 		// when
-		Aggregations aggregations = operations.query(searchQuery, new ResultsExtractor<Aggregations>() {
-			@Override
-			public Aggregations extract(SearchResponse response) {
-				return response.getAggregations();
-			}
-		}, null, IndexCoordinates.of(INDEX_NAME).withTypes("article"));
+		SearchHits<ArticleEntity> searchHits = operations.search(searchQuery, ArticleEntity.class, IndexCoordinates.of(INDEX_NAME));
+		Aggregations aggregations = searchHits.getAggregations();
+
 		// then
 		assertThat(aggregations).isNotNull();
 		assertThat(aggregations.asMap().get("subjects")).isNotNull();

--- a/src/test/java/org/springframework/data/elasticsearch/core/query/CriteriaQueryTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/query/CriteriaQueryTests.java
@@ -37,12 +37,12 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Version;
-import org.springframework.data.domain.Page;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.Score;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.junit.jupiter.ElasticsearchRestTemplateConfiguration;
 import org.springframework.data.elasticsearch.junit.jupiter.SpringIntegrationTest;
@@ -137,11 +137,11 @@ public class CriteriaQueryTests {
 				new Criteria("message").contains("some").or("message").contains("test"));
 
 		// when
-		Page<SearchHit<SampleEntity>> page = operations.searchForPage(criteriaQuery, SampleEntity.class, index);
+		SearchHits<SampleEntity> searchHits = operations.search(criteriaQuery, SampleEntity.class, index);
 
 		// then
-		assertThat(page).isNotNull();
-		assertThat(page.getTotalElements()).isGreaterThanOrEqualTo(1);
+		assertThat(searchHits).isNotNull();
+		assertThat(searchHits.getTotalHits()).isGreaterThanOrEqualTo(1);
 	}
 
 	@Test
@@ -168,14 +168,13 @@ public class CriteriaQueryTests {
 
 		// when
 
-		Page<SearchHit<SampleEntity>> page = operations.searchForPage(criteriaQuery, SampleEntity.class, index);
+		SearchHits<SampleEntity> searchHits = operations.search(criteriaQuery, SampleEntity.class, index);
 
 		// then
-		assertThat(page).isNotNull();
-		assertThat(page.getTotalElements()).isGreaterThanOrEqualTo(1);
+		assertThat(searchHits).isNotNull();
+		assertThat(searchHits.getTotalHits()).isGreaterThanOrEqualTo(1);
 	}
 
-	// @Ignore("DATAES-30")
 	@Test
 	public void shouldPerformOrOperationWithinCriteria() {
 
@@ -199,11 +198,11 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria().or(new Criteria("message").contains("some")));
 
 		// when
-		Page<SearchHit<SampleEntity>> page = operations.searchForPage(criteriaQuery, SampleEntity.class, index);
+		SearchHits<SampleEntity> searchHits = operations.search(criteriaQuery, SampleEntity.class, index);
 
 		// then
-		assertThat(page).isNotNull();
-		assertThat(page.getTotalElements()).isGreaterThanOrEqualTo(1);
+		assertThat(searchHits).isNotNull();
+		assertThat(searchHits.getTotalHits()).isGreaterThanOrEqualTo(1);
 	}
 
 	@Test
@@ -228,11 +227,11 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("message").is("some message"));
 
 		// when
-		Page<SearchHit<SampleEntity>> page = operations.searchForPage(criteriaQuery, SampleEntity.class, index);
+		SearchHits<SampleEntity> searchHits = operations.search(criteriaQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(criteriaQuery.getCriteria().getField().getName()).isEqualTo("message");
-		assertThat(page.getTotalElements()).isGreaterThanOrEqualTo(1);
+		assertThat(searchHits.getTotalHits()).isGreaterThanOrEqualTo(1);
 	}
 
 	@Test
@@ -270,11 +269,11 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("message").is("some message"));
 
 		// when
-		Page<SearchHit<SampleEntity>> page = operations.searchForPage(criteriaQuery, SampleEntity.class, index);
+		SearchHits<SampleEntity> searchHits = operations.search(criteriaQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(criteriaQuery.getCriteria().getField().getName()).isEqualTo("message");
-		assertThat(page.getTotalElements()).isEqualTo(1);
+		assertThat(searchHits.getTotalHits()).isEqualTo(1);
 	}
 
 	@Test
@@ -520,12 +519,12 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("message").is("foo").not());
 
 		// when
-		Page<SearchHit<SampleEntity>> page = operations.searchForPage(criteriaQuery, SampleEntity.class, index);
+		SearchHits<SampleEntity> searchHits = operations.search(criteriaQuery, SampleEntity.class, index);
 
 		// then
 		assertThat(criteriaQuery.getCriteria().isNegating()).isTrue();
-		assertThat(page).isNotNull();
-		assertThat(page.iterator().next().getContent().getMessage()).doesNotContain("foo");
+		assertThat(searchHits).isNotNull();
+		assertThat(searchHits.iterator().next().getContent().getMessage()).doesNotContain("foo");
 	}
 
 	@Test
@@ -606,11 +605,11 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("rate").between(350, null));
 
 		// when
-		Page<SearchHit<SampleEntity>> page = operations.searchForPage(criteriaQuery, SampleEntity.class, index);
+		SearchHits<SampleEntity> searchHits = operations.search(criteriaQuery, SampleEntity.class, index);
 
 		// then
-		assertThat(page).isNotNull();
-		assertThat(page.getTotalElements()).isGreaterThanOrEqualTo(1);
+		assertThat(searchHits).isNotNull();
+		assertThat(searchHits.getTotalHits()).isGreaterThanOrEqualTo(1);
 	}
 
 	@Test
@@ -649,11 +648,11 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("rate").between(null, 550));
 
 		// when
-		Page<SearchHit<SampleEntity>> page = operations.searchForPage(criteriaQuery, SampleEntity.class, index);
+		SearchHits<SampleEntity> searchHits = operations.search(criteriaQuery, SampleEntity.class, index);
 
 		// then
-		assertThat(page).isNotNull();
-		assertThat(page.getTotalElements()).isGreaterThanOrEqualTo(1);
+		assertThat(searchHits).isNotNull();
+		assertThat(searchHits.getTotalHits()).isGreaterThanOrEqualTo(1);
 	}
 
 	@Test
@@ -692,11 +691,11 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("rate").lessThanEqual(750));
 
 		// when
-		Page<SearchHit<SampleEntity>> page = operations.searchForPage(criteriaQuery, SampleEntity.class, index);
+		SearchHits<SampleEntity> searchHits = operations.search(criteriaQuery, SampleEntity.class, index);
 
 		// then
-		assertThat(page).isNotNull();
-		assertThat(page.getTotalElements()).isGreaterThanOrEqualTo(1);
+		assertThat(searchHits).isNotNull();
+		assertThat(searchHits.getTotalHits()).isGreaterThanOrEqualTo(1);
 	}
 
 	@Test
@@ -735,11 +734,11 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("rate").greaterThanEqual(950));
 
 		// when
-		Page<SearchHit<SampleEntity>> page = operations.searchForPage(criteriaQuery, SampleEntity.class, index);
+		SearchHits<SampleEntity> searchHits = operations.search(criteriaQuery, SampleEntity.class, index);
 
 		// then
-		assertThat(page).isNotNull();
-		assertThat(page.getTotalElements()).isGreaterThanOrEqualTo(1);
+		assertThat(searchHits).isNotNull();
+		assertThat(searchHits.getTotalHits()).isGreaterThanOrEqualTo(1);
 	}
 
 	@Test
@@ -778,10 +777,10 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(new Criteria("message").contains("foo").boost(1));
 
 		// when
-		Page<SearchHit<SampleEntity>> page = operations.searchForPage(criteriaQuery, SampleEntity.class, index);
+		SearchHits<SampleEntity> searchHits = operations.search(criteriaQuery, SampleEntity.class, index);
 
 		// then
-		assertThat(page.getTotalElements()).isGreaterThanOrEqualTo(1);
+		assertThat(searchHits.getTotalHits()).isGreaterThanOrEqualTo(1);
 	}
 
 	@Test
@@ -801,11 +800,11 @@ public class CriteriaQueryTests {
 		CriteriaQuery criteriaQuery = new CriteriaQuery(
 				new Criteria("message").contains("a").or(new Criteria("message").contains("b")));
 		criteriaQuery.setMinScore(2.0F);
-		Page<SearchHit<SampleEntity>> page = operations.searchForPage(criteriaQuery, SampleEntity.class, index);
+		SearchHits<SampleEntity> searchHits = operations.search(criteriaQuery, SampleEntity.class, index);
 
 		// then
-		assertThat(page.getTotalElements()).isEqualTo(1);
-		assertThat(page.getContent().get(0).getContent().getMessage()).isEqualTo("ab");
+		assertThat(searchHits.getTotalHits()).isEqualTo(1);
+		assertThat(searchHits.getSearchHit(0).getContent().getMessage()).isEqualTo("ab");
 	}
 
 	@Test // DATAES-213


### PR DESCRIPTION
… SearchHits.

The new _search..._ methods now all use the `SearchHits` class. All the old methods returning `AggregatedPage` still exist but are deprecated as is the whole `AggregatedPage` interface.

Repositories work as before.