### PR TITLE
DATAES-786 - Move the creation of SearchHit(s) from ElasticsearchConv…

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/SearchHitMapping.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/SearchHitMapping.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.elasticsearch.search.aggregations.Aggregations;
+import org.springframework.data.elasticsearch.core.document.SearchDocument;
+import org.springframework.data.elasticsearch.core.document.SearchDocumentResponse;
+import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentEntity;
+import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentProperty;
+import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * @author Rizwan Idrees
+ * @author Mohsin Husen
+ * @author Christoph Strobl
+ * @author Peter-Josef Meisch
+ * @author Mark Paluch
+ * @author Roman Puchkovskiy
+ * @since 4.0
+ */
+class SearchHitMapping<T> {
+	private final Class<T> type;
+	private final MappingContext<? extends ElasticsearchPersistentEntity<?>, ElasticsearchPersistentProperty> mappingContext;
+
+	private SearchHitMapping(Class<T> type,
+			MappingContext<? extends ElasticsearchPersistentEntity<?>, ElasticsearchPersistentProperty> context) {
+
+		Assert.notNull(type, "type is null");
+		Assert.notNull(context, "context is null");
+
+		this.type = type;
+		this.mappingContext = context;
+	}
+
+	static <T> SearchHitMapping<T> mappingFor(Class<T> entityClass,
+			MappingContext<? extends ElasticsearchPersistentEntity<?>, ElasticsearchPersistentProperty> context) {
+		return new SearchHitMapping<>(entityClass, context);
+	}
+
+	SearchHit<T> mapHit(SearchDocument searchDocument, T content) {
+
+		Assert.notNull(searchDocument, "searchDocument is null");
+		Assert.notNull(content, "content is null");
+
+		String id = searchDocument.hasId() ? searchDocument.getId() : null;
+		float score = searchDocument.getScore();
+		Object[] sortValues = searchDocument.getSortValues();
+		Map<String, List<String>> highlightFields = getHighlightsAndRemapFieldNames(searchDocument);
+
+		return new SearchHit<>(id, score, sortValues, highlightFields, content);
+	}
+
+	SearchHits<T> mapHits(SearchDocumentResponse searchDocumentResponse, List<T> contents) {
+		return mapHitsFromResponse(searchDocumentResponse, contents);
+	}
+
+	SearchScrollHits<T> mapScrollHits(SearchDocumentResponse searchDocumentResponse, List<T> contents) {
+		return mapHitsFromResponse(searchDocumentResponse, contents);
+	}
+
+	private SearchHitsImpl<T> mapHitsFromResponse(SearchDocumentResponse searchDocumentResponse, List<T> contents) {
+
+		Assert.notNull(searchDocumentResponse, "searchDocumentResponse is null");
+		Assert.notNull(contents, "contents is null");
+
+		Assert.isTrue(searchDocumentResponse.getSearchDocuments().size() == contents.size(),
+				"Count of documents must match the count of entities");
+
+		long totalHits = searchDocumentResponse.getTotalHits();
+		float maxScore = searchDocumentResponse.getMaxScore();
+		String scrollId = searchDocumentResponse.getScrollId();
+
+		List<SearchHit<T>> searchHits = new ArrayList<>();
+		List<SearchDocument> searchDocuments = searchDocumentResponse.getSearchDocuments();
+		for (int i = 0; i < searchDocuments.size(); i++) {
+			SearchDocument document = searchDocuments.get(i);
+			T content = contents.get(i);
+			SearchHit<T> hit = mapHit(document, content);
+			searchHits.add(hit);
+		}
+		Aggregations aggregations = searchDocumentResponse.getAggregations();
+		TotalHitsRelation totalHitsRelation = TotalHitsRelation
+				.valueOf(searchDocumentResponse.getTotalHitsRelation());
+
+		return new SearchHitsImpl<>(totalHits, totalHitsRelation, maxScore, scrollId, searchHits, aggregations);
+	}
+
+	@Nullable
+	private Map<String, List<String>> getHighlightsAndRemapFieldNames(SearchDocument searchDocument) {
+		Map<String, List<String>> highlightFields = searchDocument.getHighlightFields();
+
+		if (highlightFields == null) {
+			return null;
+		}
+
+		ElasticsearchPersistentEntity<?> persistentEntity = mappingContext.getPersistentEntity(type);
+		if (persistentEntity == null) {
+			return highlightFields;
+		}
+
+		return highlightFields.entrySet().stream().collect(Collectors.toMap(entry -> {
+			ElasticsearchPersistentProperty property = persistentEntity.getPersistentPropertyWithFieldName
+					(entry.getKey());
+			return property != null ? property.getName() : entry.getKey();
+		}, Map.Entry::getValue));
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchConverter.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchConverter.java
@@ -15,16 +15,8 @@
  */
 package org.springframework.data.elasticsearch.core.convert;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.springframework.data.convert.EntityConverter;
-import org.springframework.data.elasticsearch.core.SearchHit;
-import org.springframework.data.elasticsearch.core.SearchHits;
-import org.springframework.data.elasticsearch.core.SearchScrollHits;
 import org.springframework.data.elasticsearch.core.document.Document;
-import org.springframework.data.elasticsearch.core.document.SearchDocument;
-import org.springframework.data.elasticsearch.core.document.SearchDocumentResponse;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentEntity;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentProperty;
 import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
@@ -39,6 +31,7 @@ import org.springframework.util.Assert;
  * @author Christoph Strobl
  * @author Peter-Josef Meisch
  * @author Sasch Woo
+ * @author Roman Puchkovskiy
  */
 public interface ElasticsearchConverter
 		extends EntityConverter<ElasticsearchPersistentEntity<?>, ElasticsearchPersistentProperty, Object, Document> {
@@ -52,67 +45,6 @@ public interface ElasticsearchConverter
 	default ProjectionFactory getProjectionFactory() {
 		return new SpelAwareProxyProjectionFactory();
 	}
-
-	// region read
-	/**
-	 * Map a single {@link Document} to an instance of the given type.
-	 *
-	 * @param document the document to map
-	 * @param type must not be {@literal null}.
-	 * @param <T> the class of type
-	 * @return can be {@literal null} if the document is null or {@link Document#isEmpty()} is true.
-	 * @since 4.0
-	 */
-	@Nullable
-	<T> T mapDocument(@Nullable Document document, Class<T> type);
-
-	/**
-	 * Map a list of {@link Document}s to a list of instance of the given type.
-	 *
-	 * @param documents must not be {@literal null}.
-	 * @param type must not be {@literal null}.
-	 * @param <T> the class of type
-	 * @return a list obtained by calling {@link #mapDocument(Document, Class)} on the elements of the list.
-	 * @since 4.0
-	 */
-	default <T> List<T> mapDocuments(List<Document> documents, Class<T> type) {
-		return documents.stream().map(document -> mapDocument(document, type)).collect(Collectors.toList());
-	}
-
-	/**
-	 * builds a {@link SearchHits} from a {@link SearchDocumentResponse}.
-	 * 
-	 * @param <T> the clazz of the type, must not be {@literal null}.
-	 * @param type the type of the returned data, must not be {@literal null}.
-	 * @param searchDocumentResponse the response to read from, must not be {@literal null}.
-	 * @return a SearchHits object
-	 * @since 4.0
-	 */
-	<T> SearchHits<T> read(Class<T> type, SearchDocumentResponse searchDocumentResponse);
-	
-	/**
-	 * builds a {@link SearchScrollHits} from a {@link SearchDocumentResponse}.
-	 * 
-	 * @param <T> the clazz of the type, must not be {@literal null}.
-	 * @param type the type of the returned data, must not be {@literal null}.
-	 * @param searchDocumentResponse the response to read from, must not be {@literal null}.
-	 * @return a {@link SearchScrollHits} object
-	 * @since 4.0
-	 */
-	<T> SearchScrollHits<T> readScroll(Class<T> type, SearchDocumentResponse searchDocumentResponse);
-
-	/**
-	 * builds a {@link SearchHit} from a {@link SearchDocument}.
-	 *
-	 * @param <T> the clazz of the type, must not be {@literal null}.
-	 * @param type the type of the returned data, must not be {@literal null}.
-	 * @param searchDocument must not be {@literal null}
-	 * @return SearchHit with all available information filled in
-	 * @since 4.0
-	 */
-	<T> SearchHit<T> read(Class<T> type, SearchDocument searchDocument);
-
-	// endregion
 
 	// region write
 	/**

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
@@ -1060,7 +1060,7 @@ public abstract class ElasticsearchTemplateTests {
 		while (scroll.hasSearchHits()) {
 			sampleEntities.addAll(scroll.getSearchHits());
 			scroll = ((AbstractElasticsearchTemplate) operations).searchScrollContinue(scroll.getScrollId(), 1000,
-					SampleEntity.class);
+					SampleEntity.class, index);
 		}
 		((AbstractElasticsearchTemplate) operations).searchScrollClear(scroll.getScrollId());
 		assertThat(sampleEntities).hasSize(30);
@@ -1087,7 +1087,7 @@ public abstract class ElasticsearchTemplateTests {
 		while (scroll.hasSearchHits()) {
 			sampleEntities.addAll(scroll.getSearchHits());
 			scroll = ((AbstractElasticsearchTemplate) operations).searchScrollContinue(scroll.getScrollId(), 1000,
-					SampleEntity.class);
+					SampleEntity.class, index);
 		}
 		((AbstractElasticsearchTemplate) operations).searchScrollClear(scroll.getScrollId());
 		assertThat(sampleEntities).hasSize(30);
@@ -1115,7 +1115,8 @@ public abstract class ElasticsearchTemplateTests {
 		while (scroll.hasSearchHits()) {
 			sampleEntities.addAll(scroll.getSearchHits());
 			scrollId = scroll.getScrollId();
-			scroll = ((AbstractElasticsearchTemplate) operations).searchScrollContinue(scrollId, 1000, SampleEntity.class);
+			scroll = ((AbstractElasticsearchTemplate) operations).searchScrollContinue(scrollId, 1000,
+					SampleEntity.class, index);
 		}
 		((AbstractElasticsearchTemplate) operations).searchScrollClear(scrollId);
 		assertThat(sampleEntities).hasSize(30);
@@ -1142,7 +1143,8 @@ public abstract class ElasticsearchTemplateTests {
 		while (scroll.hasSearchHits()) {
 			sampleEntities.addAll(scroll.getSearchHits());
 			scrollId = scroll.getScrollId();
-			scroll = ((AbstractElasticsearchTemplate) operations).searchScrollContinue(scrollId, 1000, SampleEntity.class);
+			scroll = ((AbstractElasticsearchTemplate) operations).searchScrollContinue(scrollId, 1000,
+					SampleEntity.class, index);
 		}
 		((AbstractElasticsearchTemplate) operations).searchScrollClear(scrollId);
 		assertThat(sampleEntities).hasSize(30);
@@ -1169,7 +1171,8 @@ public abstract class ElasticsearchTemplateTests {
 		while (scroll.hasSearchHits()) {
 			sampleEntities.addAll(scroll.getSearchHits());
 			scrollId = scroll.getScrollId();
-			scroll = ((AbstractElasticsearchTemplate) operations).searchScrollContinue(scrollId, 1000, SampleEntity.class);
+			scroll = ((AbstractElasticsearchTemplate) operations).searchScrollContinue(scrollId, 1000,
+					SampleEntity.class, index);
 		}
 		((AbstractElasticsearchTemplate) operations).searchScrollClear(scrollId);
 		assertThat(sampleEntities).hasSize(30);
@@ -1196,7 +1199,8 @@ public abstract class ElasticsearchTemplateTests {
 		while (scroll.hasSearchHits()) {
 			sampleEntities.addAll(scroll.getSearchHits());
 			scrollId = scroll.getScrollId();
-			scroll = ((AbstractElasticsearchTemplate) operations).searchScrollContinue(scrollId, 1000, SampleEntity.class);
+			scroll = ((AbstractElasticsearchTemplate) operations).searchScrollContinue(scrollId, 1000,
+					SampleEntity.class, index);
 		}
 		((AbstractElasticsearchTemplate) operations).searchScrollClear(scrollId);
 		assertThat(sampleEntities).hasSize(30);
@@ -1223,7 +1227,8 @@ public abstract class ElasticsearchTemplateTests {
 		while (scroll.hasSearchHits()) {
 			sampleEntities.addAll(scroll.getSearchHits());
 			scrollId = scroll.getScrollId();
-			scroll = ((AbstractElasticsearchTemplate) operations).searchScrollContinue(scrollId, 1000, SampleEntity.class);
+			scroll = ((AbstractElasticsearchTemplate) operations).searchScrollContinue(scrollId, 1000,
+					SampleEntity.class, index);
 		}
 		((AbstractElasticsearchTemplate) operations).searchScrollClear(scrollId);
 		assertThat(sampleEntities).hasSize(30);
@@ -1250,7 +1255,8 @@ public abstract class ElasticsearchTemplateTests {
 		while (scroll.hasSearchHits()) {
 			sampleEntities.addAll(scroll.getSearchHits());
 			scrollId = scroll.getScrollId();
-			scroll = ((AbstractElasticsearchTemplate) operations).searchScrollContinue(scrollId, 1000, SampleEntity.class);
+			scroll = ((AbstractElasticsearchTemplate) operations).searchScrollContinue(scrollId, 1000,
+					SampleEntity.class, index);
 		}
 		((AbstractElasticsearchTemplate) operations).searchScrollClear(scrollId);
 		assertThat(sampleEntities).hasSize(30);
@@ -1535,7 +1541,7 @@ public abstract class ElasticsearchTemplateTests {
 
 		while (scroll.hasSearchHits()) {
 			scroll = ((AbstractElasticsearchTemplate) operations).searchScrollContinue(scroll.getScrollId(),
-					scrollTimeInMillis, SampleEntity.class);
+					scrollTimeInMillis, SampleEntity.class, index);
 
 			entities.addAll(scroll.getSearchHits());
 		}
@@ -2436,7 +2442,7 @@ public abstract class ElasticsearchTemplateTests {
 		while (scroll.hasSearchHits()) {
 			sampleEntities.addAll(scroll.getSearchHits());
 			scroll = ((AbstractElasticsearchTemplate) operations).searchScrollContinue(scroll.getScrollId(), 1000,
-					SampleEntity.class);
+					SampleEntity.class, index);
 		}
 		((AbstractElasticsearchTemplate) operations).searchScrollClear(scroll.getScrollId());
 
@@ -2474,7 +2480,7 @@ public abstract class ElasticsearchTemplateTests {
 		while (scroll.hasSearchHits()) {
 			sampleEntities.addAll(scroll.getSearchHits());
 			scroll = ((AbstractElasticsearchTemplate) operations).searchScrollContinue(scroll.getScrollId(), 1000,
-					SampleEntity.class);
+					SampleEntity.class, index);
 		}
 		((AbstractElasticsearchTemplate) operations).searchScrollClear(scroll.getScrollId());
 
@@ -2507,7 +2513,7 @@ public abstract class ElasticsearchTemplateTests {
 		while (scroll.hasSearchHits()) {
 			sampleEntities.addAll(scroll.getSearchHits());
 			scroll = ((AbstractElasticsearchTemplate) operations).searchScrollContinue(scroll.getScrollId(), 1000,
-					SampleEntity.class);
+					SampleEntity.class, index);
 		}
 		((AbstractElasticsearchTemplate) operations).searchScrollClear(scroll.getScrollId());
 		assertThat(sampleEntities).hasSize(3);
@@ -2554,7 +2560,7 @@ public abstract class ElasticsearchTemplateTests {
 		while (scroll.hasSearchHits()) {
 			sampleEntities.addAll(scroll.getSearchHits());
 			scroll = ((AbstractElasticsearchTemplate) operations).searchScrollContinue(scroll.getScrollId(), 1000,
-					SampleEntity.class);
+					SampleEntity.class, index);
 		}
 
 		// then
@@ -2603,7 +2609,7 @@ public abstract class ElasticsearchTemplateTests {
 		while (scroll.hasSearchHits()) {
 			sampleEntities.addAll(scroll.getSearchHits());
 			scroll = ((AbstractElasticsearchTemplate) operations).searchScrollContinue(scroll.getScrollId(), 1000,
-					SampleEntity.class);
+					SampleEntity.class, index);
 		}
 
 		// then

--- a/src/test/java/org/springframework/data/elasticsearch/core/convert/MappingElasticsearchConverterUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/convert/MappingElasticsearchConverterUnitTests.java
@@ -253,11 +253,11 @@ public class MappingElasticsearchConverterUnitTests {
 	}
 
 	@Test // DATAES-530
-	public void shouldMapJsonStringToObject() {
+	public void shouldReadJsonStringToObject() {
 		// Given
 
 		// When
-		Car result = mappingElasticsearchConverter.mapDocument(Document.parse(JSON_STRING), Car.class);
+		Car result = mappingElasticsearchConverter.read(Car.class, Document.parse(JSON_STRING));
 
 		// Then
 		assertThat(result).isNotNull();


### PR DESCRIPTION
…erter closer to ElasticsearchTemplate.

The idea is to facilitate entity callbacks invocation (see DATAES-772).
The corresponding code is moved from ElasticsearchConverter closer to ElasticsearchTemplate implementations. It is basically separated into two parts: the 'entity reading' part (that materializes entities from Document and SearchDocument instances) and SearchHit/SearchHits/SearchScrollHits construction part. These parts are separated because the 'entity reading' will later include callback invocations, so it will use different interfaces (reactive/non-reactive) according to the context, while SearchHit/etc construction stays the same.
'entity reading' is moved to DocumentCallbacks that are introduced in this PR.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
