### PR TITLE
DATAES-623 - Add bulk operations for ReactiveElasticsearchRepository …

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/ReactiveDocumentOperations.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ReactiveDocumentOperations.java
@@ -93,6 +93,7 @@ public interface ReactiveDocumentOperations {
 	 * @param index the target index, must not be {@literal null}
 	 * @param <T>
 	 * @return a {@link Flux} emitting saved entities.
+	 * @since 4.0
 	 */
 	default <T> Flux<T> saveAll(Iterable<T> entities, IndexCoordinates index) {
 		List<T> entityList = new ArrayList<>();
@@ -108,6 +109,7 @@ public interface ReactiveDocumentOperations {
 	 * @param index the target index, must not be {@literal null}
 	 * @param <T>
 	 * @return a {@link Flux} emitting saved entities.
+	 * @since 4.0
 	 */
 	<T> Flux<T> saveAll(Mono<? extends Collection<? extends T>> entities, IndexCoordinates index);
 
@@ -118,6 +120,7 @@ public interface ReactiveDocumentOperations {
 	 * @param clazz the type of the object to be returned
 	 * @param index the index(es) from which the objects are read.
 	 * @return flux with list of nullable objects
+	 * @since 4.0
 	 */
 	<T> Flux<T> multiGet(Query query, Class<T> clazz, IndexCoordinates index);
 
@@ -125,6 +128,7 @@ public interface ReactiveDocumentOperations {
 	 * Bulk update all objects. Will do update.
 	 *
 	 * @param queries the queries to execute in bulk
+	 * @since 4.0
 	 */
 	default Mono<Void> bulkUpdate(List<UpdateQuery> queries, IndexCoordinates index) {
 		return bulkUpdate(queries, BulkOptions.defaultOptions(), index);
@@ -135,6 +139,7 @@ public interface ReactiveDocumentOperations {
 	 *
 	 * @param queries the queries to execute in bulk
 	 * @param bulkOptions options to be added to the bulk request
+	 * @since 4.0
 	 */
 	Mono<Void> bulkUpdate(List<UpdateQuery> queries, BulkOptions bulkOptions, IndexCoordinates index);
 

--- a/src/main/java/org/springframework/data/elasticsearch/core/ReactiveDocumentOperations.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ReactiveDocumentOperations.java
@@ -15,17 +15,16 @@
  */
 package org.springframework.data.elasticsearch.core;
 
-import org.reactivestreams.Publisher;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.query.BulkOptions;
-import org.springframework.data.elasticsearch.core.query.IndexQuery;
 import org.springframework.data.elasticsearch.core.query.Query;
 import org.springframework.data.elasticsearch.core.query.UpdateQuery;
+import org.springframework.util.Assert;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import org.springframework.util.Assert;
-
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -96,7 +95,9 @@ public interface ReactiveDocumentOperations {
 	 * @return a {@link Flux} emitting saved entities.
 	 */
 	default <T> Flux<T> saveAll(Iterable<T> entities, IndexCoordinates index) {
-		return saveAll(Flux.fromIterable(entities), index);
+		List<T> entityList = new ArrayList<>();
+		entities.forEach(entityList::add);
+		return saveAll(Mono.just(entityList), index);
 	}
 
 	/**
@@ -108,7 +109,7 @@ public interface ReactiveDocumentOperations {
 	 * @param <T>
 	 * @return a {@link Flux} emitting saved entities.
 	 */
-	<T> Flux<T> saveAll(Publisher<T> entities, IndexCoordinates index);
+	<T> Flux<T> saveAll(Mono<? extends Collection<? extends T>> entities, IndexCoordinates index);
 
 	/**
 	 * Execute a multiGet against elasticsearch for the given ids.
@@ -119,23 +120,6 @@ public interface ReactiveDocumentOperations {
 	 * @return flux with list of nullable objects
 	 */
 	<T> Flux<T> multiGet(Query query, Class<T> clazz, IndexCoordinates index);
-
-	/**
-	 * Bulk index all objects. Will do save or update.
-	 *
-	 * @param queries the queries to execute in bulk
-	 */
-	default Mono<Void> bulkIndex(List<IndexQuery> queries, IndexCoordinates index) {
-		return bulkIndex(queries, BulkOptions.defaultOptions(), index);
-	}
-
-	/**
-	 * Bulk index all objects. Will do save or update.
-	 *
-	 * @param queries the queries to execute in bulk
-	 * @param bulkOptions options to be added to the bulk request
-	 */
-	Mono<Void> bulkIndex(List<IndexQuery> queries, BulkOptions bulkOptions, IndexCoordinates index);
 
 	/**
 	 * Bulk update all objects. Will do update.

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchEntityInformation.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchEntityInformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.data.elasticsearch.repository.support;
 import org.elasticsearch.index.VersionType;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.repository.core.EntityInformation;
+import org.springframework.lang.Nullable;
 
 /**
  * @param <T>
@@ -27,6 +28,7 @@ import org.springframework.data.repository.core.EntityInformation;
  * @author Christoph Strobl
  * @author Ivan Greene
  * @author Peter-Josef Meisch
+ * @author Aleksei Arsenev
  */
 public interface ElasticsearchEntityInformation<T, ID> extends EntityInformation<T, ID> {
 
@@ -34,9 +36,11 @@ public interface ElasticsearchEntityInformation<T, ID> extends EntityInformation
 
 	IndexCoordinates getIndexCoordinates();
 
+	@Nullable
 	Long getVersion(T entity);
 
 	VersionType getVersionType();
 
+	@Nullable
 	String getParentId(T entity);
 }

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/SimpleReactiveElasticsearchRepository.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/SimpleReactiveElasticsearchRepository.java
@@ -184,9 +184,9 @@ public class SimpleReactiveElasticsearchRepository<T, ID> implements ReactiveEla
 
 		Assert.notNull(entityStream, "EntityStream must not be null!");
 		return Flux.from(entityStream) //
-				.map(o -> {
+				.map(entity -> {
 
-					ID id = entityInformation.getId(o);
+					ID id = entityInformation.getId(entity);
 					if (id == null) {
 						throw new IllegalStateException("Entity id must not be null!");
 					}

--- a/src/test/java/org/springframework/data/elasticsearch/core/ReactiveElasticsearchTemplateTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ReactiveElasticsearchTemplateTests.java
@@ -738,24 +738,6 @@ public class ReactiveElasticsearchTemplateTests {
 	}
 
 	@Test // DATAES-623
-	public void shouldDoBulkIndex() {
-		SampleEntity entity1 = randomEntity("test message 1");
-		entity1.rate = 1;
-		SampleEntity entity2 = randomEntity("test message 2");
-		entity2.rate = 2;
-
-		List<IndexQuery> indexQueries = getIndexQueries(entity1, entity2);
-		template.bulkIndex(indexQueries, IndexCoordinates.of(DEFAULT_INDEX)).block();
-
-		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
-		template.search(searchQuery, SampleEntity.class, IndexCoordinates.of(DEFAULT_INDEX)) //
-				.as(StepVerifier::create) //
-				.expectNextMatches(hit -> entity1.equals(hit.getContent()) || entity2.equals(hit.getContent())) //
-				.expectNextMatches(hit -> entity1.equals(hit.getContent()) || entity2.equals(hit.getContent())) //
-				.verifyComplete();
-	}
-
-	@Test // DATAES-623
 	public void shouldDoBulkUpdate() {
 		SampleEntity entity1 = randomEntity("test message 1");
 		entity1.rate = 1;
@@ -796,7 +778,7 @@ public class ReactiveElasticsearchTemplateTests {
 		SampleEntity entity2 = randomEntity("test message 2");
 		entity2.rate = 2;
 
-		template.saveAll(Flux.fromArray(new SampleEntity[]{entity1, entity2}), IndexCoordinates.of(DEFAULT_INDEX)) //
+		template.saveAll(Mono.just(Arrays.asList(entity1, entity2)), IndexCoordinates.of(DEFAULT_INDEX)) //
 				.as(StepVerifier::create) //
 				.expectNext(entity1) //
 				.expectNext(entity2) //


### PR DESCRIPTION
See https://jira.spring.io/projects/DATAES/issues/DATAES-623

Summary:
- add `multiGet`/`bulkIndex`/`bulkUpdate`/`saveAll` methods to `ReactiveDocumentOperations`
- replace `findAllById`/`saveAll`/`deleteById`/`deleteAll` implementations in `SimpleReactiveElasticsearchRepository` to use bulk methods

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
