### PR TITLE
DATAES-741 / Tests fail due to Elasticsearch cluster 'blocks' on near…

### DIFF
--- a/src/test/resources/node-client-configuration.yml
+++ b/src/test/resources/node-client-configuration.yml
@@ -1,3 +1,6 @@
 #enabled scripts - this require groovy
 #script.inline: true
 #node.max_local_storage_nodes: 100
+cluster.routing.allocation.disk.watermark.low: 1gb
+cluster.routing.allocation.disk.watermark.high: 1gb
+cluster.routing.allocation.disk.watermark.flood_stage: 1gb


### PR DESCRIPTION
…ly-full file-systems.

If a filesystem available space is lower than 5-10%, even though it may be dozens of gigabytes, Elasticsearch  may block all the indices making them work in read-only mode. In such a case, tests fail with messages like the following:

org.elasticsearch.cluster.block.ClusterBlockException: blocked by: [FORBIDDEN/12/index read-only / allow delete (api)]

The problem is well-known: https://stackoverflow.com/questions/50609417/elasticsearch-error-cluster-block-exception-forbidden-12-index-read-only-all

The idea of the fix is to configure Elasticsearch with absolute (instead of relative, using percentage) watermarks of a sensible size (like 1Gb) that are ok for tests.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
