### PR TITLE
DATAES-717 - Enable Repositories to return a SearchHits instance inst…

### DIFF
--- a/src/main/asciidoc/reference/elasticsearch-operations.adoc
+++ b/src/main/asciidoc/reference/elasticsearch-operations.adoc
@@ -133,12 +133,15 @@ Contains the following information:
 * Id
 * Score
 * Sort Values
-* the retrieved entity of type <T>
+* Highligth fields
+* The retrieved entity of type <T>
 
 .SearchHits<T>
 Contains the following information:
 
 * Number of total hits
+* Total hits relation
 * Maximum score
 * A list of `SearchHit<T>` objects
+* Returned aggregations
 

--- a/src/main/asciidoc/reference/elasticsearch-repository-queries.adoc
+++ b/src/main/asciidoc/reference/elasticsearch-repository-queries.adoc
@@ -266,6 +266,16 @@ A list of supported keywords for Elasticsearch is shown below.
 
 |===
 
+== Method return types
+
+Repository methods can be defined to have the following return types for returning multiple Elements:
+
+* `List<T>`
+* `Stream<T>`
+* `SearchHits<T>`
+* `List<SearchHits<T>>`
+* `Stream<>>SearchHit<T>>`
+
 [[elasticsearch.query-methods.at-query]]
 == Using @Query Annotation
 

--- a/src/main/java/org/springframework/data/elasticsearch/core/ReactiveElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ReactiveElasticsearchTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -429,6 +429,10 @@ public class ReactiveElasticsearchTemplate implements ReactiveElasticsearchOpera
 
 	private Flux<SearchDocument> doFind(Query query, Class<?> clazz, IndexCoordinates index) {
 
+		if (query instanceof CriteriaQuery) {
+			converter.updateQuery((CriteriaQuery) query, clazz);
+		}
+
 		return Flux.defer(() -> {
 			SearchRequest request = requestFactory.searchRequest(query, clazz, index);
 
@@ -561,11 +565,10 @@ public class ReactiveElasticsearchTemplate implements ReactiveElasticsearchOpera
 
 	private QueryBuilder mappedQuery(Query query, ElasticsearchPersistentEntity<?> entity) {
 
-		// TODO: we need to actually map the fields to the according field names!
-
 		QueryBuilder elasticsearchQuery = null;
 
 		if (query instanceof CriteriaQuery) {
+			converter.updateQuery((CriteriaQuery) query, entity.getType());
 			elasticsearchQuery = new CriteriaQueryProcessor().createQueryFromCriteria(((CriteriaQuery) query).getCriteria());
 		} else if (query instanceof StringQuery) {
 			elasticsearchQuery = new WrapperQueryBuilder(((StringQuery) query).getSource());

--- a/src/main/java/org/springframework/data/elasticsearch/core/SearchHits.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/SearchHits.java
@@ -35,11 +35,11 @@ import org.springframework.util.StringUtils;
 public class SearchHits<T> implements Streamable<SearchHit<T>> {
 
 	private final long totalHits;
+	private final TotalHitsRelation totalHitsRelation;
 	private final float maxScore;
 	private final String scrollId;
 	private final List<? extends SearchHit<T>> searchHits;
 	private final Aggregations aggregations;
-	private final TotalHitsRelation totalHitsRelation;
 
 	/**
 	 * @param totalHits the number of total hits for the search

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/AbstractReactiveElasticsearchRepositoryQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/AbstractReactiveElasticsearchRepositoryQuery.java
@@ -62,7 +62,7 @@ abstract class AbstractReactiveElasticsearchRepositoryQuery implements Repositor
 
 		Object result = queryMethod.hasReactiveWrapperParameter() ? executeDeferred(parameters)
 				: execute(new ReactiveElasticsearchParametersParameterAccessor(queryMethod, parameters));
-		return SearchHitSupport.unwrapSearchHits(result);
+		return queryMethod.isNotSearchHitMethod() ? SearchHitSupport.unwrapSearchHits(result) : result;
 	}
 
 	private Object executeDeferred(Object[] parameters) {
@@ -122,7 +122,8 @@ abstract class AbstractReactiveElasticsearchRepositoryQuery implements Repositor
 			return (query, type, targetType, indexCoordinates) -> operations.search(query.setPageable(accessor.getPageable()),
 					type, targetType, indexCoordinates);
 		} else {
-			return (query, type, targetType, indexCoordinates) -> operations.search(query, type, targetType, indexCoordinates);
+			return (query, type, targetType, indexCoordinates) -> operations.search(query, type, targetType,
+					indexCoordinates);
 		}
 	}
 

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchPartQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchPartQuery.java
@@ -86,7 +86,7 @@ public class ElasticsearchPartQuery extends AbstractElasticsearchRepositoryQuery
 			} else {
 				query.setPageable(accessor.getPageable());
 			}
-			result = StreamUtils.createStreamFromIterator(elasticsearchOperations.stream(query, clazz, index));
+			result = StreamUtils.createStreamFromIterator(elasticsearchOperations.searchForStream(query, clazz, index));
 		} else if (queryMethod.isCollectionQuery()) {
 
 			if (accessor.getPageable().isUnpaged()) {
@@ -97,13 +97,14 @@ public class ElasticsearchPartQuery extends AbstractElasticsearchRepositoryQuery
 			}
 
 			result = elasticsearchOperations.search(query, clazz, index);
+
 		} else if (tree.isCountProjection()) {
 			result = elasticsearchOperations.count(query, clazz, index);
 		} else {
 			result = elasticsearchOperations.searchOne(query, clazz, index);
 		}
 
-		return SearchHitSupport.unwrapSearchHits(result);
+		return queryMethod.isNotSearchHitMethod() ? SearchHitSupport.unwrapSearchHits(result) : result;
 	}
 
 	private Object countOrGetDocumentsForDelete(CriteriaQuery query, ParametersParameterAccessor accessor) {

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchStringQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchStringQuery.java
@@ -89,8 +89,7 @@ public class ElasticsearchStringQuery extends AbstractElasticsearchRepositoryQue
 			result = elasticsearchOperations.searchOne(stringQuery, clazz, index);
 		}
 
-		return SearchHitSupport.unwrapSearchHits(result);
-
+		return queryMethod.isNotSearchHitMethod() ? SearchHitSupport.unwrapSearchHits(result) : result;
 	}
 
 	protected StringQuery createQuery(ParametersParameterAccessor parameterAccessor) {

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ReactiveElasticsearchQueryMethod.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ReactiveElasticsearchQueryMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,10 @@ package org.springframework.data.elasticsearch.repository.query;
 
 import static org.springframework.data.repository.util.ClassUtils.*;
 
+import reactor.core.publisher.Flux;
+
 import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
 
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.domain.Page;
@@ -115,4 +118,11 @@ public class ReactiveElasticsearchQueryMethod extends ElasticsearchQueryMethod {
 	public ElasticsearchParameters getParameters() {
 		return (ElasticsearchParameters) super.getParameters();
 	}
+
+	@Override
+	protected boolean isAllowedGenericType(ParameterizedType methodGenericReturnType) {
+		return super.isAllowedGenericType(methodGenericReturnType)
+				|| Flux.class.isAssignableFrom((Class<?>) methodGenericReturnType.getRawType());
+	}
+
 }

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchRepositoryFactory.java
@@ -115,4 +115,9 @@ public class ElasticsearchRepositoryFactory extends RepositoryFactorySupport {
 			return new ElasticsearchPartQuery(queryMethod, elasticsearchOperations);
 		}
 	}
+
+	@Override
+	protected RepositoryMetadata getRepositoryMetadata(Class<?> repositoryInterface) {
+		return new ElasticsearchRepositoryMetadata(repositoryInterface);
+	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchRepositoryMetadata.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchRepositoryMetadata.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.repository.support;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.util.Collection;
+import java.util.stream.Stream;
+
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.repository.core.support.DefaultRepositoryMetadata;
+
+/**
+ * @author Peter-Josef Meisch
+ * @since 4.0
+ */
+public class ElasticsearchRepositoryMetadata extends DefaultRepositoryMetadata {
+
+	public ElasticsearchRepositoryMetadata(Class<?> repositoryInterface) {
+		super(repositoryInterface);
+	}
+
+	@Override
+	public Class<?> getReturnedDomainClass(Method method) {
+		Class<?> returnedDomainClass = super.getReturnedDomainClass(method);
+		if (SearchHit.class.isAssignableFrom(returnedDomainClass)) {
+			try {
+				// dealing with Collection<SearchHit<T>> or Flux<SearchHit<T>>, getting to T
+				ParameterizedType methodGenericReturnType = ((ParameterizedType) method.getGenericReturnType());
+				if (isAllowedGenericType(methodGenericReturnType)) {
+					ParameterizedType collectionTypeArgument = (ParameterizedType) methodGenericReturnType
+							.getActualTypeArguments()[0];
+					if (SearchHit.class.isAssignableFrom((Class<?>) collectionTypeArgument.getRawType())) {
+						returnedDomainClass = (Class<?>) collectionTypeArgument.getActualTypeArguments()[0];
+					}
+				}
+			} catch (Exception ignored) {}
+		}
+		return returnedDomainClass;
+	}
+
+	protected boolean isAllowedGenericType(ParameterizedType methodGenericReturnType) {
+		return Collection.class.isAssignableFrom((Class<?>) methodGenericReturnType.getRawType())
+				|| Stream.class.isAssignableFrom((Class<?>) methodGenericReturnType.getRawType());
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/ReactiveElasticsearchRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/ReactiveElasticsearchRepositoryFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,6 +118,11 @@ public class ReactiveElasticsearchRepositoryFactory extends ReactiveRepositoryFa
 		ElasticsearchPersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(domainClass);
 		return new MappingElasticsearchEntityInformation<>((ElasticsearchPersistentEntity<T>) entity,
 				entity.getIndexCoordinates(), entity.getVersionType());
+	}
+
+	@Override
+	protected RepositoryMetadata getRepositoryMetadata(Class<?> repositoryInterface) {
+		return new ReactiveElasticsearchRepositoryMetadata(repositoryInterface);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/ReactiveElasticsearchRepositoryMetadata.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/ReactiveElasticsearchRepositoryMetadata.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.repository.support;
+
+import reactor.core.publisher.Flux;
+
+import java.lang.reflect.ParameterizedType;
+
+/**
+ * @author Peter-Josef Meisch
+ * @since 4.0
+ */
+public class ReactiveElasticsearchRepositoryMetadata extends ElasticsearchRepositoryMetadata {
+
+	public ReactiveElasticsearchRepositoryMetadata(Class<?> repositoryInterface) {
+		super(repositoryInterface);
+	}
+
+	@Override
+	protected boolean isAllowedGenericType(ParameterizedType methodGenericReturnType) {
+		return super.isAllowedGenericType(methodGenericReturnType)
+				|| Flux.class.isAssignableFrom((Class<?>) methodGenericReturnType.getRawType());
+	}
+}

--- a/src/test/java/org/springframework/data/elasticsearch/repositories/custommethod/CustomMethodRepositoryBaseTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repositories/custommethod/CustomMethodRepositoryBaseTests.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterEach;
@@ -48,6 +49,8 @@ import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.Query;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.IndexOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.geo.GeoBox;
 import org.springframework.data.elasticsearch.core.geo.GeoPoint;
 import org.springframework.data.elasticsearch.junit.jupiter.SpringIntegrationTest;
@@ -379,7 +382,7 @@ public abstract class CustomMethodRepositoryBaseTests {
 		List<SampleEntity> list = repository.findByKeywordIn(keywords);
 
 		// then
-        assertThat(list).hasSize(1);
+		assertThat(list).hasSize(1);
 		assertThat(list.get(0).getId()).isEqualTo(documentId1);
 	}
 
@@ -1366,6 +1369,53 @@ public abstract class CustomMethodRepositoryBaseTests {
 		stream.forEach(o -> assertThat(o).isInstanceOf(SampleEntity.class));
 	}
 
+	@Test // DATAES-717
+	void shouldReturnSearchHits() {
+		List<SampleEntity> entities = createSampleEntities("abc", 20);
+		repository.saveAll(entities);
+
+		// when
+		SearchHits<SampleEntity> searchHits = repository.queryByType("abc");
+
+		assertThat(searchHits.getTotalHits()).isEqualTo(20);
+	}
+
+	@Test // DATAES-717
+	void shouldReturnSearchHitList() {
+		List<SampleEntity> entities = createSampleEntities("abc", 20);
+		repository.saveAll(entities);
+
+		// when
+		List<SearchHit<SampleEntity>> searchHitList = repository.queryByMessage("Message");
+
+		assertThat(searchHitList).hasSize(20);
+	}
+
+	@Test // DATAES-717
+	void shouldReturnSearchHitStream() {
+		List<SampleEntity> entities = createSampleEntities("abc", 20);
+		repository.saveAll(entities);
+
+		// when
+		Stream<SearchHit<SampleEntity>> searchHitStream = repository.readByMessage("Message");
+
+		List<SearchHit<SampleEntity>> searchHitList = searchHitStream //
+				.peek(searchHit -> assertThat(searchHit.getContent().getType()).isEqualTo("abc")) //
+				.collect(Collectors.toList());
+		assertThat(searchHitList).hasSize(20);
+	}
+
+	@Test // DATAES-717
+	void shouldReturnSearchHitsForStringQuery() {
+		List<SampleEntity> entities = createSampleEntities("abc", 20);
+		repository.saveAll(entities);
+
+		// when
+		SearchHits<SampleEntity> searchHits = repository.queryByString("abc");
+
+		assertThat(searchHits.getTotalHits()).isEqualTo(20);
+	}
+
 	private List<SampleEntity> createSampleEntities(String type, int numberOfEntities) {
 
 		List<SampleEntity> entities = new ArrayList<>();
@@ -1386,8 +1436,7 @@ public abstract class CustomMethodRepositoryBaseTests {
 	@NoArgsConstructor
 	@AllArgsConstructor
 	@Builder
-	@Document(indexName = "test-index-sample-repositories-custo-method", replicas = 0,
-			refreshInterval = "-1")
+	@Document(indexName = "test-index-sample-repositories-custom-method", replicas = 0, refreshInterval = "-1")
 	static class SampleEntity {
 
 		@Id private String id;
@@ -1502,6 +1551,15 @@ public abstract class CustomMethodRepositoryBaseTests {
 		long countByLocationNear(Point point, Distance distance);
 
 		long countByLocationNear(GeoPoint point, String distance);
+
+		SearchHits<SampleEntity> queryByType(String type);
+
+		@Query("{\"bool\": {\"must\": [{\"term\": {\"type\": \"?0\"}}]}}")
+		SearchHits<SampleEntity> queryByString(String type);
+
+		List<SearchHit<SampleEntity>> queryByMessage(String type);
+
+		Stream<SearchHit<SampleEntity>> readByMessage(String type);
 	}
 
 	/**


### PR DESCRIPTION
…ead of a list.

Repositories now support the following additional return types:

- `SearchHits<T>`
- `List<SearchHit<T>>`
- `Stream<SearchHit<T>>`
- `Flux<SearchHit<T>>`