### PR TITLE
Dataes 716   add value mapping to the elasticsearchmappingconverter

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/convert/ConversionException.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/convert/ConversionException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core.convert;
+
+/**
+ * @author Peter-Josef Meisch
+ */
+public class ConversionException extends RuntimeException {
+	public ConversionException() {
+		super();
+	}
+
+	public ConversionException(String message) {
+		super(message);
+	}
+
+	public ConversionException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public ConversionException(Throwable cause) {
+		super(cause);
+	}
+
+	protected ConversionException(String message, Throwable cause, boolean enableSuppression,
+			boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchConverter.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchConverter.java
@@ -145,9 +145,9 @@ public interface ElasticsearchConverter
 	 * {@link org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentPropertyConverter}.
 	 * 
 	 * @param criteriaQuery the query that is internally updated
-	 * @param type the class of the object that is searched with the query
+	 * @param domainClass the class of the object that is searched with the query
 	 */
 	// region query
-	void updateQuery(CriteriaQuery criteriaQuery, Class<?> type);
+	void updateQuery(CriteriaQuery criteriaQuery, Class<?> domainClass);
 	// endregion
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchConverter.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchConverter.java
@@ -28,6 +28,7 @@ import org.springframework.data.elasticsearch.core.document.SearchDocument;
 import org.springframework.data.elasticsearch.core.document.SearchDocumentResponse;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentEntity;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentProperty;
+import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
 import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.lang.Nullable;
@@ -101,7 +102,7 @@ public interface ElasticsearchConverter
 	<T> SearchHit<T> read(Class<T> type, SearchDocument searchDocument);
 
 	<T> AggregatedPage<SearchHit<T>> mapResults(SearchDocumentResponse response, Class<T> clazz,
-												@Nullable Pageable pageable);
+			@Nullable Pageable pageable);
 
 	// endregion
 
@@ -136,5 +137,17 @@ public interface ElasticsearchConverter
 		write(source, target);
 		return target;
 	}
+	// endregion
+
+	/**
+	 * Updates a query by renaming the property names in the query to the correct mapped field names and the values to the
+	 * converted values if the {@link ElasticsearchPersistentProperty} for a property has a
+	 * {@link org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentPropertyConverter}.
+	 * 
+	 * @param criteriaQuery the query that is internally updated
+	 * @param type the class of the object that is searched with the query
+	 */
+	// region query
+	void updateQuery(CriteriaQuery criteriaQuery, Class<?> type);
 	// endregion
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchConverter.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchConverter.java
@@ -16,6 +16,7 @@
 package org.springframework.data.elasticsearch.core.convert;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.data.convert.EntityConverter;
 import org.springframework.data.domain.Pageable;
@@ -42,28 +43,6 @@ public interface ElasticsearchConverter
 		extends EntityConverter<ElasticsearchPersistentEntity<?>, ElasticsearchPersistentProperty, Object, Document> {
 
 	/**
-	 * Convert a given {@literal idValue} to its {@link String} representation taking potentially registered
-	 * {@link org.springframework.core.convert.converter.Converter Converters} into account.
-	 *
-	 * @param idValue must not be {@literal null}.
-	 * @return never {@literal null}.
-	 * @since 3.2
-	 */
-	default String convertId(Object idValue) {
-
-		Assert.notNull(idValue, "idValue must not be null!");
-
-		if (!getConversionService().canConvert(idValue.getClass(), String.class)) {
-			return idValue.toString();
-		}
-
-		return getConversionService().convert(idValue, String.class);
-	}
-
-	<T> AggregatedPage<SearchHit<T>> mapResults(SearchDocumentResponse response, Class<T> clazz,
-			@Nullable Pageable pageable);
-
-	/**
 	 * Get the configured {@link ProjectionFactory}. <br />
 	 * <strong>NOTE</strong> Should be overwritten in implementation to make use of the type cache.
 	 *
@@ -73,12 +52,13 @@ public interface ElasticsearchConverter
 		return new SpelAwareProxyProjectionFactory();
 	}
 
+	// region read
 	/**
 	 * Map a single {@link Document} to an instance of the given type.
 	 *
 	 * @param document the document to map
 	 * @param type must not be {@literal null}.
-	 * @param <T>
+	 * @param <T> the class of type
 	 * @return can be {@literal null} if the document is null or {@link Document#isEmpty()} is true.
 	 * @since 4.0
 	 */
@@ -86,7 +66,21 @@ public interface ElasticsearchConverter
 	<T> T mapDocument(@Nullable Document document, Class<T> type);
 
 	/**
+	 * Map a list of {@link Document}s to a list of instance of the given type.
+	 *
+	 * @param documents must not be {@literal null}.
+	 * @param type must not be {@literal null}.
+	 * @param <T> the class of type
+	 * @return a list obtained by calling {@link #mapDocument(Document, Class)} on the elements of the list.
+	 * @since 4.0
+	 */
+	default <T> List<T> mapDocuments(List<Document> documents, Class<T> type) {
+		return documents.stream().map(document -> mapDocument(document, type)).collect(Collectors.toList());
+	}
+
+	/**
 	 * builds a {@link SearchHits} from a {@link SearchDocumentResponse}.
+	 * 
 	 * @param <T> the clazz of the type, must not be {@literal null}.
 	 * @param type the type of the returned data, must not be {@literal null}.
 	 * @param searchDocumentResponse the response to read from, must not be {@literal null}.
@@ -106,22 +100,41 @@ public interface ElasticsearchConverter
 	 */
 	<T> SearchHit<T> read(Class<T> type, SearchDocument searchDocument);
 
+	<T> AggregatedPage<SearchHit<T>> mapResults(SearchDocumentResponse response, Class<T> clazz,
+												@Nullable Pageable pageable);
+
+	// endregion
+
+	// region write
 	/**
-	 * Map a list of {@link Document}s to alist of instance of the given type.
+	 * Convert a given {@literal idValue} to its {@link String} representation taking potentially registered
+	 * {@link org.springframework.core.convert.converter.Converter Converters} into account.
 	 *
-	 * @param documents must not be {@literal null}.
-	 * @param type must not be {@literal null}.
-	 * @param <T>
-	 * @return a list obtained by calling {@link #mapDocument(Document, Class)} on the elements of the list.
-	 * @since 4.0
+	 * @param idValue must not be {@literal null}.
+	 * @return never {@literal null}.
+	 * @since 3.2
 	 */
-	<T> List<T> mapDocuments(List<Document> documents, Class<T> type);
+	default String convertId(Object idValue) {
+
+		Assert.notNull(idValue, "idValue must not be null!");
+
+		if (!getConversionService().canConvert(idValue.getClass(), String.class)) {
+			return idValue.toString();
+		}
+
+		return getConversionService().convert(idValue, String.class);
+	}
 
 	/**
 	 * Map an object to a {@link Document}.
 	 *
-	 * @param source
+	 * @param source the object to map
 	 * @return will not be {@literal null}.
 	 */
-	Document mapObject(Object source);
+	default Document mapObject(@Nullable Object source) {
+		Document target = Document.create();
+		write(source, target);
+		return target;
+	}
+	// endregion
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchDateConverter.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchDateConverter.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core.convert;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.temporal.TemporalAccessor;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.elasticsearch.common.time.DateFormatter;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.util.Assert;
+
+/**
+ * Provides Converter instances to convert to and from Dates in the different date and time formats that elasticsearch
+ * understands.
+ *
+ * @author Peter-Josef Meisch
+ * @since 4.0
+ */
+final public class ElasticsearchDateConverter {
+
+	private static final ConcurrentHashMap<String, ElasticsearchDateConverter> converters = new ConcurrentHashMap<>();
+
+	private final DateFormatter dateFormatter;
+
+	/**
+	 * Creates an ElasticsearchDateConverter for the given {@link DateFormat}.
+	 * 
+	 * @param dateFormat must not be @{literal null}
+	 * @return converter
+	 */
+	public static ElasticsearchDateConverter of(DateFormat dateFormat) {
+
+		Assert.notNull(dateFormat, "dateFormat must not be null");
+
+		return of(dateFormat.name());
+	}
+
+	/**
+	 * Creates an ElasticsearchDateConverter for the given pattern.
+	 *
+	 * @param pattern must not be {@literal null}
+	 * @return converter
+	 */
+	public static ElasticsearchDateConverter of(String pattern) {
+		Assert.notNull(pattern, "pattern must not be null");
+
+		return converters.computeIfAbsent(pattern, p -> new ElasticsearchDateConverter(DateFormatter.forPattern(p)));
+	}
+
+	private ElasticsearchDateConverter(DateFormatter dateFormatter) {
+		this.dateFormatter = dateFormatter;
+	}
+
+	/**
+	 * Formats the given {@link TemporalAccessor} int a String
+	 * 
+	 * @param accessor must not be {@literal null}
+	 * @return the formatted object
+	 */
+	public String format(TemporalAccessor accessor) {
+		return dateFormatter.format(accessor);
+	}
+
+	/**
+	 * Parses a String into an object
+	 * 
+	 * @param input the String to parse, must not be {@literal null}.
+	 * @param type the class to return
+	 * @param <T> the class of type
+	 * @return the new created object
+	 */
+	public <T extends TemporalAccessor> T parse(String input, Class<T> type) {
+		TemporalAccessor accessor = dateFormatter.parse(input);
+		try {
+			Method method = type.getMethod("from", TemporalAccessor.class);
+			Object o = method.invoke(null, accessor);
+			return type.cast(o);
+		} catch (NoSuchMethodException e) {
+			throw new ConversionException("no 'from' factory method found in class " + type.getName());
+		} catch (IllegalAccessException | InvocationTargetException e) {
+			throw new ConversionException("could not create object of class " + type.getName(), e);
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/convert/MappingElasticsearchConverter.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/convert/MappingElasticsearchConverter.java
@@ -730,8 +730,9 @@ public class MappingElasticsearchConverter
 	// endregion
 
 	// region queries
-	public void updateQuery(CriteriaQuery criteriaQuery, Class<?> type) {
-		ElasticsearchPersistentEntity<?> persistentEntity = mappingContext.getPersistentEntity(type);
+	@Override
+	public void updateQuery(CriteriaQuery criteriaQuery, Class<?> domainClass) {
+		ElasticsearchPersistentEntity<?> persistentEntity = mappingContext.getPersistentEntity(domainClass);
 
 		if (persistentEntity != null) {
 			criteriaQuery.getCriteria().getCriteriaChain().forEach(criteria -> {

--- a/src/main/java/org/springframework/data/elasticsearch/core/convert/MappingElasticsearchConverter.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/convert/MappingElasticsearchConverter.java
@@ -642,7 +642,6 @@ public class MappingElasticsearchConverter
 		}
 		return target;
 	}
-
 	// endregion
 
 	// region helper methods

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentProperty.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentProperty.java
@@ -84,7 +84,8 @@ public interface ElasticsearchPersistentProperty extends PersistentProperty<Elas
 	}
 
 	/**
-	 * when building CriteriaQueries use the name; the fieldname is set later with {@link org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter}.
+	 * when building CriteriaQueries use the name; the fieldname is set later with
+	 * {@link org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter}.
 	 */
 	enum QueryPropertyToFieldNameConverter implements Converter<ElasticsearchPersistentProperty, String> {
 

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentProperty.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentProperty.java
@@ -17,6 +17,7 @@ package org.springframework.data.elasticsearch.core.mapping;
 
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.lang.Nullable;
 
 /**
  * ElasticsearchPersistentProperty
@@ -59,6 +60,19 @@ public interface ElasticsearchPersistentProperty extends PersistentProperty<Elas
 	 * @since 3.1
 	 */
 	boolean isParentProperty();
+
+	/**
+	 * @return true if an {@link ElasticsearchPersistentPropertyConverter} is available for this instance.
+	 * @since 4.0
+	 */
+	boolean hasPropertyConverter();
+
+	/**
+	 * @return the {@link ElasticsearchPersistentPropertyConverter} for this instance.
+	 * @since 4.0
+	 */
+	@Nullable
+	ElasticsearchPersistentPropertyConverter getPropertyConverter();
 
 	public enum PropertyToFieldNameConverter implements Converter<ElasticsearchPersistentProperty, String> {
 

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentProperty.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentProperty.java
@@ -74,12 +74,24 @@ public interface ElasticsearchPersistentProperty extends PersistentProperty<Elas
 	@Nullable
 	ElasticsearchPersistentPropertyConverter getPropertyConverter();
 
-	public enum PropertyToFieldNameConverter implements Converter<ElasticsearchPersistentProperty, String> {
+	enum PropertyToFieldNameConverter implements Converter<ElasticsearchPersistentProperty, String> {
 
 		INSTANCE;
 
 		public String convert(ElasticsearchPersistentProperty source) {
 			return source.getFieldName();
+		}
+	}
+
+	/**
+	 * when building CriteriaQueries use the name; the fieldname is set later with {@link org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter}.
+	 */
+	enum QueryPropertyToFieldNameConverter implements Converter<ElasticsearchPersistentProperty, String> {
+
+		INSTANCE;
+
+		public String convert(ElasticsearchPersistentProperty source) {
+			return source.getName();
 		}
 	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentPropertyConverter.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentPropertyConverter.java
@@ -16,20 +16,22 @@
 package org.springframework.data.elasticsearch.core.mapping;
 
 /**
+ * Interface defining methods to convert a property value to a String and back.
+ *
  * @author Peter-Josef Meisch
  */
 public interface ElasticsearchPersistentPropertyConverter {
 
 	/**
-	 * converts a property value to a String when data is written to Elasticsearch.
-	 * 
+	 * converts the property value to a String.
+	 *
 	 * @param property the property value to convert, must not be {@literal null}
 	 * @return String representation.
 	 */
 	String write(Object property);
 
 	/**
-	 * converts a property value from a String when data is read to Elasticsearch.
+	 * converts a property value from a String.
 	 *
 	 * @param s the property to convert, must not be {@literal null}
 	 * @return property value

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentPropertyConverter.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentPropertyConverter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core.mapping;
+
+/**
+ * @author Peter-Josef Meisch
+ */
+public interface ElasticsearchPersistentPropertyConverter {
+
+	/**
+	 * converts a property value to a String when data is written to Elasticsearch.
+	 * 
+	 * @param property the property value to convert, must not be {@literal null}
+	 * @return String representation.
+	 */
+	String write(Object property);
+
+	/**
+	 * converts a property value from a String when data is read to Elasticsearch.
+	 *
+	 * @param s the property to convert, must not be {@literal null}
+	 * @return property value
+	 */
+	Object read(String s);
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/Criteria.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/Criteria.java
@@ -624,6 +624,7 @@ public class Criteria {
 	public static class CriteriaEntry {
 
 		private OperationKey key;
+
 		private Object value;
 
 		CriteriaEntry(OperationKey key, Object value) {
@@ -633,6 +634,10 @@ public class Criteria {
 
 		public OperationKey getKey() {
 			return key;
+		}
+
+		public void setValue(Object value) {
+			this.value = value;
 		}
 
 		public Object getValue() {

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/Field.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/Field.java
@@ -20,13 +20,11 @@ package org.springframework.data.elasticsearch.core.query;
  *
  * @author Rizwan Idrees
  * @author Mohsin Husen
+ * @author Peter-Josef Meisch
  */
 public interface Field {
 
-	/**
-	 * Get the name of the field used in schema.xml of elasticsearch server
-	 *
-	 * @return
-	 */
+	void setName(String name);
+
 	String getName();
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/SimpleField.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/SimpleField.java
@@ -15,17 +15,26 @@
  */
 package org.springframework.data.elasticsearch.core.query;
 
+import org.springframework.util.Assert;
+
 /**
  * The most trivial implementation of a Field
  *
  * @author Rizwan Idrees
  * @author Mohsin Husen
+ * @author Peter-Josef Meisch
  */
 public class SimpleField implements Field {
 
-	private final String name;
+	private String name;
 
 	public SimpleField(String name) {
+		setName(name);
+	}
+
+	@Override
+	public void setName(String name) {
+		Assert.notNull(name, "name must not be null");
 		this.name = name;
 	}
 

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/parser/ElasticsearchQueryCreator.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/parser/ElasticsearchQueryCreator.java
@@ -65,7 +65,8 @@ public class ElasticsearchQueryCreator extends AbstractQueryCreator<CriteriaQuer
 		PersistentPropertyPath<ElasticsearchPersistentProperty> path = context
 				.getPersistentPropertyPath(part.getProperty());
 		return new CriteriaQuery(from(part,
-				new Criteria(path.toDotPath(ElasticsearchPersistentProperty.PropertyToFieldNameConverter.INSTANCE)), iterator));
+				new Criteria(path.toDotPath(ElasticsearchPersistentProperty.QueryPropertyToFieldNameConverter.INSTANCE)),
+				iterator));
 	}
 
 	@Override
@@ -76,7 +77,8 @@ public class ElasticsearchQueryCreator extends AbstractQueryCreator<CriteriaQuer
 		PersistentPropertyPath<ElasticsearchPersistentProperty> path = context
 				.getPersistentPropertyPath(part.getProperty());
 		return base.addCriteria(from(part,
-				new Criteria(path.toDotPath(ElasticsearchPersistentProperty.PropertyToFieldNameConverter.INSTANCE)), iterator));
+				new Criteria(path.toDotPath(ElasticsearchPersistentProperty.QueryPropertyToFieldNameConverter.INSTANCE)),
+				iterator));
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/parser/package-info.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/parser/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Infrastructure for the Elasticsearch document-to-object mapping subsystem.
+ */
+@org.springframework.lang.NonNullApi
+package org.springframework.data.elasticsearch.repository.query.parser;

--- a/src/test/java/org/springframework/data/elasticsearch/core/CriteriaQueryMappingTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/CriteriaQueryMappingTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core;
+
+import static org.skyscreamer.jsonassert.JSONAssert.*;
+
+import java.time.LocalDate;
+import java.util.Collections;
+
+import org.json.JSONException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.convert.support.GenericConversionService;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.core.convert.MappingElasticsearchConverter;
+import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
+import org.springframework.data.elasticsearch.core.query.Criteria;
+import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
+
+/**
+ * Tests for the mapping of {@link CriteriaQuery} by a
+ * {@link org.springframework.data.elasticsearch.core.convert.MappingElasticsearchConverter}. In the same package as
+ * {@link CriteriaQueryProcessor} as this is needed to get the String represenation to assert.
+ * 
+ * @author Peter-Josef Meisch
+ */
+public class CriteriaQueryMappingTests {
+
+	MappingElasticsearchConverter mappingElasticsearchConverter;
+
+	@BeforeEach
+	void setUp() {
+		SimpleElasticsearchMappingContext mappingContext = new SimpleElasticsearchMappingContext();
+		mappingContext.setInitialEntitySet(Collections.singleton(Person.class));
+		mappingContext.afterPropertiesSet();
+
+		mappingElasticsearchConverter = new MappingElasticsearchConverter(mappingContext, new GenericConversionService());
+		mappingElasticsearchConverter.afterPropertiesSet();
+
+	}
+
+	@Test
+	void shouldMapNamesAndConvertValuesInCriteriaQuery() throws JSONException {
+
+		// use POJO properties and types in the query building
+		CriteriaQuery criteriaQuery = new CriteriaQuery(
+				new Criteria("birthDate").between(LocalDate.of(1989, 11, 9), LocalDate.of(1990, 11, 9)).or("birthDate").is(LocalDate.of(2019, 12, 28)));
+
+		// mapped field name and converted parameter
+		String expected = '{' + //
+				"  \"bool\" : {" + //
+				"    \"should\" : [" + //
+				"      {" + //
+				"        \"range\" : {" + //
+				"          \"birth-date\" : {" + //
+				"            \"from\" : \"09.11.1989\"," + //
+				"            \"to\" : \"09.11.1990\"," + //
+				"            \"include_lower\" : true," + //
+				"            \"include_upper\" : true" + //
+				"          }" + //
+				"        }" + //
+				"      }," + //
+				"      {" + //
+				"        \"query_string\" : {" + //
+				"          \"query\" : \"28.12.2019\"," + //
+				"          \"fields\" : [" + //
+				"            \"birth-date^1.0\"" + //
+				"          ]" + //
+				"        }" + //
+				"      }" + //
+				"    ]" + //
+				"  }" + //
+				'}'; //
+
+		mappingElasticsearchConverter.updateQuery(criteriaQuery, Person.class);
+		String queryString = new CriteriaQueryProcessor().createQueryFromCriteria(criteriaQuery.getCriteria()).toString();
+
+		assertEquals(expected, queryString, false);
+	}
+
+	static class Person {
+		@Id String id;
+		@Field(name = "first-name") String firstName;
+		@Field(name = "last-name") String lastName;
+		@Field(name = "birth-date", type = FieldType.Date, format = DateFormat.custom,
+				pattern = "dd.MM.yyyy") LocalDate birthDate;
+	}
+}

--- a/src/test/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchDateConverterTest.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchDateConverterTest.java
@@ -1,0 +1,50 @@
+package org.springframework.data.elasticsearch.core.convert;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
+
+/**
+ * @author Peter-Josef Meisch
+ */
+class ElasticsearchDateConverterTest {
+
+	@ParameterizedTest
+	@EnumSource(DateFormat.class)
+	void shouldCreateConvertersForAllKnownFormats(DateFormat dateFormat) {
+
+		if (dateFormat == DateFormat.none) {
+			return;
+		}
+		String pattern = (dateFormat != DateFormat.custom) ? dateFormat.name() : "dd.MM.yyyy";
+
+		ElasticsearchDateConverter converter = ElasticsearchDateConverter.of(pattern);
+
+		assertThat(converter).isNotNull();
+	}
+
+	@Test
+	void shouldConvertToString() {
+		LocalDate localDate = LocalDate.of(2019, 12, 27);
+		ElasticsearchDateConverter converter = ElasticsearchDateConverter.of(DateFormat.basic_date);
+
+		String formatted = converter.format(localDate);
+
+		assertThat(formatted).isEqualTo("20191227");
+	}
+
+	@Test
+	void shouldParseFromString() {
+		LocalDate localDate = LocalDate.of(2019, 12, 27);
+		ElasticsearchDateConverter converter = ElasticsearchDateConverter.of(DateFormat.basic_date);
+
+		LocalDate parsed = converter.parse("20191227", LocalDate.class);
+
+		assertThat(parsed).isEqualTo(localDate);
+	}
+}

--- a/src/test/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchDateConverterTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchDateConverterTests.java
@@ -12,7 +12,7 @@ import org.springframework.data.elasticsearch.annotations.DateFormat;
 /**
  * @author Peter-Josef Meisch
  */
-class ElasticsearchDateConverterTest {
+class ElasticsearchDateConverterTests {
 
 	@ParameterizedTest
 	@EnumSource(DateFormat.class)

--- a/src/test/java/org/springframework/data/elasticsearch/core/convert/MappingElasticsearchConverterUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/convert/MappingElasticsearchConverterUnitTests.java
@@ -56,6 +56,8 @@ import org.springframework.data.elasticsearch.annotations.GeoPointField;
 import org.springframework.data.elasticsearch.core.document.Document;
 import org.springframework.data.elasticsearch.core.geo.GeoPoint;
 import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
+import org.springframework.data.elasticsearch.core.query.Criteria;
+import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
 import org.springframework.data.geo.Box;
 import org.springframework.data.geo.Circle;
 import org.springframework.data.geo.Point;
@@ -299,7 +301,7 @@ public class MappingElasticsearchConverterUnitTests {
 	public void writesNestedEntity() {
 
 		Person person = new Person();
-		person.birthdate = LocalDate.now();
+		person.birthDate = LocalDate.now();
 		person.gender = Gender.MAN;
 		person.address = observatoryRoad;
 
@@ -583,12 +585,16 @@ public class MappingElasticsearchConverterUnitTests {
 	void shouldWriteLocalDate() throws JSONException {
 		Person person = new Person();
 		person.id = "4711";
-		person.birthdate = LocalDate.of(2000, 8, 22);
+		person.firstName = "John";
+		person.lastName = "Doe";
+		person.birthDate = LocalDate.of(2000, 8, 22);
 		person.gender = Gender.MAN;
 
 		String expected = '{' + //
 				"  \"id\": \"4711\"," + //
-				"  \"birthdate\": \"22.08.2000\"," + //
+				"  \"first-name\": \"John\"," + //
+				"  \"last-name\": \"Doe\"," + //
+				"  \"birth-date\": \"22.08.2000\"," + //
 				"  \"gender\": \"MAN\"" + //
 				'}';
 		Document document = Document.create();
@@ -602,13 +608,15 @@ public class MappingElasticsearchConverterUnitTests {
 	void shouldReadLocalDate() {
 		Document document = Document.create();
 		document.put("id", "4711");
-		document.put("birthdate", "22.08.2000");
+		document.put("first-name", "John");
+		document.put("last-name", "Doe");
+		document.put("birth-date", "22.08.2000");
 		document.put("gender", "MAN");
 
 		Person person = mappingElasticsearchConverter.read(Person.class, document);
 
 		assertThat(person.getId()).isEqualTo("4711");
-		assertThat(person.getBirthdate()).isEqualTo(LocalDate.of(2000, 8, 22));
+		assertThat(person.getBirthDate()).isEqualTo(LocalDate.of(2000, 8, 22));
 		assertThat(person.getGender()).isEqualTo(Gender.MAN);
 	}
 
@@ -636,7 +644,10 @@ public class MappingElasticsearchConverterUnitTests {
 
 		@Id String id;
 		String name;
-		@Field(type = FieldType.Date, format = DateFormat.custom, pattern = "dd.MM.yyyy") LocalDate birthdate;
+		@Field(name = "first-name") String firstName;
+		@Field(name = "last-name") String lastName;
+		@Field(name = "birth-date", type = FieldType.Date, format = DateFormat.custom,
+				pattern = "dd.MM.yyyy") LocalDate birthDate;
 		Gender gender;
 		Address address;
 

--- a/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderTests.java
@@ -33,6 +33,7 @@ import java.lang.Boolean;
 import java.lang.Double;
 import java.lang.Integer;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -957,7 +958,7 @@ public class MappingBuilderTests extends MappingContextBaseTests {
 		@Field(copyTo = { "foo", "bar" }) private String copyTo;
 		@Field(ignoreAbove = 42) private String ignoreAbove;
 		@Field(type = FieldType.Integer) private String type;
-		@Field(type = FieldType.Date, format = DateFormat.custom, pattern = "YYYYMMDD") private String date;
+		@Field(type = FieldType.Date, format = DateFormat.custom, pattern = "YYYYMMDD") private LocalDate date;
 		@Field(analyzer = "ana", searchAnalyzer = "sana", normalizer = "norma") private String analyzers;
 		@Field(type = Keyword, docValues = true) private String docValuesTrue;
 		@Field(type = Keyword, docValues = false) private String docValuesFalse;


### PR DESCRIPTION
`ElasticsearchPersistentProperty`s now can have a `ElasticsearchPersistentPropertyConverter` attached.
When the `MappingElasticsearchConverter` writes and reads the domain objects, it uses this converter to do a value mapping for the property. `MappingElasticsearchConverter` also can process `CriteriaQuery` instances and replace the field names and values with the mapped ones like they are expected.
A custom converter for Java 8 time classes (implementations of `TemporalAccessor` is implemented, so that a field like _birthDate_  now works out of the box.

```
static class Person {
	@Id String id;
	@Field(name = "first-name") String firstName;
	@Field(name = "last-name") String lastName;
	@Field(name = "birth-date", type = FieldType.Date, format = DateFormat.custom,
			pattern = "dd.MM.yyyy") LocalDate birthDate;
}
```
is automatically converted.