### PR TITLE
DATAES-372 - Support highlighting via annotation.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/annotations/Highlight.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/Highlight.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Peter-Josef Meisch
+ * @since 4.0
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Highlight {
+
+	HighlightParameters parameters() default @HighlightParameters;
+
+	HighlightField[] fields();
+}

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/HighlightField.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/HighlightField.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * @author Peter-Josef Meisch
+ * @since 4.0
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HighlightField {
+
+	/**
+	 * The name of the field to apply highlighting to. This must be the field name of the entity's property, not the name
+	 * of the field in the index mappings.
+	 */
+	String name() default "";
+
+	HighlightParameters parameters() default @HighlightParameters;
+}

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/HighlightParameters.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/HighlightParameters.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * @author Peter-Josef Meisch
+ * @since 4.0
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HighlightParameters {
+	String boundaryChars() default "";
+
+	int boundaryMaxScan() default -1;
+
+	String boundaryScanner() default "";
+
+	String boundaryScannerLocale() default "";
+
+	/**
+	 * only used for {@link Highlight}s.
+	 */
+	String encoder() default "";
+
+	boolean forceSource() default false;
+
+	String fragmenter() default "";
+
+	/**
+	 * only used for {@link HighlightField}s.
+	 */
+	int fragmentOffset() default -1;
+
+	int fragmentSize() default -1;
+
+	/**
+	 * only used for {@link HighlightField}s.
+	 */
+	String[] matchedFields() default {};
+
+	int noMatchSize() default -1;
+
+	int numberOfFragments() default -1;
+
+	String order() default "";
+
+	int phraseLimit() default -1;
+
+	String[] preTags() default {};
+
+	String[] postTags() default {};
+
+	boolean requireFieldMatch() default true;
+
+	/**
+	 * only used for {@link Highlight}s.
+	 */
+	String tagsSchema() default "";
+
+	String type() default "";
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/RequestFactory.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/RequestFactory.java
@@ -241,20 +241,24 @@ class RequestFactory {
 	}
 
 	public HighlightBuilder highlightBuilder(Query query) {
-		HighlightBuilder highlightBuilder = null;
-		if (query instanceof NativeSearchQuery) {
-			NativeSearchQuery searchQuery = (NativeSearchQuery) query;
+		HighlightBuilder highlightBuilder = query.getHighlightQuery().map(HighlightQuery::getHighlightBuilder).orElse(null);
 
-			if (searchQuery.getHighlightFields() != null || searchQuery.getHighlightBuilder() != null) {
-				highlightBuilder = searchQuery.getHighlightBuilder();
+		if (highlightBuilder == null) {
 
-				if (highlightBuilder == null) {
-					highlightBuilder = new HighlightBuilder();
-				}
+			if (query instanceof NativeSearchQuery) {
+				NativeSearchQuery searchQuery = (NativeSearchQuery) query;
 
-				if (searchQuery.getHighlightFields() != null) {
-					for (HighlightBuilder.Field highlightField : searchQuery.getHighlightFields()) {
-						highlightBuilder.field(highlightField);
+				if (searchQuery.getHighlightFields() != null || searchQuery.getHighlightBuilder() != null) {
+					highlightBuilder = searchQuery.getHighlightBuilder();
+
+					if (highlightBuilder == null) {
+						highlightBuilder = new HighlightBuilder();
+					}
+
+					if (searchQuery.getHighlightFields() != null) {
+						for (HighlightBuilder.Field highlightField : searchQuery.getHighlightFields()) {
+							highlightBuilder.field(highlightField);
+						}
 					}
 				}
 			}

--- a/src/main/java/org/springframework/data/elasticsearch/core/SearchHit.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/SearchHit.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -76,6 +77,11 @@ public class SearchHit<T> {
 	 */
 	public List<Object> getSortValues() {
 		return Collections.unmodifiableList(sortValues);
+	}
+
+	public Map<String, List<String>> getHighlightFields() {
+		return Collections.unmodifiableMap(highlightFields.entrySet().stream()
+				.collect(Collectors.toMap(Map.Entry::getKey, entry -> Collections.unmodifiableList(entry.getValue()))));
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentEntity.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentEntity.java
@@ -16,6 +16,7 @@
 package org.springframework.data.elasticsearch.core.mapping;
 
 import org.elasticsearch.index.VersionType;
+import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.lang.Nullable;
 
@@ -80,4 +81,15 @@ public interface ElasticsearchPersistentEntity<T> extends PersistentEntity<T, El
 	@Nullable
 	@Deprecated
 	ElasticsearchPersistentProperty getScoreProperty();
+
+	/**
+	 * returns the {@link ElasticsearchPersistentProperty} with the given fieldName (may be set by the {@link Field}
+	 * annotation.
+	 *
+	 * @param fieldName to field name for the search, must not be {@literal null}
+	 * @return the found property, otherwise null
+	 * @since 4.0
+	 */
+	@Nullable
+	ElasticsearchPersistentProperty getPersistentPropertyWithFieldName(String fieldName);
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/AbstractQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/AbstractQuery.java
@@ -20,6 +20,7 @@ import static java.util.Collections.*;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -52,6 +53,7 @@ abstract class AbstractQuery implements Query {
 	protected boolean trackScores;
 	protected String preference;
 	protected Integer maxResults;
+	protected HighlightQuery highlightQuery;
 
 	@Override
 	public Sort getSort() {
@@ -195,4 +197,15 @@ abstract class AbstractQuery implements Query {
 	public void setMaxResults(Integer maxResults) {
 		this.maxResults = maxResults;
 	}
+
+	@Override
+	public void setHighlightQuery(HighlightQuery highlightQuery) {
+		this.highlightQuery = highlightQuery;
+	}
+
+	@Override
+	public Optional<HighlightQuery> getHighlightQuery() {
+		return Optional.ofNullable(highlightQuery);
+	}
+
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/HighlightQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/HighlightQuery.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core.query;
+
+import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
+
+/**
+ * Encapsulates an Elasticsearch {@link org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder} to prevent
+ * leaking of Elasticsearch classes into the query API.
+ * 
+ * @author Peter-Josef Meisch
+ * @since 4.0
+ */
+public class HighlightQuery {
+	private final HighlightBuilder highlightBuilder;
+
+	public HighlightQuery(HighlightBuilder highlightBuilder) {
+		this.highlightBuilder = highlightBuilder;
+	}
+
+	public HighlightBuilder getHighlightBuilder() {
+		return highlightBuilder;
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/HighlightQueryBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/HighlightQueryBuilder.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core.query;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.elasticsearch.search.fetch.subphase.highlight.AbstractHighlighterBuilder;
+import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
+import org.springframework.data.elasticsearch.annotations.Highlight;
+import org.springframework.data.elasticsearch.annotations.HighlightField;
+import org.springframework.data.elasticsearch.annotations.HighlightParameters;
+import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentEntity;
+import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentProperty;
+import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * Converts the {@link Highlight} annotation from a method to an Elasticsearch {@link HighlightBuilder}.
+ * 
+ * @author Peter-Josef Meisch
+ */
+public class HighlightQueryBuilder {
+
+	private final MappingContext<? extends ElasticsearchPersistentEntity<?>, ElasticsearchPersistentProperty> mappingContext;
+
+	public HighlightQueryBuilder(
+			MappingContext<? extends ElasticsearchPersistentEntity<?>, ElasticsearchPersistentProperty> mappingContext) {
+		this.mappingContext = mappingContext;
+	}
+
+	/**
+	 * creates a HighlightBuilder from an annotation
+	 * 
+	 * @param highlight, must not be {@literal null}
+	 * @param type the entity type, used to map field names. If null, field names are not mapped.
+	 * @return the builder for the highlight
+	 */
+	public HighlightQuery getHighlightQuery(Highlight highlight, @Nullable Class<?> type) {
+
+		Assert.notNull(highlight, "highlight must not be null");
+
+		HighlightBuilder highlightBuilder = new HighlightBuilder();
+
+		addParameters(highlight.parameters(), highlightBuilder, type);
+
+		for (HighlightField highlightField : highlight.fields()) {
+			String mappedName = mapFieldName(highlightField.name(), type);
+			HighlightBuilder.Field field = new HighlightBuilder.Field(mappedName);
+
+			addParameters(highlightField.parameters(), field, type);
+
+			highlightBuilder.field(field);
+		}
+
+		return new HighlightQuery(highlightBuilder);
+	}
+
+	private void addParameters(HighlightParameters parameters, AbstractHighlighterBuilder<?> builder, Class<?> type) {
+
+		if (StringUtils.hasLength(parameters.boundaryChars())) {
+			builder.boundaryChars(parameters.boundaryChars().toCharArray());
+		}
+
+		if (parameters.boundaryMaxScan() > -1) {
+			builder.boundaryMaxScan(parameters.boundaryMaxScan());
+		}
+
+		if (StringUtils.hasLength(parameters.boundaryScanner())) {
+			builder.boundaryScannerType(parameters.boundaryScanner());
+		}
+
+		if (StringUtils.hasLength(parameters.boundaryScannerLocale())) {
+			builder.boundaryScannerLocale(parameters.boundaryScannerLocale());
+		}
+
+		if (parameters.forceSource()) { // default is false
+			builder.forceSource(parameters.forceSource());
+		}
+
+		if (StringUtils.hasLength(parameters.fragmenter())) {
+			builder.fragmenter(parameters.fragmenter());
+		}
+
+		if (parameters.fragmentSize() > -1) {
+			builder.fragmentSize(parameters.fragmentSize());
+		}
+
+		if (parameters.noMatchSize() > -1) {
+			builder.noMatchSize(parameters.noMatchSize());
+		}
+
+		if (parameters.numberOfFragments() > -1) {
+			builder.numOfFragments(parameters.numberOfFragments());
+		}
+
+		if (StringUtils.hasLength(parameters.order())) {
+			builder.order(parameters.order());
+		}
+
+		if (parameters.phraseLimit() > -1) {
+			builder.phraseLimit(parameters.phraseLimit());
+		}
+
+		if (parameters.preTags().length > 0) {
+			builder.preTags(parameters.preTags());
+		}
+
+		if (parameters.postTags().length > 0) {
+			builder.postTags(parameters.postTags());
+		}
+
+		if (!parameters.requireFieldMatch()) { // default is true
+			builder.requireFieldMatch(parameters.requireFieldMatch());
+		}
+
+		if (StringUtils.hasLength(parameters.type())) {
+			builder.highlighterType(parameters.type());
+		}
+
+		if (builder instanceof HighlightBuilder) {
+			HighlightBuilder highlightBuilder = (HighlightBuilder) builder;
+
+			if (StringUtils.hasLength(parameters.encoder())) {
+				highlightBuilder.encoder(parameters.encoder());
+			}
+
+			if (StringUtils.hasLength(parameters.tagsSchema())) {
+				highlightBuilder.tagsSchema(parameters.tagsSchema());
+			}
+		}
+
+		if (builder instanceof HighlightBuilder.Field) {
+			HighlightBuilder.Field field = (HighlightBuilder.Field) builder;
+
+			if (parameters.fragmentOffset() > -1) {
+				field.fragmentOffset(parameters.fragmentOffset());
+			}
+
+			if (parameters.matchedFields().length > 0) {
+				field.matchedFields(Arrays.stream(parameters.matchedFields()) //
+						.map(fieldName -> mapFieldName(fieldName, type)) //
+						.collect(Collectors.toList()) //
+						.toArray(new String[] {})); //
+			}
+		}
+	}
+
+	private String mapFieldName(String fieldName, @Nullable Class<?> type) {
+
+		if (type != null) {
+			ElasticsearchPersistentEntity<?> persistentEntity = mappingContext.getPersistentEntity(type);
+
+			if (persistentEntity != null) {
+				ElasticsearchPersistentProperty persistentProperty = persistentEntity.getPersistentProperty(fieldName);
+
+				if (persistentProperty != null) {
+					return persistentProperty.getFieldName();
+				}
+			}
+		}
+
+		return fieldName;
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/Query.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/Query.java
@@ -17,6 +17,7 @@ package org.springframework.data.elasticsearch.core.query;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -24,6 +25,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.lang.Nullable;
 
 /**
  * Query
@@ -185,4 +187,19 @@ public interface Query {
 		return null;
 	}
 
+	/**
+	 * Sets the {@link HighlightQuery}.*
+	 * 
+	 * @param highlightQuery the query to set
+	 * @since 4.0
+	 */
+	void setHighlightQuery(@Nullable HighlightQuery highlightQuery);
+
+	/**
+	 * @return the optional set {@link HighlightQuery}.
+	 * @since 4.0
+	 */
+	default Optional<HighlightQuery> getHighlightQuery() {
+		return Optional.empty();
+	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/AbstractReactiveElasticsearchRepositoryQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/AbstractReactiveElasticsearchRepositoryQuery.java
@@ -84,6 +84,10 @@ abstract class AbstractReactiveElasticsearchRepositoryQuery implements Repositor
 		Query query = createQuery(
 				new ConvertingParameterAccessor(elasticsearchOperations.getElasticsearchConverter(), parameterAccessor));
 
+		if (queryMethod.hasAnnotatedHighlight()) {
+			query.setHighlightQuery(queryMethod.getAnnotatedHighlightQuery());
+		}
+
 		Class<?> targetType = processor.getReturnedType().getTypeToRead();
 		String indexName = queryMethod.getEntityInformation().getIndexName();
 		String indexTypeName = queryMethod.getEntityInformation().getIndexTypeName();

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchPartQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchPartQuery.java
@@ -58,12 +58,18 @@ public class ElasticsearchPartQuery extends AbstractElasticsearchRepositoryQuery
 
 	@Override
 	public Object execute(Object[] parameters) {
+		Class<?> clazz = queryMethod.getEntityInformation().getJavaType();
 		ParametersParameterAccessor accessor = new ParametersParameterAccessor(queryMethod.getParameters(), parameters);
+
 		CriteriaQuery query = createQuery(accessor);
+
 		Assert.notNull(query, "unsupported query");
 
-		Class<?> clazz = queryMethod.getEntityInformation().getJavaType();
 		elasticsearchConverter.updateQuery(query, clazz);
+
+		if (queryMethod.hasAnnotatedHighlight()) {
+			query.setHighlightQuery(queryMethod.getAnnotatedHighlightQuery());
+		}
 
 		IndexCoordinates index = elasticsearchOperations.getIndexCoordinatesFor(clazz);
 

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchStringQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchStringQuery.java
@@ -69,9 +69,17 @@ public class ElasticsearchStringQuery extends AbstractElasticsearchRepositoryQue
 
 	@Override
 	public Object execute(Object[] parameters) {
-		ParametersParameterAccessor accessor = new ParametersParameterAccessor(queryMethod.getParameters(), parameters);
-		StringQuery stringQuery = createQuery(accessor);
 		Class<?> clazz = queryMethod.getEntityInformation().getJavaType();
+		ParametersParameterAccessor accessor = new ParametersParameterAccessor(queryMethod.getParameters(), parameters);
+
+		StringQuery stringQuery = createQuery(accessor);
+
+		Assert.notNull(stringQuery, "unsupported query");
+
+		if (queryMethod.hasAnnotatedHighlight()) {
+			stringQuery.setHighlightQuery(queryMethod.getAnnotatedHighlightQuery());
+		}
+
 		IndexCoordinates index = elasticsearchOperations.getIndexCoordinatesFor(clazz);
 
 		Object result = null;

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ReactivePartTreeElasticsearchQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ReactivePartTreeElasticsearchQuery.java
@@ -46,6 +46,7 @@ public class ReactivePartTreeElasticsearchQuery extends AbstractReactiveElastics
 		if (tree.isLimiting()) {
 			query.setMaxResults(tree.getMaxResults());
 		}
+
 		return query;
 	}
 

--- a/src/test/java/org/springframework/data/elasticsearch/core/mapping/SimpleElasticsearchPersistentEntityTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/mapping/SimpleElasticsearchPersistentEntityTests.java
@@ -17,10 +17,10 @@ package org.springframework.data.elasticsearch.core.mapping;
 
 import static org.assertj.core.api.Assertions.*;
 
-import java.beans.IntrospectionException;
-
 import org.junit.jupiter.api.Test;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Version;
+import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.Score;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.model.Property;
@@ -79,6 +79,21 @@ public class SimpleElasticsearchPersistentEntityTests {
 				.withMessageContaining("second");
 	}
 
+	@Test
+	void shouldFindPropertiesByMappedName() {
+
+		SimpleElasticsearchMappingContext context = new SimpleElasticsearchMappingContext();
+		SimpleElasticsearchPersistentEntity<?> persistentEntity = context
+				.getRequiredPersistentEntity(FieldNameEntity.class);
+
+		ElasticsearchPersistentProperty persistentProperty = persistentEntity
+				.getPersistentPropertyWithFieldName("renamed-field");
+
+		assertThat(persistentProperty).isNotNull();
+		assertThat(persistentProperty.getName()).isEqualTo("renamedField");
+		assertThat(persistentProperty.getFieldName()).isEqualTo("renamed-field");
+	}
+
 	private static SimpleElasticsearchPersistentProperty createProperty(SimpleElasticsearchPersistentEntity<?> entity,
 			String field) {
 
@@ -129,5 +144,10 @@ public class SimpleElasticsearchPersistentEntityTests {
 
 		@Score float first;
 		@Score float second;
+	}
+
+	private static class FieldNameEntity {
+		@Id private String id;
+		@Field(name = "renamed-field") private String renamedField;
 	}
 }

--- a/src/test/java/org/springframework/data/elasticsearch/core/query/HighlightQueryBuilderTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/query/HighlightQueryBuilderTests.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core.query;
+
+import static org.skyscreamer.jsonassert.JSONAssert.*;
+
+import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.Highlight;
+import org.springframework.data.elasticsearch.annotations.HighlightField;
+import org.springframework.data.elasticsearch.annotations.HighlightParameters;
+import org.springframework.data.elasticsearch.core.ResourceUtil;
+import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
+import org.springframework.util.Assert;
+
+/**
+ * @author Peter-Josef Meisch
+ */
+@ExtendWith(MockitoExtension.class)
+class HighlightQueryBuilderTests {
+
+	private final SimpleElasticsearchMappingContext context = new SimpleElasticsearchMappingContext();
+
+	private HighlightQueryBuilder highlightQueryBuilder = new HighlightQueryBuilder(context);
+
+	@Test
+	void shouldProcessAnnotationWithNoParameters() throws NoSuchMethodException, JSONException {
+		Highlight highlight = getAnnotation("annotatedMethod");
+		String expected = ResourceUtil.readFileFromClasspath("/highlights/highlights.json");
+
+		HighlightBuilder highlightBuilder = highlightQueryBuilder.getHighlightQuery(highlight, HighlightEntity.class)
+				.getHighlightBuilder();
+		String actualStr = highlightBuilder.toString();
+		assertEquals(expected, actualStr, false);
+
+	}
+
+	@Test
+	void shouldProcessAnnotationWithParameters() throws NoSuchMethodException, JSONException {
+		Highlight highlight = getAnnotation("annotatedMethodWithManyValue");
+		String expected = ResourceUtil.readFileFromClasspath("/highlights/highlights-with-parameters.json");
+
+		HighlightBuilder highlightBuilder = highlightQueryBuilder.getHighlightQuery(highlight, HighlightEntity.class)
+				.getHighlightBuilder();
+		String actualStr = highlightBuilder.toString();
+
+		assertEquals(expected, actualStr, true);
+	}
+
+	private Highlight getAnnotation(String methodName) throws NoSuchMethodException {
+		Highlight highlight = HighlightQueryBuilderTests.class.getDeclaredMethod(methodName).getAnnotation(Highlight.class);
+
+		Assert.notNull(highlight, "no highlight annotation found");
+
+		return highlight;
+	}
+
+	/**
+	 * The annotation values on this method are just random values. The field has just one common parameters and the field
+	 * specific, the whole bunch pf parameters is tested on the top level. tagsSchema cannot be tested together with
+	 * preTags and postTags, ist it sets it's own values for these.
+	 */
+	// region test data
+	@Highlight(fields = { @HighlightField(name = "someField") })
+	private void annotatedMethod() {}
+
+	@Highlight( //
+			parameters = @HighlightParameters( //
+					boundaryChars = "#+*", //
+					boundaryMaxScan = 7, //
+					boundaryScanner = "chars", //
+					boundaryScannerLocale = "de-DE", //
+					encoder = "html", //
+					forceSource = true, //
+					fragmenter = "span", //
+					noMatchSize = 2, //
+					numberOfFragments = 3, //
+					fragmentSize = 5, //
+					order = "score", //
+					phraseLimit = 42, //
+					preTags = { "<ab>", "<cd>" }, //
+					postTags = { "</ab>", "</cd>" }, //
+					requireFieldMatch = false, //
+					type = "plain" //
+			), //
+			fields = { //
+					@HighlightField( //
+							name = "someField", //
+							parameters = @HighlightParameters( //
+									fragmentOffset = 3, //
+									matchedFields = { "someField", "otherField" }, //
+									numberOfFragments = 4) //
+					//
+					) //
+			} //
+	) //
+	private void annotatedMethodWithManyValue() {}
+
+	@Document(indexName = "dont-care")
+	private static class HighlightEntity {
+		@Id private String id;
+		@Field(name = "some-field") private String someField;
+		@Field(name = "other-field") private String otherField;
+
+		public String getId() {
+			return id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		public String getSomeField() {
+			return someField;
+		}
+
+		public void setSomeField(String someField) {
+			this.someField = someField;
+		}
+	}
+	// endregion
+}

--- a/src/test/resources/highlights/highlights-with-parameters.json
+++ b/src/test/resources/highlights/highlights-with-parameters.json
@@ -1,0 +1,34 @@
+{
+  "boundary_chars": "#+*",
+  "boundary_max_scan": 7,
+  "boundary_scanner": "CHARS",
+  "boundary_scanner_locale": "de-DE",
+  "encoder": "html",
+  "force_source": true,
+  "fragmenter": "span",
+  "fragment_size": 5,
+  "no_match_size": 2,
+  "number_of_fragments": 3,
+  "order": "score",
+  "phrase_limit": 42,
+  "pre_tags": [
+    "<ab>",
+    "<cd>"
+  ],
+  "post_tags": [
+    "</ab>",
+    "</cd>"
+  ],
+  "require_field_match": false,
+  "type": "plain",
+  "fields": {
+    "some-field": {
+      "fragment_offset": 3,
+      "number_of_fragments": 4,
+      "matched_fields": [
+        "some-field",
+        "other-field"
+      ]
+    }
+  }
+}

--- a/src/test/resources/highlights/highlights.json
+++ b/src/test/resources/highlights/highlights.json
@@ -1,0 +1,5 @@
+{
+  "fields": {
+    "some-field": {}
+  }
+}


### PR DESCRIPTION
Adding Highlight configuration per annotation for repository methods - non reactive and reactive. Works on standard methods and on `@Query` annotated methods.