### PR TITLE
DATAES-785 - Various entity callbacks implementation improvements.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/AbstractElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/AbstractElasticsearchTemplate.java
@@ -463,23 +463,23 @@ public abstract class AbstractElasticsearchTemplate implements ElasticsearchOper
 	// endregion
 
 	// region Entity callbacks
-	protected <T> T maybeCallbackBeforeConvert(T entity) {
+	protected <T> T maybeCallbackBeforeConvert(T entity, IndexCoordinates index) {
 
 		if (entityCallbacks != null) {
-			return entityCallbacks.callback(BeforeConvertCallback.class, entity);
+			return entityCallbacks.callback(BeforeConvertCallback.class, entity, index);
 		}
 
 		return entity;
 	}
 
-	protected void maybeCallbackBeforeConvertWithQuery(Object query) {
+	protected void maybeCallbackBeforeConvertWithQuery(Object query, IndexCoordinates index) {
 
 		if (query instanceof IndexQuery) {
 			IndexQuery indexQuery = (IndexQuery) query;
 			Object queryObject = indexQuery.getObject();
 
 			if (queryObject != null) {
-				queryObject = maybeCallbackBeforeConvert(queryObject);
+				queryObject = maybeCallbackBeforeConvert(queryObject, index);
 				indexQuery.setObject(queryObject);
 			}
 		}
@@ -487,8 +487,8 @@ public abstract class AbstractElasticsearchTemplate implements ElasticsearchOper
 
 	// this can be called with either a List<IndexQuery> or a List<UpdateQuery>; these query classes
 	// don't have a common base class, therefore the List<?> argument
-	protected void maybeCallbackBeforeConvertWithQueries(List<?> queries) {
-		queries.forEach(this::maybeCallbackBeforeConvertWithQuery);
+	protected void maybeCallbackBeforeConvertWithQueries(List<?> queries, IndexCoordinates index) {
+		queries.forEach(query -> maybeCallbackBeforeConvertWithQuery(query, index));
 	}
 
 	protected <T> T maybeCallbackAfterSave(T entity, IndexCoordinates index) {

--- a/src/main/java/org/springframework/data/elasticsearch/core/AbstractElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/AbstractElasticsearchTemplate.java
@@ -491,23 +491,23 @@ public abstract class AbstractElasticsearchTemplate implements ElasticsearchOper
 		queries.forEach(this::maybeCallbackBeforeConvertWithQuery);
 	}
 
-	protected <T> T maybeCallbackAfterSave(T entity) {
+	protected <T> T maybeCallbackAfterSave(T entity, IndexCoordinates index) {
 
 		if (entityCallbacks != null) {
-			return entityCallbacks.callback(AfterSaveCallback.class, entity);
+			return entityCallbacks.callback(AfterSaveCallback.class, entity, index);
 		}
 
 		return entity;
 	}
 
-	protected void maybeCallbackAfterSaveWithQuery(Object query) {
+	protected void maybeCallbackAfterSaveWithQuery(Object query, IndexCoordinates index) {
 
 		if (query instanceof IndexQuery) {
 			IndexQuery indexQuery = (IndexQuery) query;
 			Object queryObject = indexQuery.getObject();
 
 			if (queryObject != null) {
-				queryObject = maybeCallbackAfterSave(queryObject);
+				queryObject = maybeCallbackAfterSave(queryObject, index);
 				indexQuery.setObject(queryObject);
 			}
 		}
@@ -515,8 +515,8 @@ public abstract class AbstractElasticsearchTemplate implements ElasticsearchOper
 
 	// this can be called with either a List<IndexQuery> or a List<UpdateQuery>; these query classes
 	// don't have a common base class, therefore the List<?> argument
-	protected void maybeCallbackAfterSaveWithQueries(List<?> queries) {
-		queries.forEach(this::maybeCallbackAfterSaveWithQuery);
+	protected void maybeCallbackAfterSaveWithQueries(List<?> queries, IndexCoordinates index) {
+		queries.forEach(query -> maybeCallbackAfterSaveWithQuery(query, index));
 	}
 
 	protected <T> T maybeCallbackAfterConvert(T entity, Document document, IndexCoordinates index) {

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
@@ -136,7 +136,7 @@ public class ElasticsearchRestTemplate extends AbstractElasticsearchTemplate {
 	@Override
 	public String index(IndexQuery query, IndexCoordinates index) {
 
-		maybeCallbackBeforeConvertWithQuery(query);
+		maybeCallbackBeforeConvertWithQuery(query, index);
 
 		IndexRequest request = requestFactory.indexRequest(query, index);
 		String documentId = execute(client -> client.index(request, RequestOptions.DEFAULT).getId());
@@ -232,7 +232,7 @@ public class ElasticsearchRestTemplate extends AbstractElasticsearchTemplate {
 	}
 
 	private List<String> doBulkOperation(List<?> queries, BulkOptions bulkOptions, IndexCoordinates index) {
-		maybeCallbackBeforeConvertWithQueries(queries);
+		maybeCallbackBeforeConvertWithQueries(queries, index);
 		BulkRequest bulkRequest = requestFactory.bulkRequest(queries, bulkOptions, index);
 		List<String> ids = checkForBulkOperationFailure(
 				execute(client -> client.bulk(bulkRequest, RequestOptions.DEFAULT)));

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
@@ -147,7 +147,7 @@ public class ElasticsearchRestTemplate extends AbstractElasticsearchTemplate {
 			setPersistentEntityId(queryObject, documentId);
 		}
 
-		maybeCallbackAfterSaveWithQuery(query);
+		maybeCallbackAfterSaveWithQuery(query, index);
 
 		return documentId;
 	}
@@ -236,7 +236,7 @@ public class ElasticsearchRestTemplate extends AbstractElasticsearchTemplate {
 		BulkRequest bulkRequest = requestFactory.bulkRequest(queries, bulkOptions, index);
 		List<String> ids = checkForBulkOperationFailure(
 				execute(client -> client.bulk(bulkRequest, RequestOptions.DEFAULT)));
-		maybeCallbackAfterSaveWithQueries(queries);
+		maybeCallbackAfterSaveWithQueries(queries, index);
 		return ids;
 	}
 	// endregion

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
@@ -142,7 +142,7 @@ public class ElasticsearchTemplate extends AbstractElasticsearchTemplate {
 	@Override
 	public String index(IndexQuery query, IndexCoordinates index) {
 
-		maybeCallbackBeforeConvertWithQuery(query);
+		maybeCallbackBeforeConvertWithQuery(query, index);
 
 		IndexRequestBuilder indexRequestBuilder = requestFactory.indexRequestBuilder(client, query, index);
 		String documentId = indexRequestBuilder.execute().actionGet().getId();
@@ -245,7 +245,7 @@ public class ElasticsearchTemplate extends AbstractElasticsearchTemplate {
 	}
 
 	private List<String> doBulkOperation(List<?> queries, BulkOptions bulkOptions, IndexCoordinates index) {
-		maybeCallbackBeforeConvertWithQueries(queries);
+		maybeCallbackBeforeConvertWithQueries(queries, index);
 		BulkRequestBuilder bulkRequest = requestFactory.bulkRequestBuilder(client, queries, bulkOptions, index);
 		return checkForBulkOperationFailure(bulkRequest.execute().actionGet());
 	}

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
@@ -153,7 +153,7 @@ public class ElasticsearchTemplate extends AbstractElasticsearchTemplate {
 			setPersistentEntityId(queryObject, documentId);
 		}
 
-		maybeCallbackAfterSaveWithQuery(query);
+		maybeCallbackAfterSaveWithQuery(query, index);
 
 		return documentId;
 	}
@@ -196,7 +196,7 @@ public class ElasticsearchTemplate extends AbstractElasticsearchTemplate {
 
 		List<String> ids = doBulkOperation(queries, bulkOptions, index);
 
-		maybeCallbackAfterSaveWithQueries(queries);
+		maybeCallbackAfterSaveWithQueries(queries, index);
 
 		return ids;
 	}

--- a/src/main/java/org/springframework/data/elasticsearch/core/ReactiveElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ReactiveElasticsearchTemplate.java
@@ -332,7 +332,7 @@ public class ReactiveElasticsearchTemplate implements ReactiveElasticsearchOpera
 
 	private Mono<IndexResponse> doIndex(Object value, AdaptibleEntity<?> entity, IndexCoordinates index) {
 
-		return maybeCallBeforeConvert(value).flatMap(it -> {
+		return maybeCallBeforeConvert(value, index).flatMap(it -> {
 			IndexRequest request = getIndexRequest(value, entity, index);
 			request = prepareIndexRequest(value, request);
 			return doIndex(request);
@@ -876,10 +876,10 @@ public class ReactiveElasticsearchTemplate implements ReactiveElasticsearchOpera
 	}
 
 	// region callbacks
-	protected <T> Mono<T> maybeCallBeforeConvert(T entity) {
+	protected <T> Mono<T> maybeCallBeforeConvert(T entity, IndexCoordinates index) {
 
 		if (null != entityCallbacks) {
-			return entityCallbacks.callback(ReactiveBeforeConvertCallback.class, entity);
+			return entityCallbacks.callback(ReactiveBeforeConvertCallback.class, entity, index);
 		}
 
 		return Mono.just(entity);

--- a/src/main/java/org/springframework/data/elasticsearch/core/ReactiveElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ReactiveElasticsearchTemplate.java
@@ -190,7 +190,7 @@ public class ReactiveElasticsearchTemplate implements ReactiveElasticsearchOpera
 		return doIndex(entity, adaptableEntity, index) //
 				.map(it -> {
 					return adaptableEntity.populateIdIfNecessary(it.getId());
-				}).flatMap(this::maybeCallAfterSave);
+				}).flatMap(saved -> maybeCallAfterSave(saved, index));
 	}
 
 	@Override
@@ -222,7 +222,7 @@ public class ReactiveElasticsearchTemplate implements ReactiveElasticsearchOpera
 
 						AdaptibleEntity<? extends T> mappedEntity = iterator.next();
 						mappedEntity.populateIdIfNecessary(bulkItemResponse.getResponse().getId());
-						return maybeCallAfterSave(mappedEntity.getBean());
+						return maybeCallAfterSave(mappedEntity.getBean(), index);
 					});
 		});
 	}
@@ -885,10 +885,10 @@ public class ReactiveElasticsearchTemplate implements ReactiveElasticsearchOpera
 		return Mono.just(entity);
 	}
 
-	protected <T> Mono<T> maybeCallAfterSave(T entity) {
+	protected <T> Mono<T> maybeCallAfterSave(T entity, IndexCoordinates index) {
 
 		if (null != entityCallbacks) {
-			return entityCallbacks.callback(ReactiveAfterSaveCallback.class, entity);
+			return entityCallbacks.callback(ReactiveAfterSaveCallback.class, entity, index);
 		}
 
 		return Mono.just(entity);

--- a/src/main/java/org/springframework/data/elasticsearch/core/event/AfterSaveCallback.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/event/AfterSaveCallback.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.elasticsearch.core.event;
 
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.mapping.callback.EntityCallback;
 import org.springframework.data.mapping.callback.EntityCallbacks;
 
@@ -33,7 +34,8 @@ public interface AfterSaveCallback<T> extends EntityCallback<T> {
 	 * the domain object.
 	 *
 	 * @param entity the domain object that was saved.
+	 * @param index must not be {@literal null}.
 	 * @return the domain object that was persisted.
 	 */
-	T onAfterSave(T entity);
+	T onAfterSave(T entity, IndexCoordinates index);
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/event/AuditingEntityCallback.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/event/AuditingEntityCallback.java
@@ -18,6 +18,7 @@ package org.springframework.data.elasticsearch.core.event;
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.core.Ordered;
 import org.springframework.data.auditing.IsNewAwareAuditingHandler;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.mapping.callback.EntityCallback;
 import org.springframework.util.Assert;
 
@@ -25,6 +26,7 @@ import org.springframework.util.Assert;
  * {@link EntityCallback} to populate auditing related fields on an entity about to be saved.
  *
  * @author Peter-Josef Meisch
+ * @author Roman Puchkovskiy
  * @since 4.0
  */
 public class AuditingEntityCallback implements BeforeConvertCallback<Object>, Ordered {
@@ -45,7 +47,7 @@ public class AuditingEntityCallback implements BeforeConvertCallback<Object>, Or
 	}
 
 	@Override
-	public Object onBeforeConvert(Object entity) {
+	public Object onBeforeConvert(Object entity, IndexCoordinates index) {
 		return auditingHandlerFactory.getObject().markAudited(entity);
 	}
 

--- a/src/main/java/org/springframework/data/elasticsearch/core/event/BeforeConvertCallback.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/event/BeforeConvertCallback.java
@@ -15,12 +15,14 @@
  */
 package org.springframework.data.elasticsearch.core.event;
 
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.mapping.callback.EntityCallback;
 
 /**
  * Callback being invoked before a domain object is converted to be persisted.
  *
  * @author Peter-Josef Meisch
+ * @author Roman Puchkovskiy
  * @since 4.0
  */
 @FunctionalInterface
@@ -31,7 +33,8 @@ public interface BeforeConvertCallback<T> extends EntityCallback<T> {
 	 * the domain entity class.
 	 * 
 	 * @param entity the entity being converted
+	 * @param index must not be {@literal null}.
 	 * @return the entity to be converted
 	 */
-	T onBeforeConvert(T entity);
+	T onBeforeConvert(T entity, IndexCoordinates index);
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/event/ReactiveAfterSaveCallback.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/event/ReactiveAfterSaveCallback.java
@@ -16,6 +16,7 @@
 package org.springframework.data.elasticsearch.core.event;
 
 import org.reactivestreams.Publisher;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.mapping.callback.EntityCallback;
 import org.springframework.data.mapping.callback.ReactiveEntityCallbacks;
 
@@ -34,7 +35,8 @@ public interface ReactiveAfterSaveCallback<T> extends EntityCallback<T> {
 	 * the domain object.
 	 *
 	 * @param entity the domain object that was saved.
+	 * @param index must not be {@literal null}.
 	 * @return a {@link Publisher} emitting the domain object to be returned to the caller.
 	 */
-	Publisher<T> onAfterSave(T entity);
+	Publisher<T> onAfterSave(T entity, IndexCoordinates index);
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/event/ReactiveAuditingEntityCallback.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/event/ReactiveAuditingEntityCallback.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.elasticsearch.core.event;
 
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import reactor.core.publisher.Mono;
 
 import org.springframework.beans.factory.ObjectFactory;
@@ -27,6 +28,7 @@ import org.springframework.util.Assert;
  * {@link EntityCallback} to populate auditing related fields on an entity about to be saved.
  *
  * @author Peter-Josef Meisch
+ * @author Roman Puchkovskiy
  * @since 4.0
  */
 public class ReactiveAuditingEntityCallback implements ReactiveBeforeConvertCallback<Object>, Ordered {
@@ -47,7 +49,7 @@ public class ReactiveAuditingEntityCallback implements ReactiveBeforeConvertCall
 	}
 
 	@Override
-	public Mono<Object> onBeforeConvert(Object entity) {
+	public Mono<Object> onBeforeConvert(Object entity, IndexCoordinates index) {
 		return Mono.just(auditingHandlerFactory.getObject().markAudited(entity));
 	}
 

--- a/src/main/java/org/springframework/data/elasticsearch/core/event/ReactiveBeforeConvertCallback.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/event/ReactiveBeforeConvertCallback.java
@@ -16,12 +16,14 @@
 package org.springframework.data.elasticsearch.core.event;
 
 import org.reactivestreams.Publisher;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.mapping.callback.EntityCallback;
 
 /**
  * Callback being invoked before a domain object is converted to be persisted.
  *
  * @author Peter-Josef Meisch
+ * @author Roman Puchkovskiy
  * @since 4.0
  */
 @FunctionalInterface
@@ -32,7 +34,8 @@ public interface ReactiveBeforeConvertCallback<T> extends EntityCallback<T> {
 	 * the domain entity class.
 	 * 
 	 * @param entity the entity being converted
+	 * @param index must not be {@literal null}.
 	 * @return the entity to be converted
 	 */
-	Publisher<T> onBeforeConvert(T entity);
+	Publisher<T> onBeforeConvert(T entity, IndexCoordinates index);
 }

--- a/src/test/java/org/springframework/data/elasticsearch/config/AuditingIntegrationTest.java
+++ b/src/test/java/org/springframework/data/elasticsearch/config/AuditingIntegrationTest.java
@@ -31,12 +31,14 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.domain.Persistable;
 import org.springframework.data.elasticsearch.core.event.BeforeConvertCallback;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
 import org.springframework.data.mapping.callback.EntityCallbacks;
 import org.springframework.lang.Nullable;
 
 /**
  * @author Peter-Josef Meisch
+ * @author Roman Puchkovskiy
  */
 public abstract class AuditingIntegrationTest {
 
@@ -64,7 +66,7 @@ public abstract class AuditingIntegrationTest {
 
 		Entity entity = new Entity();
 		entity.setId("1");
-		entity = callbacks.callback(BeforeConvertCallback.class, entity);
+		entity = callbacks.callback(BeforeConvertCallback.class, entity, IndexCoordinates.of("index"));
 
 		assertThat(entity.getCreated()).isNotNull();
 		assertThat(entity.getModified()).isEqualTo(entity.created);
@@ -73,7 +75,7 @@ public abstract class AuditingIntegrationTest {
 
 		Thread.sleep(10);
 
-		entity = callbacks.callback(BeforeConvertCallback.class, entity);
+		entity = callbacks.callback(BeforeConvertCallback.class, entity, IndexCoordinates.of("index"));
 
 		assertThat(entity.getCreated()).isNotNull();
 		assertThat(entity.getModified()).isNotEqualTo(entity.created);

--- a/src/test/java/org/springframework/data/elasticsearch/config/ReactiveAuditingIntegrationTest.java
+++ b/src/test/java/org/springframework/data/elasticsearch/config/ReactiveAuditingIntegrationTest.java
@@ -33,6 +33,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.domain.Persistable;
 import org.springframework.data.elasticsearch.core.event.ReactiveBeforeConvertCallback;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
 import org.springframework.data.elasticsearch.junit.jupiter.ReactiveElasticsearchRestTemplateConfiguration;
 import org.springframework.data.elasticsearch.junit.jupiter.SpringIntegrationTest;
@@ -42,6 +43,7 @@ import org.springframework.test.context.ContextConfiguration;
 
 /**
  * @author Peter-Josef Meisch
+ * @author Roman Puchkovskiy
  */
 @SpringIntegrationTest
 @ContextConfiguration(classes = { ReactiveAuditingIntegrationTest.Config.class })
@@ -81,7 +83,7 @@ public class ReactiveAuditingIntegrationTest {
 
 		Entity entity = new Entity();
 		entity.setId("1");
-		entity = callbacks.callback(ReactiveBeforeConvertCallback.class, entity).block();
+		entity = callbacks.callback(ReactiveBeforeConvertCallback.class, entity, IndexCoordinates.of("index")).block();
 
 		assertThat(entity.getCreated()).isNotNull();
 		assertThat(entity.getModified()).isEqualTo(entity.created);
@@ -90,7 +92,7 @@ public class ReactiveAuditingIntegrationTest {
 
 		Thread.sleep(10);
 
-		entity = callbacks.callback(ReactiveBeforeConvertCallback.class, entity).block();
+		entity = callbacks.callback(ReactiveBeforeConvertCallback.class, entity, IndexCoordinates.of("index")).block();
 
 		assertThat(entity.getCreated()).isNotNull();
 		assertThat(entity.getModified()).isNotEqualTo(entity.created);

--- a/src/test/java/org/springframework/data/elasticsearch/core/AbstractElasticsearchTemplateCallbackTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/AbstractElasticsearchTemplateCallbackTests.java
@@ -86,7 +86,7 @@ abstract class AbstractElasticsearchTemplateCallbackTests {
 
 		Person saved = template.save(entity);
 
-		verify(afterSaveCallback).onAfterSave(eq(entity));
+		verify(afterSaveCallback).onAfterSave(eq(entity), any());
 		assertThat(saved.id).isEqualTo("after-save");
 	}
 
@@ -97,7 +97,7 @@ abstract class AbstractElasticsearchTemplateCallbackTests {
 
 		Person saved = template.save(entity, index);
 
-		verify(afterSaveCallback).onAfterSave(eq(entity));
+		verify(afterSaveCallback).onAfterSave(eq(entity), eq(index));
 		assertThat(saved.id).isEqualTo("after-save");
 	}
 
@@ -109,7 +109,7 @@ abstract class AbstractElasticsearchTemplateCallbackTests {
 
 		Iterable<Person> saved = template.save(entity1, entity2);
 
-		verify(afterSaveCallback, times(2)).onAfterSave(any());
+		verify(afterSaveCallback, times(2)).onAfterSave(any(), any());
 		Iterator<Person> savedIterator = saved.iterator();
 		assertThat(savedIterator.next().getId()).isEqualTo("after-save");
 		assertThat(savedIterator.next().getId()).isEqualTo("after-save");
@@ -123,7 +123,7 @@ abstract class AbstractElasticsearchTemplateCallbackTests {
 
 		Iterable<Person> saved = template.save(Arrays.asList(entity1, entity2));
 
-		verify(afterSaveCallback, times(2)).onAfterSave(any());
+		verify(afterSaveCallback, times(2)).onAfterSave(any(), any());
 		Iterator<Person> savedIterator = saved.iterator();
 		assertThat(savedIterator.next().getId()).isEqualTo("after-save");
 		assertThat(savedIterator.next().getId()).isEqualTo("after-save");
@@ -137,7 +137,7 @@ abstract class AbstractElasticsearchTemplateCallbackTests {
 
 		Iterable<Person> saved = template.save(Arrays.asList(entity1, entity2), index);
 
-		verify(afterSaveCallback, times(2)).onAfterSave(any());
+		verify(afterSaveCallback, times(2)).onAfterSave(any(), eq(index));
 		Iterator<Person> savedIterator = saved.iterator();
 		assertThat(savedIterator.next().getId()).isEqualTo("after-save");
 		assertThat(savedIterator.next().getId()).isEqualTo("after-save");
@@ -151,7 +151,7 @@ abstract class AbstractElasticsearchTemplateCallbackTests {
 		IndexQuery indexQuery = indexQueryForEntity(entity);
 		template.index(indexQuery, index);
 
-		verify(afterSaveCallback).onAfterSave(eq(entity));
+		verify(afterSaveCallback).onAfterSave(eq(entity), eq(index));
 		Person savedPerson = (Person) indexQuery.getObject();
 		assertThat(savedPerson.id).isEqualTo("after-save");
 	}
@@ -172,7 +172,7 @@ abstract class AbstractElasticsearchTemplateCallbackTests {
 		IndexQuery query2 = indexQueryForEntity(entity2);
 		template.bulkIndex(Arrays.asList(query1, query2), index);
 
-		verify(afterSaveCallback, times(2)).onAfterSave(any());
+		verify(afterSaveCallback, times(2)).onAfterSave(any(), eq(index));
 		Person savedPerson1 = (Person) query1.getObject();
 		Person savedPerson2 = (Person) query2.getObject();
 		assertThat(savedPerson1.getId()).isEqualTo("after-save");
@@ -189,7 +189,7 @@ abstract class AbstractElasticsearchTemplateCallbackTests {
 		IndexQuery query2 = indexQueryForEntity(entity2);
 		template.bulkIndex(Arrays.asList(query1, query2), BulkOptions.defaultOptions(), index);
 
-		verify(afterSaveCallback, times(2)).onAfterSave(any());
+		verify(afterSaveCallback, times(2)).onAfterSave(any(), eq(index));
 		Person savedPerson1 = (Person) query1.getObject();
 		Person savedPerson2 = (Person) query2.getObject();
 		assertThat(savedPerson1.getId()).isEqualTo("after-save");
@@ -530,7 +530,7 @@ abstract class AbstractElasticsearchTemplateCallbackTests {
 			implements AfterSaveCallback<Person> {
 
 		@Override
-		public Person onAfterSave(Person entity) {
+		public Person onAfterSave(Person entity, IndexCoordinates index) {
 
 			capture(entity);
 			return new Person() {

--- a/src/test/java/org/springframework/data/elasticsearch/core/ReactiveElasticsearchTemplateCallbackTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ReactiveElasticsearchTemplateCallbackTests.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -55,6 +56,7 @@ import org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsea
 import org.springframework.data.elasticsearch.core.document.Document;
 import org.springframework.data.elasticsearch.core.event.ReactiveAfterConvertCallback;
 import org.springframework.data.elasticsearch.core.event.ReactiveAfterSaveCallback;
+import org.springframework.data.elasticsearch.core.event.ReactiveBeforeConvertCallback;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
 import org.springframework.data.elasticsearch.core.query.Query;
@@ -81,6 +83,10 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 	@Mock private org.elasticsearch.search.SearchHit searchHit;
 
 	private final IndexCoordinates index = IndexCoordinates.of("index");
+
+	@Spy private ValueCapturingAfterSaveCallback afterSaveCallback = new ValueCapturingAfterSaveCallback();
+	@Spy private ValueCapturingAfterConvertCallback afterConvertCallback = new ValueCapturingAfterConvertCallback();
+	@Spy private ValueCapturingBeforeConvertCallback beforeConvertCallback = new ValueCapturingBeforeConvertCallback();
 
 	@BeforeEach
 	public void setUp() {
@@ -122,8 +128,6 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 	@Test // DATAES-771
 	void saveOneShouldInvokeAfterSaveCallbacks() {
 
-		ValueCapturingAfterSaveCallback afterSaveCallback = spy(new ValueCapturingAfterSaveCallback());
-
 		template.setEntityCallbacks(ReactiveEntityCallbacks.create(afterSaveCallback));
 
 		Person entity = new Person("init", "luke");
@@ -131,13 +135,11 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 		Person saved = template.save(entity).block(Duration.ofSeconds(1));
 
 		verify(afterSaveCallback).onAfterSave(eq(entity), any());
-		assertThat(saved.id).isEqualTo("after-save");
+		assertThat(saved.firstname).isEqualTo("after-save");
 	}
 
 	@Test // DATAES-771
 	void saveOneFromPublisherShouldInvokeAfterSaveCallbacks() {
-
-		ValueCapturingAfterSaveCallback afterSaveCallback = spy(new ValueCapturingAfterSaveCallback());
 
 		template.setEntityCallbacks(ReactiveEntityCallbacks.create(afterSaveCallback));
 
@@ -146,13 +148,11 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 		Person saved = template.save(Mono.just(entity)).block(Duration.ofSeconds(1));
 
 		verify(afterSaveCallback).onAfterSave(eq(entity), any());
-		assertThat(saved.id).isEqualTo("after-save");
+		assertThat(saved.firstname).isEqualTo("after-save");
 	}
 
 	@Test // DATAES-771
 	void saveWithIndexCoordinatesShouldInvokeAfterSaveCallbacks() {
-
-		ValueCapturingAfterSaveCallback afterSaveCallback = spy(new ValueCapturingAfterSaveCallback());
 
 		template.setEntityCallbacks(ReactiveEntityCallbacks.create(afterSaveCallback));
 
@@ -161,13 +161,11 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 		Person saved = template.save(entity, index).block(Duration.ofSeconds(1));
 
 		verify(afterSaveCallback).onAfterSave(eq(entity), eq(index));
-		assertThat(saved.id).isEqualTo("after-save");
+		assertThat(saved.firstname).isEqualTo("after-save");
 	}
 
 	@Test // DATAES-771
 	void saveFromPublisherWithIndexCoordinatesShouldInvokeAfterSaveCallbacks() {
-
-		ValueCapturingAfterSaveCallback afterSaveCallback = spy(new ValueCapturingAfterSaveCallback());
 
 		template.setEntityCallbacks(ReactiveEntityCallbacks.create(afterSaveCallback));
 
@@ -176,13 +174,11 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 		Person saved = template.save(Mono.just(entity), index).block(Duration.ofSeconds(1));
 
 		verify(afterSaveCallback).onAfterSave(eq(entity), eq(index));
-		assertThat(saved.id).isEqualTo("after-save");
+		assertThat(saved.firstname).isEqualTo("after-save");
 	}
 
 	@Test // DATAES-771
 	void saveAllShouldInvokeAfterSaveCallbacks() {
-
-		ValueCapturingAfterSaveCallback afterSaveCallback = spy(new ValueCapturingAfterSaveCallback());
 
 		template.setEntityCallbacks(ReactiveEntityCallbacks.create(afterSaveCallback));
 
@@ -193,14 +189,12 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 				.collect(Collectors.toList());
 
 		verify(afterSaveCallback, times(2)).onAfterSave(any(), eq(index));
-		assertThat(saved.get(0).getId()).isEqualTo("after-save");
-		assertThat(saved.get(1).getId()).isEqualTo("after-save");
+		assertThat(saved.get(0).firstname).isEqualTo("after-save");
+		assertThat(saved.get(1).firstname).isEqualTo("after-save");
 	}
 
 	@Test // DATAES-771
 	void saveFromMonoAllShouldInvokeAfterSaveCallbacks() {
-
-		ValueCapturingAfterSaveCallback afterSaveCallback = spy(new ValueCapturingAfterSaveCallback());
 
 		template.setEntityCallbacks(ReactiveEntityCallbacks.create(afterSaveCallback));
 
@@ -211,14 +205,12 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 				.toStream().collect(Collectors.toList());
 
 		verify(afterSaveCallback, times(2)).onAfterSave(any(), eq(index));
-		assertThat(saved.get(0).getId()).isEqualTo("after-save");
-		assertThat(saved.get(1).getId()).isEqualTo("after-save");
+		assertThat(saved.get(0).firstname).isEqualTo("after-save");
+		assertThat(saved.get(1).firstname).isEqualTo("after-save");
 	}
 
 	@Test // DATAES-772
 	void multiGetShouldInvokeAfterConvertCallbacks() {
-
-		ValueCapturingAfterConvertCallback afterConvertCallback = spy(new ValueCapturingAfterConvertCallback());
 
 		template.setEntityCallbacks(ReactiveEntityCallbacks.create(afterConvertCallback));
 
@@ -227,14 +219,12 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 
 		verify(afterConvertCallback, times(2)).onAfterConvert(eq(new Person("init", "luke")), eq(lukeDocument()),
 				eq(index));
-		assertThat(results.get(0).id).isEqualTo("after-convert");
-		assertThat(results.get(1).id).isEqualTo("after-convert");
+		assertThat(results.get(0).firstname).isEqualTo("after-convert");
+		assertThat(results.get(1).firstname).isEqualTo("after-convert");
 	}
 
 	@Test // DATAES-772
 	void findByIdShouldInvokeAfterConvertCallbacks() {
-
-		ValueCapturingAfterConvertCallback afterConvertCallback = spy(new ValueCapturingAfterConvertCallback());
 
 		template.setEntityCallbacks(ReactiveEntityCallbacks.create(afterConvertCallback));
 
@@ -242,13 +232,11 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 		Person result = template.findById("init", Person.class).block(Duration.ofSeconds(1));
 
 		verify(afterConvertCallback).onAfterConvert(eq(new Person("init", "luke")), eq(lukeDocument()), any());
-		assertThat(result.id).isEqualTo("after-convert");
+		assertThat(result.firstname).isEqualTo("after-convert");
 	}
 
 	@Test // DATAES-772
 	void findByIdWithIndexCoordinatesShouldInvokeAfterConvertCallbacks() {
-
-		ValueCapturingAfterConvertCallback afterConvertCallback = spy(new ValueCapturingAfterConvertCallback());
 
 		template.setEntityCallbacks(ReactiveEntityCallbacks.create(afterConvertCallback));
 
@@ -256,39 +244,33 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 		Person result = template.findById("init", Person.class, index).block(Duration.ofSeconds(1));
 
 		verify(afterConvertCallback).onAfterConvert(eq(new Person("init", "luke")), eq(lukeDocument()), eq(index));
-		assertThat(result.id).isEqualTo("after-convert");
+		assertThat(result.firstname).isEqualTo("after-convert");
 	}
 
 	@Test // DATAES-772
 	void getShouldInvokeAfterConvertCallbacks() {
-
-		ValueCapturingAfterConvertCallback afterConvertCallback = spy(new ValueCapturingAfterConvertCallback());
 
 		template.setEntityCallbacks(ReactiveEntityCallbacks.create(afterConvertCallback));
 
 		Person result = template.get("init", Person.class).block(Duration.ofSeconds(1));
 
 		verify(afterConvertCallback).onAfterConvert(eq(new Person("init", "luke")), eq(lukeDocument()), any());
-		assertThat(result.id).isEqualTo("after-convert");
+		assertThat(result.firstname).isEqualTo("after-convert");
 	}
 
 	@Test // DATAES-772
 	void getWithIndexCoordinatesShouldInvokeAfterConvertCallbacks() {
-
-		ValueCapturingAfterConvertCallback afterConvertCallback = spy(new ValueCapturingAfterConvertCallback());
 
 		template.setEntityCallbacks(ReactiveEntityCallbacks.create(afterConvertCallback));
 
 		Person result = template.get("init", Person.class, index).block(Duration.ofSeconds(1));
 
 		verify(afterConvertCallback).onAfterConvert(eq(new Person("init", "luke")), eq(lukeDocument()), eq(index));
-		assertThat(result.id).isEqualTo("after-convert");
+		assertThat(result.firstname).isEqualTo("after-convert");
 	}
 
 	@Test // DATAES-772
 	void findUsingPageableShouldInvokeAfterConvertCallbacks() {
-
-		ValueCapturingAfterConvertCallback afterConvertCallback = spy(new ValueCapturingAfterConvertCallback());
 
 		template.setEntityCallbacks(ReactiveEntityCallbacks.create(afterConvertCallback));
 
@@ -297,8 +279,8 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 				.collect(Collectors.toList());
 
 		verify(afterConvertCallback, times(2)).onAfterConvert(eq(new Person("init", "luke")), eq(lukeDocument()), any());
-		assertThat(results.get(0).id).isEqualTo("after-convert");
-		assertThat(results.get(1).id).isEqualTo("after-convert");
+		assertThat(results.get(0).firstname).isEqualTo("after-convert");
+		assertThat(results.get(1).firstname).isEqualTo("after-convert");
 	}
 
 	private Query pagedQueryForTwo() {
@@ -313,8 +295,6 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 	@Test // DATAES-772
 	void findUsingScrollShouldInvokeAfterConvertCallbacks() {
 
-		ValueCapturingAfterConvertCallback afterConvertCallback = spy(new ValueCapturingAfterConvertCallback());
-
 		template.setEntityCallbacks(ReactiveEntityCallbacks.create(afterConvertCallback));
 
 		@SuppressWarnings("deprecation") // we know what we test
@@ -322,8 +302,8 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 				.collect(Collectors.toList());
 
 		verify(afterConvertCallback, times(2)).onAfterConvert(eq(new Person("init", "luke")), eq(lukeDocument()), any());
-		assertThat(results.get(0).id).isEqualTo("after-convert");
-		assertThat(results.get(1).id).isEqualTo("after-convert");
+		assertThat(results.get(0).firstname).isEqualTo("after-convert");
+		assertThat(results.get(1).firstname).isEqualTo("after-convert");
 	}
 
 	private Query scrollingQueryForTwo() {
@@ -333,8 +313,6 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 	@Test // DATAES-772
 	void findWithIndexCoordinatesShouldInvokeAfterConvertCallbacks() {
 
-		ValueCapturingAfterConvertCallback afterConvertCallback = spy(new ValueCapturingAfterConvertCallback());
-
 		template.setEntityCallbacks(ReactiveEntityCallbacks.create(afterConvertCallback));
 
 		@SuppressWarnings("deprecation") // we know what we test
@@ -343,14 +321,12 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 
 		verify(afterConvertCallback, times(2)).onAfterConvert(eq(new Person("init", "luke")), eq(lukeDocument()),
 				eq(index));
-		assertThat(results.get(0).id).isEqualTo("after-convert");
-		assertThat(results.get(1).id).isEqualTo("after-convert");
+		assertThat(results.get(0).firstname).isEqualTo("after-convert");
+		assertThat(results.get(1).firstname).isEqualTo("after-convert");
 	}
 
 	@Test // DATAES-772
 	void findWithReturnTypeShouldInvokeAfterConvertCallbacks() {
-
-		ValueCapturingAfterConvertCallback afterConvertCallback = spy(new ValueCapturingAfterConvertCallback());
 
 		template.setEntityCallbacks(ReactiveEntityCallbacks.create(afterConvertCallback));
 
@@ -359,14 +335,12 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 				.toStream().collect(Collectors.toList());
 
 		verify(afterConvertCallback, times(2)).onAfterConvert(eq(new Person("init", "luke")), eq(lukeDocument()), any());
-		assertThat(results.get(0).id).isEqualTo("after-convert");
-		assertThat(results.get(1).id).isEqualTo("after-convert");
+		assertThat(results.get(0).firstname).isEqualTo("after-convert");
+		assertThat(results.get(1).firstname).isEqualTo("after-convert");
 	}
 
 	@Test // DATAES-772
 	void findWithReturnTypeAndIndexCoordinatesShouldInvokeAfterConvertCallbacks() {
-
-		ValueCapturingAfterConvertCallback afterConvertCallback = spy(new ValueCapturingAfterConvertCallback());
 
 		template.setEntityCallbacks(ReactiveEntityCallbacks.create(afterConvertCallback));
 
@@ -376,14 +350,12 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 
 		verify(afterConvertCallback, times(2)).onAfterConvert(eq(new Person("init", "luke")), eq(lukeDocument()),
 				eq(index));
-		assertThat(results.get(0).id).isEqualTo("after-convert");
-		assertThat(results.get(1).id).isEqualTo("after-convert");
+		assertThat(results.get(0).firstname).isEqualTo("after-convert");
+		assertThat(results.get(1).firstname).isEqualTo("after-convert");
 	}
 
 	@Test // DATAES-772
 	void searchShouldInvokeAfterConvertCallbacks() {
-
-		ValueCapturingAfterConvertCallback afterConvertCallback = spy(new ValueCapturingAfterConvertCallback());
 
 		template.setEntityCallbacks(ReactiveEntityCallbacks.create(afterConvertCallback));
 
@@ -391,14 +363,12 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 				.toStream().collect(Collectors.toList());
 
 		verify(afterConvertCallback, times(2)).onAfterConvert(eq(new Person("init", "luke")), eq(lukeDocument()), any());
-		assertThat(results.get(0).getContent().id).isEqualTo("after-convert");
-		assertThat(results.get(1).getContent().id).isEqualTo("after-convert");
+		assertThat(results.get(0).getContent().firstname).isEqualTo("after-convert");
+		assertThat(results.get(1).getContent().firstname).isEqualTo("after-convert");
 	}
 
 	@Test // DATAES-772
 	void searchWithIndexCoordinatesShouldInvokeAfterConvertCallbacks() {
-
-		ValueCapturingAfterConvertCallback afterConvertCallback = spy(new ValueCapturingAfterConvertCallback());
 
 		template.setEntityCallbacks(ReactiveEntityCallbacks.create(afterConvertCallback));
 
@@ -407,14 +377,12 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 
 		verify(afterConvertCallback, times(2)).onAfterConvert(eq(new Person("init", "luke")), eq(lukeDocument()),
 				eq(index));
-		assertThat(results.get(0).getContent().id).isEqualTo("after-convert");
-		assertThat(results.get(1).getContent().id).isEqualTo("after-convert");
+		assertThat(results.get(0).getContent().firstname).isEqualTo("after-convert");
+		assertThat(results.get(1).getContent().firstname).isEqualTo("after-convert");
 	}
 
 	@Test // DATAES-772
 	void searchWithResultTypeShouldInvokeAfterConvertCallbacks() {
-
-		ValueCapturingAfterConvertCallback afterConvertCallback = spy(new ValueCapturingAfterConvertCallback());
 
 		template.setEntityCallbacks(ReactiveEntityCallbacks.create(afterConvertCallback));
 
@@ -422,14 +390,12 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 				.timeout(Duration.ofSeconds(1)).toStream().collect(Collectors.toList());
 
 		verify(afterConvertCallback, times(2)).onAfterConvert(eq(new Person("init", "luke")), eq(lukeDocument()), any());
-		assertThat(results.get(0).getContent().id).isEqualTo("after-convert");
-		assertThat(results.get(1).getContent().id).isEqualTo("after-convert");
+		assertThat(results.get(0).getContent().firstname).isEqualTo("after-convert");
+		assertThat(results.get(1).getContent().firstname).isEqualTo("after-convert");
 	}
 
 	@Test // DATAES-772
 	void searchWithResultTypeAndIndexCoordinatesShouldInvokeAfterConvertCallbacks() {
-
-		ValueCapturingAfterConvertCallback afterConvertCallback = spy(new ValueCapturingAfterConvertCallback());
 
 		template.setEntityCallbacks(ReactiveEntityCallbacks.create(afterConvertCallback));
 
@@ -438,8 +404,37 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 
 		verify(afterConvertCallback, times(2)).onAfterConvert(eq(new Person("init", "luke")), eq(lukeDocument()),
 				eq(index));
-		assertThat(results.get(0).getContent().id).isEqualTo("after-convert");
-		assertThat(results.get(1).getContent().id).isEqualTo("after-convert");
+		assertThat(results.get(0).getContent().firstname).isEqualTo("after-convert");
+		assertThat(results.get(1).getContent().firstname).isEqualTo("after-convert");
+	}
+
+	@Test // DATAES-785
+	void saveOneShouldInvokeBeforeConvertCallbacks() {
+
+		template.setEntityCallbacks(ReactiveEntityCallbacks.create(beforeConvertCallback));
+
+		Person entity = new Person("init1", "luke1");
+
+		Person saved = template.save(entity, index).block(Duration.ofSeconds(1));
+
+		verify(beforeConvertCallback).onBeforeConvert(any(), eq(index));
+		assertThat(saved.firstname).isEqualTo("before-convert");
+	}
+
+	@Test // DATAES-785
+	void saveAllShouldInvokeBeforeConvertCallbacks() {
+
+		template.setEntityCallbacks(ReactiveEntityCallbacks.create(beforeConvertCallback));
+
+		Person entity1 = new Person("init1", "luke1");
+		Person entity2 = new Person("init2", "luke2");
+
+		List<Person> saved = template.saveAll(Arrays.asList(entity1, entity2), index).toStream()
+				.collect(Collectors.toList());
+
+		verify(beforeConvertCallback, times(2)).onBeforeConvert(any(), eq(index));
+		assertThat(saved.get(0).firstname).isEqualTo("before-convert");
+		assertThat(saved.get(1).firstname).isEqualTo("before-convert");
 	}
 
 	@Data
@@ -480,8 +475,8 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 				capture(entity);
 				Person newPerson = new Person() {
 					{
-						id = "after-save";
-						firstname = entity.firstname;
+						id = entity.id;
+						firstname = "after-save";
 					}
 				};
 				return Mono.just(newPerson);
@@ -499,8 +494,27 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 				capture(entity);
 				Person newPerson = new Person() {
 					{
-						id = "after-convert";
-						firstname = entity.firstname;
+						id = entity.id;
+						firstname = "after-convert";
+					}
+				};
+				return Mono.just(newPerson);
+			});
+		}
+	}
+
+	static class ValueCapturingBeforeConvertCallback extends ValueCapturingEntityCallback<Person>
+			implements ReactiveBeforeConvertCallback<Person> {
+
+		@Override
+		public Mono<Person> onBeforeConvert(Person entity, IndexCoordinates index) {
+
+			return Mono.defer(() -> {
+				capture(entity);
+				Person newPerson = new Person() {
+					{
+						id = entity.id;
+						firstname = "before-convert";
 					}
 				};
 				return Mono.just(newPerson);

--- a/src/test/java/org/springframework/data/elasticsearch/core/ReactiveElasticsearchTemplateCallbackTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ReactiveElasticsearchTemplateCallbackTests.java
@@ -130,7 +130,7 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 
 		Person saved = template.save(entity).block(Duration.ofSeconds(1));
 
-		verify(afterSaveCallback).onAfterSave(eq(entity));
+		verify(afterSaveCallback).onAfterSave(eq(entity), any());
 		assertThat(saved.id).isEqualTo("after-save");
 	}
 
@@ -145,7 +145,7 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 
 		Person saved = template.save(Mono.just(entity)).block(Duration.ofSeconds(1));
 
-		verify(afterSaveCallback).onAfterSave(eq(entity));
+		verify(afterSaveCallback).onAfterSave(eq(entity), any());
 		assertThat(saved.id).isEqualTo("after-save");
 	}
 
@@ -158,9 +158,9 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 
 		Person entity = new Person("init", "luke");
 
-		Person saved = template.save(entity, IndexCoordinates.of("index")).block(Duration.ofSeconds(1));
+		Person saved = template.save(entity, index).block(Duration.ofSeconds(1));
 
-		verify(afterSaveCallback).onAfterSave(eq(entity));
+		verify(afterSaveCallback).onAfterSave(eq(entity), eq(index));
 		assertThat(saved.id).isEqualTo("after-save");
 	}
 
@@ -173,9 +173,9 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 
 		Person entity = new Person("init", "luke");
 
-		Person saved = template.save(Mono.just(entity), IndexCoordinates.of("index")).block(Duration.ofSeconds(1));
+		Person saved = template.save(Mono.just(entity), index).block(Duration.ofSeconds(1));
 
-		verify(afterSaveCallback).onAfterSave(eq(entity));
+		verify(afterSaveCallback).onAfterSave(eq(entity), eq(index));
 		assertThat(saved.id).isEqualTo("after-save");
 	}
 
@@ -189,10 +189,10 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 		Person entity1 = new Person("init1", "luke1");
 		Person entity2 = new Person("init2", "luke2");
 
-		List<Person> saved = template.saveAll(Arrays.asList(entity1, entity2), IndexCoordinates.of("index")).toStream()
+		List<Person> saved = template.saveAll(Arrays.asList(entity1, entity2), index).toStream()
 				.collect(Collectors.toList());
 
-		verify(afterSaveCallback, times(2)).onAfterSave(any());
+		verify(afterSaveCallback, times(2)).onAfterSave(any(), eq(index));
 		assertThat(saved.get(0).getId()).isEqualTo("after-save");
 		assertThat(saved.get(1).getId()).isEqualTo("after-save");
 	}
@@ -207,10 +207,10 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 		Person entity1 = new Person("init1", "luke1");
 		Person entity2 = new Person("init2", "luke2");
 
-		List<Person> saved = template.saveAll(Mono.just(Arrays.asList(entity1, entity2)), IndexCoordinates.of("index"))
+		List<Person> saved = template.saveAll(Mono.just(Arrays.asList(entity1, entity2)), index)
 				.toStream().collect(Collectors.toList());
 
-		verify(afterSaveCallback, times(2)).onAfterSave(any());
+		verify(afterSaveCallback, times(2)).onAfterSave(any(), eq(index));
 		assertThat(saved.get(0).getId()).isEqualTo("after-save");
 		assertThat(saved.get(1).getId()).isEqualTo("after-save");
 	}
@@ -474,7 +474,7 @@ public class ReactiveElasticsearchTemplateCallbackTests {
 			implements ReactiveAfterSaveCallback<Person> {
 
 		@Override
-		public Mono<Person> onAfterSave(Person entity) {
+		public Mono<Person> onAfterSave(Person entity, IndexCoordinates index) {
 
 			return Mono.defer(() -> {
 				capture(entity);

--- a/src/test/java/org/springframework/data/elasticsearch/core/event/AuditingEntityCallbackTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/event/AuditingEntityCallbackTests.java
@@ -30,12 +30,14 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.auditing.IsNewAwareAuditingHandler;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
 import org.springframework.data.mapping.context.PersistentEntities;
 import org.springframework.lang.Nullable;
 
 /**
  * @author Peter-Josef Meisch
+ * @author Roman Puchkovskiy
  */
 @ExtendWith(MockitoExtension.class)
 class AuditingEntityCallbackTests {
@@ -66,7 +68,7 @@ class AuditingEntityCallbackTests {
 	void shouldCallHandler() {
 		Sample entity = new Sample();
 		entity.setId("42");
-		callback.onBeforeConvert(entity);
+		callback.onBeforeConvert(entity, IndexCoordinates.of("index"));
 
 		verify(handler).markAudited(eq(entity));
 	}
@@ -79,7 +81,7 @@ class AuditingEntityCallbackTests {
 		sample2.setId("2");
 		doReturn(sample2).when(handler).markAudited(any());
 
-		Sample result = (Sample) callback.onBeforeConvert(sample1);
+		Sample result = (Sample) callback.onBeforeConvert(sample1, IndexCoordinates.of("index"));
 
 		assertThat(result).isSameAs(sample2);
 	}

--- a/src/test/java/org/springframework/data/elasticsearch/core/event/ElasticsearchOperationsCallbackTest.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/event/ElasticsearchOperationsCallbackTest.java
@@ -26,10 +26,12 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.IndexOperations;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Peter-Josef Meisch
+ * @author Roman Puchkovskiy
  */
 abstract class ElasticsearchOperationsCallbackTest {
 
@@ -41,7 +43,7 @@ abstract class ElasticsearchOperationsCallbackTest {
 		@Component
 		static class SampleEntityBeforeConvertCallback implements BeforeConvertCallback<SampleEntity> {
 			@Override
-			public SampleEntity onBeforeConvert(SampleEntity entity) {
+			public SampleEntity onBeforeConvert(SampleEntity entity, IndexCoordinates index) {
 				entity.setText("converted");
 				return entity;
 			}

--- a/src/test/java/org/springframework/data/elasticsearch/core/event/ReactiveAuditingEntityCallbackTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/event/ReactiveAuditingEntityCallbackTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.elasticsearch.core.event;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import reactor.test.StepVerifier;
 
 import java.time.LocalDateTime;
@@ -38,6 +39,7 @@ import org.springframework.lang.Nullable;
 
 /**
  * @author Peter-Josef Meisch
+ * @author Roman Puchkovskiy
  */
 @ExtendWith(MockitoExtension.class)
 class ReactiveAuditingEntityCallbackTests {
@@ -68,7 +70,7 @@ class ReactiveAuditingEntityCallbackTests {
 	void shouldCallHandler() {
 		Sample entity = new Sample();
 		entity.setId("42");
-		callback.onBeforeConvert(entity);
+		callback.onBeforeConvert(entity, IndexCoordinates.of("index"));
 
 		verify(handler).markAudited(eq(entity));
 	}
@@ -81,7 +83,7 @@ class ReactiveAuditingEntityCallbackTests {
 		sample2.setId("2");
 		doReturn(sample2).when(handler).markAudited(any());
 
-		callback.onBeforeConvert(sample1) //
+		callback.onBeforeConvert(sample1, IndexCoordinates.of("index")) //
 				.as(StepVerifier::create) //
 				.consumeNextWith(it -> { //
 					assertThat(it).isSameAs(sample2); //

--- a/src/test/java/org/springframework/data/elasticsearch/core/event/ReactiveElasticsearchOperationsCallbackTest.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/event/ReactiveElasticsearchOperationsCallbackTest.java
@@ -31,6 +31,7 @@ import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.IndexOperations;
 import org.springframework.data.elasticsearch.core.ReactiveElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.junit.jupiter.ElasticsearchRestTemplateConfiguration;
 import org.springframework.data.elasticsearch.junit.jupiter.ReactiveElasticsearchRestTemplateConfiguration;
 import org.springframework.data.elasticsearch.junit.jupiter.SpringIntegrationTest;
@@ -39,6 +40,7 @@ import org.springframework.test.context.ContextConfiguration;
 
 /**
  * @author Peter-Josef Meisch
+ * @author Roman Puchkovskiy
  */
 @SpringIntegrationTest
 @ContextConfiguration(classes = { ReactiveElasticsearchOperationsCallbackTest.Config.class })
@@ -50,7 +52,7 @@ public class ReactiveElasticsearchOperationsCallbackTest {
 		@Component
 		static class SampleEntityBeforeConvertCallback implements ReactiveBeforeConvertCallback<SampleEntity> {
 			@Override
-			public Mono<SampleEntity> onBeforeConvert(SampleEntity entity) {
+			public Mono<SampleEntity> onBeforeConvert(SampleEntity entity, IndexCoordinates index) {
 				entity.setText("reactive-converted");
 				return Mono.just(entity);
 			}


### PR DESCRIPTION
* Add IndexCoordinates parameter to [Reactive]AfterSaveCallback.
* Add IndexCoordinates parameter to [Reactive]BeforeConvertCallback.
* Make sure before-convert callbacks are invoked in reactive save-all case.

The third task (before-convert callbacks in reactive save-all case) made me make the code rather involved. I tried to reduce its complexity by introducing a helper class, `Entities`.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
