### PR TITLE
DATAES-840 - Introduce IndexCoordinateResolver.

### DIFF
--- a/src/main/asciidoc/reference/elasticsearch-migration-guide-4.0-4.1.adoc
+++ b/src/main/asciidoc/reference/elasticsearch-migration-guide-4.0-4.1.adoc
@@ -3,8 +3,16 @@
 
 This section describes breaking changes from version 4.0.x to 4.1.x and how removed features can be replaced by new introduced features.
 
+== Deprecations
+
+.Definition of the id property
+It is possible to define a property of en entity as the id property by naming it either `id` or  `document`. This behaviour is now deprecated and  will produce a warning. PLease us the `@Id` annotation to mark a property as being the id property.
+
 [[elasticsearch-migration-guide-4.0-4.1.removal]]
 == Removals
 
+.Type mappings
 The _type mappings_ parameters of the `@Document` annotation and the `IndexCoordinates` object were removed. They had been deprecated in Spring Data Elasticsearch 4.0 and their values weren't used anymore.
+
+=== Breaking changes
 

--- a/src/main/java/org/springframework/data/elasticsearch/core/DocumentOperations.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/DocumentOperations.java
@@ -119,6 +119,16 @@ public interface DocumentOperations {
 	 *
 	 * @param query the query defining the ids of the objects to get
 	 * @param clazz the type of the object to be returned
+	 * @return list of objects, contains null values for ids that are not found
+	 * @since 4.1
+	 */
+	<T> List<T> multiGet(Query query, Class<T> clazz);
+
+	/**
+	 * Execute a multiGet against elasticsearch for the given ids.
+	 *
+	 * @param query the query defining the ids of the objects to get
+	 * @param clazz the type of the object to be returned
 	 * @param index the index(es) from which the objects are read.
 	 * @return list of objects, contains null values for ids that are not found
 	 */
@@ -146,11 +156,34 @@ public interface DocumentOperations {
 	 * Bulk index all objects. Will do save or update.
 	 *
 	 * @param queries the queries to execute in bulk
+	 * @param clazz the entity class
+	 * @return the ids of the indexed objects
+	 * @since 4.1
+	 */
+	default List<String> bulkIndex(List<IndexQuery> queries, Class<?> clazz) {
+		return bulkIndex(queries, BulkOptions.defaultOptions(), clazz);
+	}
+
+	/**
+	 * Bulk index all objects. Will do save or update.
+	 *
+	 * @param queries the queries to execute in bulk
 	 * @return the ids of the indexed objects
 	 */
 	default List<String> bulkIndex(List<IndexQuery> queries, IndexCoordinates index) {
 		return bulkIndex(queries, BulkOptions.defaultOptions(), index);
 	}
+
+	/**
+	 * Bulk index all objects. Will do save or update.
+	 *
+	 * @param queries the queries to execute in bulk
+	 * @param bulkOptions options to be added to the bulk request
+	 * @param clazz the entity class
+	 * @return the ids of the indexed objects
+	 * @since 4.1
+	 */
+	List<String> bulkIndex(List<IndexQuery> queries, BulkOptions bulkOptions, Class<?> clazz);
 
 	/**
 	 * Bulk index all objects. Will do save or update.
@@ -169,6 +202,14 @@ public interface DocumentOperations {
 	default void bulkUpdate(List<UpdateQuery> queries, IndexCoordinates index) {
 		bulkUpdate(queries, BulkOptions.defaultOptions(), index);
 	}
+
+	/**
+	 * Bulk update all objects. Will do update.
+	 * @param clazz the entity class
+	 * @param queries the queries to execute in bulk
+	 * @since 4.1
+	 */
+	void bulkUpdate(List<UpdateQuery> queries, Class<?> clazz);
 
 	/**
 	 * Bulk update all objects. Will do update.
@@ -212,6 +253,16 @@ public interface DocumentOperations {
 	 * @return documentId of the document deleted
 	 */
 	String delete(Object entity, IndexCoordinates index);
+
+	/**
+	 * Delete all records matching the query.
+	 *
+	 * @param query query defining the objects
+	 * @param clazz The entity class, must be annotated with
+	 *          {@link org.springframework.data.elasticsearch.annotations.Document}
+	 * @since 4.1
+	 */
+	void delete(Query query, Class<?> clazz);
 
 	/**
 	 * Delete all records matching the query.

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchOperations.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchOperations.java
@@ -60,17 +60,17 @@ public interface ElasticsearchOperations extends DocumentOperations, SearchOpera
 	IndexCoordinates getIndexCoordinatesFor(Class<?> clazz);
 
 	// region IndexOperations
-/**
- * Create an index for given indexName .
- *
- * @param indexName the name of the index
- * @return {@literal true} if the index was created
- * @deprecated since 4.0, use {@link IndexOperations#create()}
- */
-@Deprecated
-default boolean createIndex(String indexName) {
-	return indexOps(IndexCoordinates.of(indexName)).create();
-}
+	/**
+	 * Create an index for given indexName .
+	 *
+	 * @param indexName the name of the index
+	 * @return {@literal true} if the index was created
+	 * @deprecated since 4.0, use {@link IndexOperations#create()}
+	 */
+	@Deprecated
+	default boolean createIndex(String indexName) {
+		return indexOps(IndexCoordinates.of(indexName)).create();
+	}
 
 	/**
 	 * Create an index for given indexName and Settings.

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
@@ -37,7 +37,6 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
-import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.search.suggest.SuggestBuilder;
 import org.slf4j.Logger;
@@ -315,10 +314,7 @@ public class ElasticsearchRestTemplate extends AbstractElasticsearchTemplate {
 
 	@Override
 	public SearchResponse suggest(SuggestBuilder suggestion, IndexCoordinates index) {
-		SearchRequest searchRequest = new SearchRequest(index.getIndexNames());
-		SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
-		sourceBuilder.suggest(suggestion);
-		searchRequest.source(sourceBuilder);
+		SearchRequest searchRequest = requestFactory.searchRequest(suggestion, index);
 		return execute(client -> client.search(searchRequest, RequestOptions.DEFAULT));
 	}
 

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.admin.cluster.node.info.NodesInfoAction;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequestBuilder;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.delete.DeleteRequestBuilder;
 import org.elasticsearch.action.get.GetRequestBuilder;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.get.MultiGetRequestBuilder;
@@ -227,8 +228,9 @@ public class ElasticsearchTemplate extends AbstractElasticsearchTemplate {
 		Assert.notNull(id, "id must not be null");
 		Assert.notNull(index, "index must not be null");
 
-		return client.prepareDelete(index.getIndexName(), IndexCoordinates.TYPE, elasticsearchConverter.convertId(id))
-				.execute().actionGet().getId();
+		DeleteRequestBuilder deleteRequestBuilder = requestFactory.deleteRequestBuilder(client,
+				elasticsearchConverter.convertId(id), index);
+		return deleteRequestBuilder.execute().actionGet().getId();
 	}
 
 	@Override
@@ -293,8 +295,7 @@ public class ElasticsearchTemplate extends AbstractElasticsearchTemplate {
 
 		Assert.notNull(query.getPageable(), "pageable of query must not be null.");
 
-		ActionFuture<SearchResponse> action = requestFactory //
-				.searchRequestBuilder(client, query, clazz, index) //
+		ActionFuture<SearchResponse> action = requestFactory.searchRequestBuilder(client, query, clazz, index) //
 				.setScroll(TimeValue.timeValueMillis(scrollTimeInMillis)) //
 				.execute();
 
@@ -332,7 +333,8 @@ public class ElasticsearchTemplate extends AbstractElasticsearchTemplate {
 
 	@Override
 	public SearchResponse suggest(SuggestBuilder suggestion, IndexCoordinates index) {
-		return client.prepareSearch(index.getIndexNames()).suggest(suggestion).get();
+		SearchRequestBuilder searchRequestBuilder = requestFactory.searchRequestBuilder(client, suggestion, index);
+		return searchRequestBuilder.get();
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/elasticsearch/core/EntityOperations.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/EntityOperations.java
@@ -28,7 +28,6 @@ import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mapping.model.ConvertingPropertyAccessor;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 
 /**
  * Common operations performed on an entity in the context of it's mapping metadata.
@@ -43,6 +42,8 @@ class EntityOperations {
 
 	private static final String ID_FIELD = "id";
 
+	private final MappingContext<? extends ElasticsearchPersistentEntity<?>, ElasticsearchPersistentProperty> context;
+
 	public EntityOperations(
 			MappingContext<? extends ElasticsearchPersistentEntity<?>, ElasticsearchPersistentProperty> context) {
 
@@ -50,8 +51,6 @@ class EntityOperations {
 
 		this.context = context;
 	}
-
-	private final MappingContext<? extends ElasticsearchPersistentEntity<?>, ElasticsearchPersistentProperty> context;
 
 	/**
 	 * Creates a new {@link Entity} for the given bean.
@@ -100,9 +99,24 @@ class EntityOperations {
 	 * @param index index name override can be {@literal null}.
 	 * @param type index type override can be {@literal null}.
 	 * @return the {@link IndexCoordinates} containing index name and index type.
+	 * @deprecated since 4.1, use {@link EntityOperations#determineIndex(Entity, String)}
 	 */
+	@Deprecated
 	IndexCoordinates determineIndex(Entity<?> entity, @Nullable String index, @Nullable String type) {
 		return determineIndex(entity.getPersistentEntity(), index, type);
+	}
+
+	/**
+	 * Determine index name and type name from {@link Entity} with {@code index} and {@code type} overrides. Allows using
+	 * preferred values for index and type if provided, otherwise fall back to index and type defined on entity level.
+	 *
+	 * @param entity the entity to determine the index name. Can be {@literal null} if {@code index} and {@literal type}
+	 *          are provided.
+	 * @param index index name override can be {@literal null}.
+	 * @return the {@link IndexCoordinates} containing index name and index type.
+	 */
+	IndexCoordinates determineIndex(Entity<?> entity, @Nullable String index) {
+		return determineIndex(entity.getPersistentEntity(), index);
 	}
 
 	/**
@@ -115,20 +129,27 @@ class EntityOperations {
 	 * @param index index name override can be {@literal null}.
 	 * @param type index type override can be {@literal null}.
 	 * @return the {@link IndexCoordinates} containing index name and index type.
+	 * @deprecated since 4.1, use {@link EntityOperations#determineIndex(ElasticsearchPersistentEntity, String)}
 	 */
+	@Deprecated
 	IndexCoordinates determineIndex(ElasticsearchPersistentEntity<?> persistentEntity, @Nullable String index,
 			@Nullable String type) {
-		return persistentEntity.getIndexCoordinates();
+		return determineIndex(persistentEntity, index);
 	}
 
-	private static String indexName(@Nullable ElasticsearchPersistentEntity<?> entity, @Nullable String index) {
-
-		if (StringUtils.isEmpty(index)) {
-			Assert.notNull(entity, "Cannot determine index name");
-			return entity.getIndexCoordinates().getIndexName();
-		}
-
-		return index;
+	/**
+	 * Determine index name and type name from {@link ElasticsearchPersistentEntity} with {@code index} and {@code type}
+	 * overrides. Allows using preferred values for index and type if provided, otherwise fall back to index and type
+	 * defined on entity level.
+	 *
+	 * @param persistentEntity the entity to determine the index name. Can be {@literal null} if {@code index} and
+	 *          {@literal type} are provided.
+	 * @param index index name override can be {@literal null}.
+	 * @return the {@link IndexCoordinates} containing index name and index type.
+	 * @since 4.1
+	 */
+	IndexCoordinates determineIndex(ElasticsearchPersistentEntity<?> persistentEntity, @Nullable String index) {
+		return index != null ? IndexCoordinates.of(index) : persistentEntity.getIndexCoordinates();
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/elasticsearch/core/ReactiveElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ReactiveElasticsearchTemplate.java
@@ -190,6 +190,11 @@ public class ReactiveElasticsearchTemplate implements ReactiveElasticsearchOpera
 	}
 
 	@Override
+	public <T> Flux<T> saveAll(Mono<? extends Collection<? extends T>> entities, Class<T> clazz) {
+		return saveAll(entities, getIndexCoordinatesFor(clazz));
+	}
+
+	@Override
 	public <T> Flux<T> saveAll(Mono<? extends Collection<? extends T>> entitiesPublisher, IndexCoordinates index) {
 
 		Assert.notNull(entitiesPublisher, "Entities must not be null!");
@@ -213,6 +218,11 @@ public class ReactiveElasticsearchTemplate implements ReactiveElasticsearchOpera
 						return maybeCallAfterSave(savedEntity, index);
 					});
 		});
+	}
+
+	@Override
+	public <T> Flux<T> multiGet(Query query, Class<T> clazz) {
+		return multiGet(query, clazz, getIndexCoordinatesFor(clazz));
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/elasticsearch/core/SearchOperations.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/SearchOperations.java
@@ -245,6 +245,16 @@ public interface SearchOperations {
 	 * Does a suggest query
 	 *
 	 * @param suggestion the query
+	 * @param the entity class
+	 * @return the suggest response
+	 * @since 4.1
+	 */
+	SearchResponse suggest(SuggestBuilder suggestion, Class<?> clazz);
+
+	/**
+	 * Does a suggest query
+	 *
+	 * @param suggestion the query
 	 * @param index the index to run the query against
 	 * @return the suggest response
 	 */
@@ -281,12 +291,33 @@ public interface SearchOperations {
 	 * Execute the multi search query against elasticsearch and return result as {@link List} of {@link SearchHits}.
 	 *
 	 * @param queries the queries to execute
+	 * @param clazz the entity clazz
+	 * @param <T> element return type
+	 * @return list of SearchHits
+	 * @since 4.1
+	 */
+	<T> List<SearchHits<T>> multiSearch(List<? extends Query> queries, Class<T> clazz);
+
+	/**
+	 * Execute the multi search query against elasticsearch and return result as {@link List} of {@link SearchHits}.
+	 *
+	 * @param queries the queries to execute
 	 * @param clazz the entity clazz used for property mapping
 	 * @param index the index to run the query against
 	 * @param <T> element return type
 	 * @return list of SearchHits
 	 */
 	<T> List<SearchHits<T>> multiSearch(List<? extends Query> queries, Class<T> clazz, IndexCoordinates index);
+
+	/**
+	 * Execute the multi search query against elasticsearch and return result as {@link List} of {@link SearchHits}.
+	 *
+	 * @param queries the queries to execute
+	 * @param classes the entity classes
+	 * @return list of SearchHits
+	 * @since 4.1
+	 */
+	List<SearchHits<?>> multiSearch(List<? extends Query> queries, List<Class<?>> classes);
 
 	/**
 	 * Execute the multi search query against elasticsearch and return result as {@link List} of {@link SearchHits}.

--- a/src/main/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchConverter.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchConverter.java
@@ -73,8 +73,12 @@ public interface ElasticsearchConverter
 	 * @return will not be {@literal null}.
 	 */
 	default Document mapObject(@Nullable Object source) {
+
 		Document target = Document.create();
-		write(source, target);
+
+		if (source != null) {
+			write(source, target);
+		}
 		return target;
 	}
 	// endregion

--- a/src/main/java/org/springframework/data/elasticsearch/core/convert/MappingElasticsearchConverter.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/convert/MappingElasticsearchConverter.java
@@ -87,9 +87,9 @@ public class MappingElasticsearchConverter
 	private final GenericConversionService conversionService;
 
 	private CustomConversions conversions = new ElasticsearchCustomConversions(Collections.emptyList());
-	private EntityInstantiators instantiators = new EntityInstantiators();
+	private final EntityInstantiators instantiators = new EntityInstantiators();
 
-	private ElasticsearchTypeMapper typeMapper;
+	private final ElasticsearchTypeMapper typeMapper;
 
 	private ConcurrentHashMap<String, Integer> propertyWarnings = new ConcurrentHashMap<>();
 

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentEntity.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentEntity.java
@@ -58,6 +58,7 @@ public interface ElasticsearchPersistentEntity<T> extends PersistentEntity<T, El
 	@Nullable
 	ElasticsearchPersistentProperty getParentIdProperty();
 
+	@Nullable
 	String settingPath();
 
 	@Nullable

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/SimpleElasticsearchMappingContext.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/SimpleElasticsearchMappingContext.java
@@ -15,14 +15,10 @@
  */
 package org.springframework.data.elasticsearch.core.mapping;
 
-import org.springframework.beans.BeansException;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
 import org.springframework.data.mapping.context.AbstractMappingContext;
 import org.springframework.data.mapping.model.Property;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
 import org.springframework.data.util.TypeInformation;
-import org.springframework.lang.Nullable;
 
 /**
  * SimpleElasticsearchMappingContext
@@ -30,31 +26,19 @@ import org.springframework.lang.Nullable;
  * @author Rizwan Idrees
  * @author Mohsin Husen
  * @author Mark Paluch
+ * @author Peter-Josef Meisch
  */
 public class SimpleElasticsearchMappingContext
-		extends AbstractMappingContext<SimpleElasticsearchPersistentEntity<?>, ElasticsearchPersistentProperty>
-		implements ApplicationContextAware {
-
-	private @Nullable ApplicationContext context;
+		extends AbstractMappingContext<SimpleElasticsearchPersistentEntity<?>, ElasticsearchPersistentProperty> {
 
 	@Override
 	protected <T> SimpleElasticsearchPersistentEntity<?> createPersistentEntity(TypeInformation<T> typeInformation) {
-		SimpleElasticsearchPersistentEntity<T> persistentEntity = new SimpleElasticsearchPersistentEntity<>(
-				typeInformation);
-		if (context != null) {
-			persistentEntity.setApplicationContext(context);
-		}
-		return persistentEntity;
+		return new SimpleElasticsearchPersistentEntity<>(typeInformation);
 	}
 
 	@Override
 	protected ElasticsearchPersistentProperty createPersistentProperty(Property property,
 			SimpleElasticsearchPersistentEntity<?> owner, SimpleTypeHolder simpleTypeHolder) {
 		return new SimpleElasticsearchPersistentProperty(property, owner, simpleTypeHolder);
-	}
-
-	@Override
-	public void setApplicationContext(ApplicationContext context) throws BeansException {
-		this.context = context;
 	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/SimpleElasticsearchPersistentProperty.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/SimpleElasticsearchPersistentProperty.java
@@ -20,6 +20,9 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.DateFormat;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
@@ -50,6 +53,8 @@ import org.springframework.util.StringUtils;
 public class SimpleElasticsearchPersistentProperty extends
 		AnnotationBasedPersistentProperty<ElasticsearchPersistentProperty> implements ElasticsearchPersistentProperty {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(SimpleElasticsearchPersistentProperty.class);
+
 	private static final List<String> SUPPORTED_ID_PROPERTY_NAMES = Arrays.asList("id", "document");
 
 	private final boolean isScore;
@@ -66,6 +71,15 @@ public class SimpleElasticsearchPersistentProperty extends
 
 		this.annotatedFieldName = getAnnotatedFieldName();
 		this.isId = super.isIdProperty() || SUPPORTED_ID_PROPERTY_NAMES.contains(getFieldName());
+
+		// deprecated since 4.1
+		@Deprecated
+		boolean isIdWithoutAnnotation = isId && !isAnnotationPresent(Id.class);
+		if (isIdWithoutAnnotation) {
+			LOGGER.warn("Using the property name of '{}' to identify the id property is deprecated."
+					+ " Please annotate the id property with '@Id'", getName());
+		}
+
 		this.isScore = isAnnotationPresent(Score.class);
 		this.isParent = isAnnotationPresent(Parent.class);
 		this.isSeqNoPrimaryTerm = SeqNoPrimaryTerm.class.isAssignableFrom(getRawType());

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchEntityInformation.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/ElasticsearchEntityInformation.java
@@ -39,6 +39,7 @@ public interface ElasticsearchEntityInformation<T, ID> extends EntityInformation
 	@Nullable
 	Long getVersion(T entity);
 
+	@Nullable
 	VersionType getVersionType();
 
 	@Nullable

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/MappingElasticsearchEntityInformation.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/MappingElasticsearchEntityInformation.java
@@ -16,9 +16,9 @@
 package org.springframework.data.elasticsearch.repository.support;
 
 import org.elasticsearch.index.VersionType;
-import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentEntity;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentProperty;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.repository.core.support.PersistentEntityInformation;
 
 /**
@@ -35,44 +35,34 @@ import org.springframework.data.repository.core.support.PersistentEntityInformat
  * @author Christoph Strobl
  * @author Ivan Greene
  * @author Sylvain Laurent
+ * @author Peter-Josef Meisch
  */
 public class MappingElasticsearchEntityInformation<T, ID> extends PersistentEntityInformation<T, ID>
 		implements ElasticsearchEntityInformation<T, ID> {
 
-	private final ElasticsearchPersistentEntity<T> entityMetadata;
-	private final IndexCoordinates indexCoordinates;
-	private final VersionType versionType;
+	private final ElasticsearchPersistentEntity<T> persistentEntity;
 
-	public MappingElasticsearchEntityInformation(ElasticsearchPersistentEntity<T> entity) {
-		this(entity, entity.getIndexCoordinates(), entity.getVersionType());
-	}
-
-	public MappingElasticsearchEntityInformation(ElasticsearchPersistentEntity<T> entity,
-			IndexCoordinates indexCoordinates, VersionType versionType) {
-		super(entity);
-
-		this.entityMetadata = entity;
-		this.indexCoordinates = indexCoordinates;
-		this.versionType = versionType;
+	public MappingElasticsearchEntityInformation(ElasticsearchPersistentEntity<T> persistentEntity) {
+		super(persistentEntity);
+		this.persistentEntity = persistentEntity;
 	}
 
 	@Override
 	public String getIdAttribute() {
-		return entityMetadata.getRequiredIdProperty().getFieldName();
+		return persistentEntity.getRequiredIdProperty().getFieldName();
 	}
-
 
 	@Override
 	public IndexCoordinates getIndexCoordinates() {
-		return indexCoordinates;
+		return persistentEntity.getIndexCoordinates();
 	}
 
 	@Override
 	public Long getVersion(T entity) {
 
-		ElasticsearchPersistentProperty versionProperty = entityMetadata.getVersionProperty();
+		ElasticsearchPersistentProperty versionProperty = persistentEntity.getVersionProperty();
 		try {
-			return versionProperty != null ? (Long) entityMetadata.getPropertyAccessor(entity).getProperty(versionProperty)
+			return versionProperty != null ? (Long) persistentEntity.getPropertyAccessor(entity).getProperty(versionProperty)
 					: null;
 		} catch (Exception e) {
 			throw new IllegalStateException("failed to load version field", e);
@@ -81,15 +71,15 @@ public class MappingElasticsearchEntityInformation<T, ID> extends PersistentEnti
 
 	@Override
 	public VersionType getVersionType() {
-		return versionType;
+		return persistentEntity.getVersionType();
 	}
 
 	@Override
 	public String getParentId(T entity) {
 
-		ElasticsearchPersistentProperty parentProperty = entityMetadata.getParentIdProperty();
+		ElasticsearchPersistentProperty parentProperty = persistentEntity.getParentIdProperty();
 		try {
-			return parentProperty != null ? (String) entityMetadata.getPropertyAccessor(entity).getProperty(parentProperty)
+			return parentProperty != null ? (String) persistentEntity.getPropertyAccessor(entity).getProperty(parentProperty)
 					: null;
 		} catch (Exception e) {
 			throw new IllegalStateException("failed to load parent ID: " + e, e);

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/ReactiveElasticsearchRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/ReactiveElasticsearchRepositoryFactory.java
@@ -113,8 +113,7 @@ public class ReactiveElasticsearchRepositoryFactory extends ReactiveRepositoryFa
 			@Nullable RepositoryInformation information) {
 
 		ElasticsearchPersistentEntity<?> entity = mappingContext.getRequiredPersistentEntity(domainClass);
-		return new MappingElasticsearchEntityInformation<>((ElasticsearchPersistentEntity<T>) entity,
-				entity.getIndexCoordinates(), entity.getVersionType());
+		return new MappingElasticsearchEntityInformation<>((ElasticsearchPersistentEntity<T>) entity);
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchPartQueryTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchPartQueryTests.java
@@ -492,6 +492,7 @@ class ElasticsearchPartQueryTests {
 
 	private String getQueryBuilder(String methodName, Class<?>[] parameterClasses, Object[] parameters)
 			throws NoSuchMethodException {
+
 		Method method = SampleRepository.class.getMethod(methodName, parameterClasses);
 		ElasticsearchQueryMethod queryMethod = new ElasticsearchQueryMethod(method,
 				new DefaultRepositoryMetadata(SampleRepository.class), new SpelAwareProxyProjectionFactory(),

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
@@ -2781,13 +2781,23 @@ public abstract class ElasticsearchTemplateTests {
 
 		AliasMetaData aliasMetaData1 = aliasMetaData.get(0);
 		assertThat(aliasMetaData1).isNotNull();
-		assertThat(aliasMetaData1.alias()).isEqualTo(alias1);
-		assertThat(aliasMetaData1.indexRouting()).isEqualTo("0");
+		if (aliasMetaData1.alias().equals(alias1)) {
+			assertThat(aliasMetaData1.indexRouting()).isEqualTo("0");
+		} else if (aliasMetaData1.alias().equals(alias2)) {
+			assertThat(aliasMetaData1.searchRouting()).isEqualTo("1");
+		} else {
+			fail("unknown alias");
+		}
 
 		AliasMetaData aliasMetaData2 = aliasMetaData.get(1);
 		assertThat(aliasMetaData2).isNotNull();
-		assertThat(aliasMetaData2.alias()).isEqualTo(alias2);
-		assertThat(aliasMetaData2.searchRouting()).isEqualTo("1");
+		if (aliasMetaData2.alias().equals(alias1)) {
+			assertThat(aliasMetaData2.indexRouting()).isEqualTo("0");
+		} else if (aliasMetaData2.alias().equals(alias2)) {
+			assertThat(aliasMetaData2.searchRouting()).isEqualTo("1");
+		} else {
+			fail("unknown alias");
+		}
 
 		// cleanup
 		indexOperations.removeAlias(aliasQuery1);


### PR DESCRIPTION
This PR introduces the `IndexCordinateResolver` class that is used to resolve index names that are defined with SpEL expressions. Up to now this was handled in the `SimpleElasticsearchPersistentEntity` class, but we will need this functionality for functions that are not related to entities as well (alias management, index templates, support for rolling indices).

The aim is later to support a definition like the following:
 ```
@Document(indexName="log-all", 
    writeIndexName="log-#{T(java.time.LocalDate).now().toString()}")
```
with _log-all_ being an alias (or just use _log-*_ as indexName).

So the following has changed:
* all `*Operations` implementations now use the `RequestFactory` to have the requests created that are sent to Elasticsearch
* the `RequestFactory` class takes care of resolving the index names for the requests to build
* new `IndexCoordinateResolver` class that lives within the `MappingElasticsearchConverter` and is used by the `RequestFactory`.
* the code that was used up to now for evaluating SpEL expressions in the `SimpleElasticsearchPersistentEntity` is removed.

The changes in `RequestFactory` look more than what was actually done. Basically there were some functions added, but I rearranged and grouped them. I wait for the day that the `TransportClient` goes away, then this file will shrink to half it's size.