### PR TITLE
DATAES-795 - Don't change primitive types into Strings when converting into Map<String, Object>.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/convert/MappingElasticsearchConverter.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/convert/MappingElasticsearchConverter.java
@@ -70,6 +70,7 @@ import org.springframework.util.ObjectUtils;
  * @author Peter-Josef Meisch
  * @author Mark Paluch
  * @author Roman Puchkovskiy
+ * @author Konrad Kurdej
  * @since 3.2
  */
 public class MappingElasticsearchConverter
@@ -319,7 +320,7 @@ public class MappingElasticsearchConverter
 				target.put(entryKey, null);
 			} else if (isSimpleType(entryValue)) {
 				target.put(entryKey,
-						readSimpleValue(entryValue, targetType.isMap() ? targetType.getComponentType() : targetType));
+						readSimpleValue(entryValue, targetType.isMap() ? targetType.getMapValueType() : targetType));
 			} else {
 
 				ElasticsearchPersistentEntity<?> targetEntity = computeGenericValueTypeForRead(property, entryValue);

--- a/src/test/java/org/springframework/data/elasticsearch/core/convert/MappingElasticsearchConverterUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/convert/MappingElasticsearchConverterUnitTests.java
@@ -68,6 +68,7 @@ import org.springframework.lang.Nullable;
  * @author Christoph Strobl
  * @author Mark Paluch
  * @author Peter-Josef Meisch
+ * @author Konrad Kurdej
  */
 public class MappingElasticsearchConverterUnitTests {
 
@@ -662,6 +663,20 @@ public class MappingElasticsearchConverterUnitTests {
 		assertThat(notification.params.get("content")).isNull();
 	}
 
+	@Test // DATAES-795
+	void readGenericMapWithSimpleTypes() {
+		Map<String, Object> mapWithSimpleValues = new HashMap<>();
+		mapWithSimpleValues.put("int", 1);
+		mapWithSimpleValues.put("string", "string");
+		mapWithSimpleValues.put("boolean", true);
+
+		Document document = Document.create();
+		document.put("schemaLessObject", mapWithSimpleValues);
+
+		SchemaLessObjectWrapper wrapper = mappingElasticsearchConverter.read(SchemaLessObjectWrapper.class, document);
+		assertThat(wrapper.getSchemaLessObject()).isEqualTo(mapWithSimpleValues);
+	}
+
 	private String pointTemplate(String name, Point point) {
 		return String.format(Locale.ENGLISH, "\"%s\":{\"lat\":%.1f,\"lon\":%.1f}", name, point.getX(), point.getY());
 	}
@@ -859,5 +874,13 @@ public class MappingElasticsearchConverterUnitTests {
 		@GeoPointField private String pointC;
 
 		@GeoPointField private double[] pointD;
+	}
+
+	@Data
+	@NoArgsConstructor
+	@AllArgsConstructor
+	static class SchemaLessObjectWrapper {
+
+		private Map<String, Object> schemaLessObject;
 	}
 }


### PR DESCRIPTION
Without this fix we observed situation when class annotated with `@Document` and field of type `Map<String, Object>` were storing data correctly to Elasticsearch, but on retrieval were converting some fields to Strings. For example:
```json
{ "a": 1 }
```
become
```json
{ "a": "1" }
```
