### PR TITLE
DATAES-766 - Adapt RestClients class to change in InetSocketAddress c…

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/client/ClientConfiguration.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/ClientConfiguration.java
@@ -26,6 +26,7 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 
 import org.springframework.http.HttpHeaders;
+import org.springframework.lang.Nullable;
 import org.springframework.web.reactive.function.client.WebClient;
 
 /**
@@ -153,6 +154,7 @@ public interface ClientConfiguration {
 	 * @return the path prefix.
 	 * @since 4.0
 	 */
+	@Nullable
 	String getPathPrefix();
 
 	/**

--- a/src/main/java/org/springframework/data/elasticsearch/client/DefaultClientConfiguration.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/DefaultClientConfiguration.java
@@ -47,14 +47,15 @@ class DefaultClientConfiguration implements ClientConfiguration {
 	private final @Nullable SSLContext sslContext;
 	private final Duration soTimeout;
 	private final Duration connectTimeout;
-	private final String pathPrefix;
+	private final @Nullable String pathPrefix;
 	private final @Nullable HostnameVerifier hostnameVerifier;
-	private final String proxy;
-	private final Function<WebClient, WebClient> webClientConfigurer;
+	private final @Nullable String proxy;
+	private final @Nullable Function<WebClient, WebClient> webClientConfigurer;
 
 	DefaultClientConfiguration(List<InetSocketAddress> hosts, HttpHeaders headers, boolean useSsl,
 			@Nullable SSLContext sslContext, Duration soTimeout, Duration connectTimeout, @Nullable String pathPrefix,
-			@Nullable HostnameVerifier hostnameVerifier, String proxy, Function<WebClient, WebClient> webClientConfigurer) {
+			@Nullable HostnameVerifier hostnameVerifier, @Nullable String proxy,
+			@Nullable Function<WebClient, WebClient> webClientConfigurer) {
 
 		this.hosts = Collections.unmodifiableList(new ArrayList<>(hosts));
 		this.headers = new HttpHeaders(headers);
@@ -103,6 +104,7 @@ class DefaultClientConfiguration implements ClientConfiguration {
 		return this.soTimeout;
 	}
 
+	@Nullable
 	@Override
 	public String getPathPrefix() {
 		return this.pathPrefix;

--- a/src/main/java/org/springframework/data/elasticsearch/client/RestClients.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/RestClients.java
@@ -55,6 +55,7 @@ import org.springframework.util.Assert;
  * @author Mark Paluch
  * @author Huw Ayling-Miller
  * @author Henrique Amaral
+ * @author Peter-Josef Meisch
  * @since 3.2
  */
 public final class RestClients {
@@ -134,7 +135,7 @@ public final class RestClients {
 	}
 
 	private static List<String> formattedHosts(List<InetSocketAddress> hosts, boolean useSsl) {
-		return hosts.stream().map(it -> (useSsl ? "https" : "http") + "://" + it).collect(Collectors.toList());
+		return hosts.stream().map(it -> (useSsl ? "https" : "http") + "://" + it.getHostString() + ":" + it.getPort()).collect(Collectors.toList());
 	}
 
 	/**


### PR DESCRIPTION
…lass in JDK14.

In JDK 14 the `InetSocketAddress.toString()` method changed for unresolved addresses to _hostname/\<unresolved>:port_. So it is necessary to explicitly construct the connection string