### PR TITLE
DATAES-791 - DocumentOperations.multiGet() implementations must retur…

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/DocumentOperations.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/DocumentOperations.java
@@ -16,7 +16,6 @@
 package org.springframework.data.elasticsearch.core;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.query.BulkOptions;
@@ -121,7 +120,7 @@ public interface DocumentOperations {
 	 * @param query the query defining the ids of the objects to get
 	 * @param clazz the type of the object to be returned
 	 * @param index the index(es) from which the objects are read.
-	 * @return list of objects
+	 * @return list of objects, contains null values for ids that are not found
 	 */
 	<T> List<T> multiGet(Query query, Class<T> clazz, IndexCoordinates index);
 

--- a/src/main/java/org/springframework/data/elasticsearch/core/document/DocumentAdapters.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/document/DocumentAdapters.java
@@ -118,16 +118,16 @@ public class DocumentAdapters {
 	 * Creates a List of {@link Document}s from {@link MultiGetResponse}.
 	 * 
 	 * @param source the source {@link MultiGetResponse}, not {@literal null}.
-	 * @return a possibly empty list of the Documents.
+	 * @return a list of Documents, contains null values for not found Documents.
 	 */
 	public static List<Document> from(MultiGetResponse source) {
 
 		Assert.notNull(source, "MultiGetResponse must not be null");
 
-		//noinspection ReturnOfNull
+		// noinspection ReturnOfNull
 		return Arrays.stream(source.getResponses()) //
 				.map(itemResponse -> itemResponse.isFailed() ? null : DocumentAdapters.from(itemResponse.getResponse())) //
-				.filter(Objects::nonNull).collect(Collectors.toList());
+				.collect(Collectors.toList());
 	}
 
 	/**
@@ -299,8 +299,7 @@ public class DocumentAdapters {
 		public Object get(Object key) {
 			return documentFields.stream() //
 					.filter(documentField -> documentField.getName().equals(key)) //
-					.map(DocumentField::getValue)
-					.findFirst() //
+					.map(DocumentField::getValue).findFirst() //
 					.orElse(null); //
 
 		}


### PR DESCRIPTION
…n null values for  not found entities.