### PR TITLE
DATAES-767 - Fix ReactiveElasticsearch handling of 4xx HTTP responses.

### DIFF
--- a/src/test/java/org/springframework/data/elasticsearch/client/reactive/ReactiveElasticsearchClientTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/client/reactive/ReactiveElasticsearchClientTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.elasticsearch.client.reactive;
 import static org.assertj.core.api.Assertions.*;
 
 import lombok.SneakyThrows;
+import org.springframework.web.client.HttpClientErrorException;
 import reactor.test.StepVerifier;
 
 import java.io.IOException;
@@ -147,7 +148,7 @@ public class ReactiveElasticsearchClientTests {
 
 		client.get(new GetRequest(INDEX_I, "nonono")) //
 				.as(StepVerifier::create) //
-				.expectError(ElasticsearchStatusException.class) //
+				.expectError(HttpClientErrorException.class) //
 				.verify();
 	}
 
@@ -304,7 +305,7 @@ public class ReactiveElasticsearchClientTests {
 
 		client.index(request) //
 				.as(StepVerifier::create) //
-				.verifyError(ElasticsearchStatusException.class);
+				.verifyError(HttpClientErrorException.class);
 	}
 
 	@Test // DATAES-488
@@ -353,7 +354,7 @@ public class ReactiveElasticsearchClientTests {
 
 		client.update(request) //
 				.as(StepVerifier::create) //
-				.verifyError(ElasticsearchStatusException.class);
+				.verifyError(HttpClientErrorException.class);
 	}
 
 	@Test // DATAES-488
@@ -514,7 +515,7 @@ public class ReactiveElasticsearchClientTests {
 
 		client.indices().createIndex(request -> request.index(INDEX_I)) //
 				.as(StepVerifier::create) //
-				.verifyError(ElasticsearchStatusException.class);
+				.verifyError(HttpClientErrorException.class);
 	}
 
 	@Test // DATAES-569
@@ -529,12 +530,12 @@ public class ReactiveElasticsearchClientTests {
 		assertThat(syncClient.indices().exists(new GetIndexRequest(INDEX_I), RequestOptions.DEFAULT)).isFalse();
 	}
 
-	@Test // DATAES-569
+	@Test // DATAES-569, DATAES-767
 	public void deleteNonExistingIndexErrors() {
 
 		client.indices().deleteIndex(request -> request.indices(INDEX_I)) //
 				.as(StepVerifier::create) //
-				.verifyError(ElasticsearchStatusException.class);
+				.verifyError(HttpClientErrorException.class);
 	}
 
 	@Test // DATAES-569
@@ -547,12 +548,12 @@ public class ReactiveElasticsearchClientTests {
 				.verifyComplete();
 	}
 
-	@Test // DATAES-569
+	@Test // DATAES-569, DATAES-767
 	public void openNonExistingIndex() {
 
 		client.indices().openIndex(request -> request.indices(INDEX_I)) //
 				.as(StepVerifier::create) //
-				.verifyError(ElasticsearchStatusException.class);
+				.verifyError(HttpClientErrorException.class);
 	}
 
 	@Test // DATAES-569
@@ -565,12 +566,12 @@ public class ReactiveElasticsearchClientTests {
 				.verifyComplete();
 	}
 
-	@Test // DATAES-569
+	@Test // DATAES-569, DATAES-767
 	public void closeNonExistingIndex() {
 
 		client.indices().closeIndex(request -> request.indices(INDEX_I)) //
 				.as(StepVerifier::create) //
-				.verifyError(ElasticsearchStatusException.class);
+				.verifyError(HttpClientErrorException.class);
 	}
 
 	@Test // DATAES-569
@@ -583,12 +584,12 @@ public class ReactiveElasticsearchClientTests {
 				.verifyComplete();
 	}
 
-	@Test // DATAES-569
+	@Test // DATAES-569, DATAES-767
 	public void refreshNonExistingIndex() {
 
 		client.indices().refreshIndex(request -> request.indices(INDEX_I)) //
 				.as(StepVerifier::create) //
-				.verifyError(ElasticsearchStatusException.class);
+				.verifyError(HttpClientErrorException.class);
 	}
 
 	@Test // DATAES-569
@@ -604,7 +605,7 @@ public class ReactiveElasticsearchClientTests {
 				.verifyComplete();
 	}
 
-	@Test // DATAES-569
+	@Test // DATAES-569, DATAES-767
 	public void updateMappingNonExistingIndex() {
 
 		Map<String, Object> jsonMap = Collections.singletonMap("properties",
@@ -612,7 +613,7 @@ public class ReactiveElasticsearchClientTests {
 
 		client.indices().updateMapping(request -> request.indices(INDEX_I).type(TYPE_I).source(jsonMap)) //
 				.as(StepVerifier::create) //
-				.verifyError(ElasticsearchStatusException.class);
+				.verifyError(HttpClientErrorException.class);
 	}
 
 	@Test // DATAES-569
@@ -625,12 +626,12 @@ public class ReactiveElasticsearchClientTests {
 				.verifyComplete();
 	}
 
-	@Test // DATAES-569
+	@Test // DATAES-569, DATAES-767
 	public void flushNonExistingIndex() {
 
 		client.indices().flushIndex(request -> request.indices(INDEX_I)) //
 				.as(StepVerifier::create) //
-				.verifyError(ElasticsearchStatusException.class);
+				.verifyError(HttpClientErrorException.class);
 	}
 
 	@Test // DATAES-684

--- a/src/test/java/org/springframework/data/elasticsearch/client/reactive/ReactiveElasticsearchClientUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/client/reactive/ReactiveElasticsearchClientUnitTests.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.data.elasticsearch.client.reactive.ReactiveMockClientTestsUtils.MockWebClientProvider.Receive.*;
 
+import org.springframework.web.client.HttpClientErrorException;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -459,7 +460,7 @@ public class ReactiveElasticsearchClientUnitTests {
 				.verifyComplete();
 	}
 
-	@Test // DATAES-488
+	@Test // DATAES-488, DATAES-767
 	public void updateShouldEmitErrorWhenNotFound() {
 
 		hostProvider.when(HOST) //
@@ -467,7 +468,7 @@ public class ReactiveElasticsearchClientUnitTests {
 
 		client.update(new UpdateRequest("twitter", "doc", "1").doc(Collections.singletonMap("user", "cstrobl")))
 				.as(StepVerifier::create) //
-				.expectError(ElasticsearchStatusException.class) //
+				.expectError(HttpClientErrorException.class) //
 				.verify();
 	}
 

--- a/src/test/java/org/springframework/data/elasticsearch/repository/support/SimpleReactiveElasticsearchRepositoryTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repository/support/SimpleReactiveElasticsearchRepositoryTests.java
@@ -72,6 +72,7 @@ import org.springframework.data.elasticsearch.repository.config.EnableReactiveEl
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpClientErrorException;
 
 /**
  * @author Christoph Strobl
@@ -129,9 +130,11 @@ public class SimpleReactiveElasticsearchRepositoryTests {
 				.verifyComplete();
 	}
 
-	@Test // DATAES-519
-	public void findByIdShouldCompleteIfIndexDoesNotExist() {
-		repository.findById("id-two").as(StepVerifier::create).verifyComplete();
+	@Test // DATAES-519, DATAES-767
+	public void findByIdShouldErrorIfIndexDoesNotExist() {
+		repository.findById("id-two") //
+				.as(StepVerifier::create) //
+				.expectError(HttpClientErrorException.class);
 	}
 
 	@Test // DATAES-519
@@ -264,9 +267,11 @@ public class SimpleReactiveElasticsearchRepositoryTests {
 				.verifyComplete();
 	}
 
-	@Test // DATAES-519
-	public void countShouldReturnZeroWhenIndexDoesNotExist() {
-		repository.count().as(StepVerifier::create).expectNext(0L).verifyComplete();
+	@Test // DATAES-519, DATAES-767
+	public void countShouldErrorWhenIndexDoesNotExist() {
+		repository.count() //
+				.as(StepVerifier::create) //
+				.expectError(HttpClientErrorException.class);
 	}
 
 	@Test // DATAES-519
@@ -352,9 +357,12 @@ public class SimpleReactiveElasticsearchRepositoryTests {
 		repository.deleteById("does-not-exist").as(StepVerifier::create).verifyComplete();
 	}
 
-	@Test // DATAES-519
-	public void deleteByIdShouldCompleteWhenIndexDoesNotExist() {
-		repository.deleteById("does-not-exist").as(StepVerifier::create).verifyComplete();
+	@Test // DATAES-519, DATAES-767
+	public void deleteByIdShouldErrorWhenIndexDoesNotExist() {
+		repository.deleteById("does-not-exist") //
+				.as(StepVerifier::create) //
+				.verifyError(HttpClientErrorException.class);
+		;
 	}
 
 	@Test // DATAES-519


### PR DESCRIPTION
Setup handling of 4xx errors from ES:
* when the response body contains an `ElasticsearchException`, this is transferred to a `HttpClientErrorException`
* otherwise it is handle as before, we try to parse the content into the expected response type