### PR TITLE
DATAES-653 - Make it easier to use a custom request converter when ex…

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/client/reactive/DefaultRequestCreator.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/reactive/DefaultRequestCreator.java
@@ -1,0 +1,8 @@
+package org.springframework.data.elasticsearch.client.reactive;
+
+/**
+ * @author Roman Puchkovskiy
+ * @since 4.0
+ */
+class DefaultRequestCreator implements RequestCreator {
+}

--- a/src/main/java/org/springframework/data/elasticsearch/client/reactive/ReactiveRestClients.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/reactive/ReactiveRestClients.java
@@ -24,6 +24,7 @@ import org.springframework.util.Assert;
  *
  * @author Christoph Strobl
  * @author Mark Paluch
+ * @author Roman Puchkovskiy
  * @since 3.2
  */
 public final class ReactiveRestClients {
@@ -33,6 +34,8 @@ public final class ReactiveRestClients {
 	/**
 	 * Start here to create a new client tailored to your needs.
 	 *
+	 * @param clientConfiguration client configuration to use for building {@link ReactiveElasticsearchClient};
+	 *                            must not be {@literal null}.
 	 * @return new instance of {@link ReactiveElasticsearchClient}.
 	 */
 	public static ReactiveElasticsearchClient create(ClientConfiguration clientConfiguration) {
@@ -40,5 +43,22 @@ public final class ReactiveRestClients {
 		Assert.notNull(clientConfiguration, "ClientConfiguration must not be null!");
 
 		return DefaultReactiveElasticsearchClient.create(clientConfiguration);
+	}
+
+	/**
+	 * Start here to create a new client tailored to your needs.
+	 *
+	 * @param clientConfiguration client configuration to use for building {@link ReactiveElasticsearchClient};
+	 *                            must not be {@literal null}.
+	 * @param requestCreator request creator to use in the client; must not be {@literal null}.
+	 * @return new instance of {@link ReactiveElasticsearchClient}.
+	 */
+	public static ReactiveElasticsearchClient create(ClientConfiguration clientConfiguration,
+			RequestCreator requestCreator) {
+
+		Assert.notNull(clientConfiguration, "ClientConfiguration must not be null!");
+		Assert.notNull(requestCreator, "RequestCreator must not be null!");
+
+		return DefaultReactiveElasticsearchClient.create(clientConfiguration, requestCreator);
 	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/client/reactive/RequestCreator.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/reactive/RequestCreator.java
@@ -1,0 +1,134 @@
+package org.springframework.data.elasticsearch.client.reactive;
+
+import org.elasticsearch.action.admin.indices.close.CloseIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.admin.indices.flush.FlushRequest;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.open.OpenIndexRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.MultiGetRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.main.MainRequest;
+import org.elasticsearch.action.search.ClearScrollRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchScrollRequest;
+import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.core.CountRequest;
+import org.elasticsearch.index.reindex.DeleteByQueryRequest;
+import org.springframework.data.elasticsearch.ElasticsearchException;
+import org.springframework.data.elasticsearch.client.util.RequestConverters;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+/**
+ * @author Roman Puchkovskiy
+ * @since 4.0
+ */
+public interface RequestCreator {
+
+	default Function<SearchRequest, Request> search() {
+		return RequestConverters::search;
+	}
+
+	default Function<SearchScrollRequest, Request> scroll() {
+		return RequestConverters::searchScroll;
+	}
+
+	default Function<ClearScrollRequest, Request> clearScroll() {
+		return RequestConverters::clearScroll;
+	}
+
+	default Function<IndexRequest, Request> index() {
+		return RequestConverters::index;
+	}
+
+	default Function<GetRequest, Request> get() {
+		return RequestConverters::get;
+	}
+
+	default Function<MainRequest, Request> ping() {
+		return (request) -> RequestConverters.ping();
+	}
+
+	default Function<MainRequest, Request> info() {
+		return (request) -> RequestConverters.info();
+	}
+
+	default Function<MultiGetRequest, Request> multiGet() {
+		return RequestConverters::multiGet;
+	}
+
+	default Function<GetRequest, Request> exists() {
+		return RequestConverters::exists;
+	}
+
+	default Function<UpdateRequest, Request> update() {
+		return RequestConverters::update;
+	}
+
+	default Function<DeleteRequest, Request> delete() {
+		return RequestConverters::delete;
+	}
+
+	default Function<DeleteByQueryRequest, Request> deleteByQuery() {
+		return RequestConverters::deleteByQuery;
+	}
+
+	default Function<BulkRequest, Request> bulk() {
+
+		return request -> {
+
+			try {
+				return RequestConverters.bulk(request);
+			} catch (IOException e) {
+				throw new ElasticsearchException("Could not parse request", e);
+			}
+		};
+	}
+
+	// --> INDICES
+
+	default Function<GetIndexRequest, Request> indexExists() {
+		return RequestConverters::indexExists;
+	}
+
+	default Function<DeleteIndexRequest, Request> indexDelete() {
+		return RequestConverters::indexDelete;
+	}
+
+	default Function<CreateIndexRequest, Request> indexCreate() {
+		return RequestConverters::indexCreate;
+	}
+
+	default Function<OpenIndexRequest, Request> indexOpen() {
+		return RequestConverters::indexOpen;
+	}
+
+	default Function<CloseIndexRequest, Request> indexClose() {
+		return RequestConverters::indexClose;
+	}
+
+	default Function<RefreshRequest, Request> indexRefresh() {
+		return RequestConverters::indexRefresh;
+	}
+
+	default Function<PutMappingRequest, Request> putMapping() {
+		return RequestConverters::putMapping;
+	}
+
+	default Function<FlushRequest, Request> flushIndex() {
+		return RequestConverters::flushIndex;
+	}
+
+	default Function<CountRequest, Request> count() {
+		return RequestConverters::count;
+	}
+
+}


### PR DESCRIPTION
…tending DefaultReactiveElasticsearchClient.

- convert RequestConverters class (with static methods) to RequestConverter interface (with default methods)
- use a default RequestConverter implementation in DefaultReactiveElasticsearchClient
- make it possible to supply a custom RequestConverter implementation to be used by DefaultReactiveElasticsearchClient to make it possible to customize how the requests are being built

This is a prototype to try the approach suggested in https://jira.spring.io/browse/DATAES-653

To be honest, I don't like the result too much. The problems are:

* A ton of default methods simply do not seem right. Maybe it's just that I'm not accustomed with interfaces having so much code; probably it's a matter of habit
* In this approach, it's natural to convert static methods to instance methods, but in Java 8 interfaces cannot have private instance methods, so all private methods need to remain static. The best I could do is move them to a separate class (`DefaultRequestConverters`), but here comes another problem: it's not clear what static methods need to remain static and which need to be accessible (package local? public?)

Maybe I just did not understand the idea of @sothawo (mentioned in DATAES-653) correctly.

But it seems that it would look better if we leave the interface (`RequestConverter`) an interface (with only abstract methods) and move all the code to `DefaultRequestConverter`. (In the future, when new methods would need to be added to the interface, they could be added as default methods to avoid breaking compilation of users code).

What do you think?

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
