### PR TITLE
DATAES-839 - ReactiveElasticsearchTemplate should use RequestFactory.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/BulkFailureException.java
+++ b/src/main/java/org/springframework/data/elasticsearch/BulkFailureException.java
@@ -15,15 +15,23 @@
  */
 package org.springframework.data.elasticsearch;
 
-import org.springframework.dao.UncategorizedDataAccessException;
+import org.springframework.dao.DataRetrievalFailureException;
+
+import java.util.Map;
 
 /**
  * @author Peter-Josef Meisch
- * @since 4.0
+ * @since 4.1
  */
-public class UncategorizedElasticsearchException extends UncategorizedDataAccessException {
+public class BulkFailureException extends DataRetrievalFailureException {
+	private final Map<String, String> failedDocuments;
 
-	public UncategorizedElasticsearchException(String msg, Throwable cause) {
-		super(msg, cause);
+	public BulkFailureException(String msg, Map<String, String> failedDocuments) {
+		super(msg);
+		this.failedDocuments = failedDocuments;
+	}
+
+	public Map<String, String> getFailedDocuments() {
+		return failedDocuments;
 	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/AbstractElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/AbstractElasticsearchTemplate.java
@@ -36,7 +36,7 @@ import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.data.convert.EntityReader;
-import org.springframework.data.elasticsearch.ElasticsearchException;
+import org.springframework.data.elasticsearch.BulkFailureException;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
 import org.springframework.data.elasticsearch.core.convert.MappingElasticsearchConverter;
 import org.springframework.data.elasticsearch.core.document.Document;
@@ -405,7 +405,7 @@ public abstract class AbstractElasticsearchTemplate implements ElasticsearchOper
 				if (item.isFailed())
 					failedDocuments.put(item.getId(), item.getFailureMessage());
 			}
-			throw new ElasticsearchException(
+			throw new BulkFailureException(
 					"Bulk operation has failures. Use ElasticsearchException.getFailedDocuments() for detailed messages ["
 							+ failedDocuments + ']',
 					failedDocuments);

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
@@ -210,7 +210,7 @@ public class ElasticsearchRestTemplate extends AbstractElasticsearchTemplate {
 		Assert.notNull(id, "id must not be null");
 		Assert.notNull(index, "index must not be null");
 
-		DeleteRequest request = new DeleteRequest(index.getIndexName(), elasticsearchConverter.convertId(id));
+		DeleteRequest request = requestFactory.deleteRequest(elasticsearchConverter.convertId(id), index);
 		return execute(client -> client.delete(request, RequestOptions.DEFAULT).getId());
 	}
 

--- a/src/main/java/org/springframework/data/elasticsearch/core/RequestFactory.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/RequestFactory.java
@@ -29,6 +29,7 @@ import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequestBuilder;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetRequestBuilder;
 import org.elasticsearch.action.get.MultiGetRequest;
@@ -249,6 +250,10 @@ class RequestFactory {
 		return deleteByQueryRequest;
 	}
 
+	public DeleteRequest deleteRequest(String id, IndexCoordinates index) {
+		return new DeleteRequest(index.getIndexName(), id);
+	}
+
 	@Deprecated
 	public DeleteByQueryRequestBuilder deleteByQueryRequestBuilder(Client client, DeleteQuery deleteQuery,
 			IndexCoordinates index) {
@@ -344,6 +349,7 @@ class RequestFactory {
 			throw new ElasticsearchException(
 					"object or source is null, failed to index the document [id: " + query.getId() + ']');
 		}
+
 		if (query.getVersion() != null) {
 			indexRequest.version(query.getVersion());
 			VersionType versionType = retrieveVersionTypeFromPersistentEntity(query.getObject().getClass());
@@ -353,6 +359,7 @@ class RequestFactory {
 		if (query.getSeqNo() != null) {
 			indexRequest.setIfSeqNo(query.getSeqNo());
 		}
+
 		if (query.getPrimaryTerm() != null) {
 			indexRequest.setIfPrimaryTerm(query.getPrimaryTerm());
 		}


### PR DESCRIPTION
`ReactiveElasticsearchTemplate` now uses `RequestFactory` to build all requests.