### PR TITLE
DATAES-847 Add DateFormat values for epoch_millis and epoch_second; adopt week_year name changes

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/annotations/DateFormat.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/DateFormat.java
@@ -17,6 +17,7 @@ package org.springframework.data.elasticsearch.annotations;
 
 /**
  * @author Jakub Vavrik
+ * @author Tim te Beek
  *         Values based on reference doc - https://www.elastic.co/guide/reference/mapping/date-format/
  */
 public enum DateFormat {

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/DateFormat.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/DateFormat.java
@@ -24,8 +24,8 @@ public enum DateFormat {
 	basic_ordinal_date_time_no_millis, basic_time, basic_time_no_millis, basic_t_time, basic_t_time_no_millis,
 	basic_week_date, basic_week_date_time, basic_week_date_time_no_millis, date, date_hour, date_hour_minute,
 	date_hour_minute_second, date_hour_minute_second_fraction, date_hour_minute_second_millis, date_optional_time,
-	date_time, date_time_no_millis, hour, hour_minute, hour_minute_second, hour_minute_second_fraction,
-	hour_minute_second_millis, ordinal_date, ordinal_date_time, ordinal_date_time_no_millis, time, time_no_millis,
-	t_time, t_time_no_millis, week_date, week_date_time, weekDateTimeNoMillis, week_year, weekyearWeek,
-	weekyearWeekDay, year, year_month, year_month_day
+	date_time, date_time_no_millis, epoch_millis, epoch_second, hour, hour_minute, hour_minute_second,
+	hour_minute_second_fraction, hour_minute_second_millis, ordinal_date, ordinal_date_time,
+	ordinal_date_time_no_millis, time, time_no_millis, t_time, t_time_no_millis, week_date, week_date_time,
+	weekDateTimeNoMillis, week_year, weekyearWeek, weekyearWeekDay, year, year_month, year_month_day
 }

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/DateFormat.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/DateFormat.java
@@ -28,5 +28,5 @@ public enum DateFormat {
 	date_time, date_time_no_millis, epoch_millis, epoch_second, hour, hour_minute, hour_minute_second,
 	hour_minute_second_fraction, hour_minute_second_millis, ordinal_date, ordinal_date_time,
 	ordinal_date_time_no_millis, time, time_no_millis, t_time, t_time_no_millis, week_date, week_date_time,
-	weekDateTimeNoMillis, week_year, weekyearWeek, weekyearWeekDay, year, year_month, year_month_day
+	week_date_time_no_millis, weekyear, weekyear_week, weekyear_week_day, year, year_month, year_month_day
 }

--- a/src/test/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchDateConverterTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchDateConverterTests.java
@@ -17,6 +17,7 @@ import org.springframework.data.elasticsearch.annotations.DateFormat;
 
 /**
  * @author Peter-Josef Meisch
+ * @author Tim te Beek
  */
 class ElasticsearchDateConverterTests {
 

--- a/src/test/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchDateConverterTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchDateConverterTests.java
@@ -2,6 +2,7 @@ package org.springframework.data.elasticsearch.core.convert;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -75,5 +76,25 @@ class ElasticsearchDateConverterTests {
 		Date parsed = converter.parse("20200419T194400.000Z");
 
 		assertThat(parsed).isEqualTo(legacyDate);
+	}
+
+	@Test
+	void shouldParseEpochMillisString() {
+		Instant instant = Instant.ofEpochMilli(1234568901234L);
+		ElasticsearchDateConverter converter = ElasticsearchDateConverter.of(DateFormat.epoch_millis);
+
+		Date parsed = converter.parse("1234568901234");
+
+		assertThat(parsed.toInstant()).isEqualTo(instant);
+	}
+
+	@Test
+	void shouldConvertInstantToString() {
+		Instant instant = Instant.ofEpochMilli(1234568901234L);
+		ElasticsearchDateConverter converter = ElasticsearchDateConverter.of(DateFormat.epoch_millis);
+
+		String formatted = converter.format(instant);
+
+		assertThat(formatted).isEqualTo("1234568901234");
 	}
 }


### PR DESCRIPTION
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES-847).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
