### PR TITLE
[DATAES-433] Support join datatype

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/annotations/JoinTypeRelation.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/JoinTypeRelation.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Subhobrata Dey
+ * @since 4.1
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+public @interface JoinTypeRelation {
+
+    String parent();
+
+    String[] children();
+}

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/JoinTypeRelations.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/JoinTypeRelations.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Subhobrata Dey
+ * @since 4.1
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+@Inherited
+public @interface JoinTypeRelations {
+
+    JoinTypeRelation[] relations();
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/RequestFactory.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/RequestFactory.java
@@ -743,6 +743,10 @@ class RequestFactory {
 			deleteByQueryRequest.setScroll(TimeValue.timeValueMillis(query.getScrollTime().toMillis()));
 		}
 
+		if (query.getRoute() != null) {
+			deleteByQueryRequest.setRouting(query.getRoute());
+		}
+
 		return deleteByQueryRequest;
 	}
 
@@ -796,6 +800,10 @@ class RequestFactory {
 		if (query.hasScrollTime()) {
 			// noinspection ConstantConditions
 			source.setScroll(TimeValue.timeValueMillis(query.getScrollTime().toMillis()));
+		}
+
+		if (query.getRoute() != null) {
+			source.setRouting(query.getRoute());
 		}
 
 		return requestBuilder;
@@ -888,6 +896,10 @@ class RequestFactory {
 			indexRequest.setIfPrimaryTerm(query.getPrimaryTerm());
 		}
 
+		if (query.getRouting() != null) {
+			indexRequest.routing(query.getRouting());
+		}
+
 		return indexRequest;
 	}
 
@@ -925,6 +937,9 @@ class RequestFactory {
 		}
 		if (query.getPrimaryTerm() != null) {
 			indexRequestBuilder.setIfPrimaryTerm(query.getPrimaryTerm());
+		}
+		if (query.getRouting() != null) {
+			indexRequestBuilder.setRouting(query.getRouting());
 		}
 
 		return indexRequestBuilder;

--- a/src/main/java/org/springframework/data/elasticsearch/core/convert/MappingElasticsearchConverter.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/convert/MappingElasticsearchConverter.java
@@ -44,6 +44,7 @@ import org.springframework.data.elasticsearch.ElasticsearchException;
 import org.springframework.data.elasticsearch.annotations.ScriptedField;
 import org.springframework.data.elasticsearch.core.document.Document;
 import org.springframework.data.elasticsearch.core.document.SearchDocument;
+import org.springframework.data.elasticsearch.core.join.JoinField;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentEntity;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentProperty;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentPropertyConverter;
@@ -709,6 +710,13 @@ public class MappingElasticsearchConverter
 
 			if (container.equals(type) && type.getType().equals(actualType)) {
 				return false;
+			}
+
+			if (container.getRawTypeInformation().equals(type)) {
+				Class<?> containerClass = container.getRawTypeInformation().getType();
+				if (containerClass.equals(JoinField.class) && type.getType().equals(actualType)) {
+					return false;
+				}
 			}
 		}
 

--- a/src/main/java/org/springframework/data/elasticsearch/core/join/JoinField.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/join/JoinField.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core.join;
+
+import org.springframework.lang.Nullable;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Subhobrata Dey
+ * @since 4.1
+ */
+public class JoinField<ID> {
+
+    private final String name;
+
+    @Nullable private ID parent;
+
+    public JoinField() {
+        this("default", null);
+    }
+
+    public JoinField(String name) {
+        this(name, null);
+    }
+
+    public JoinField(String name, @Nullable ID parent) {
+        this.name = name;
+        this.parent = parent;
+    }
+
+    public void setParent(@Nullable ID parent) {
+        this.parent = parent;
+    }
+
+    @Nullable
+    public ID getParent() {
+        return parent;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Map<String, Object> getAsMap() {
+        Map<String, Object> joinMap = new HashMap<>();
+        joinMap.put("name", getName());
+        joinMap.put("parent", getParent());
+
+        return Collections.unmodifiableMap(joinMap);
+    }
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentEntity.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentEntity.java
@@ -18,6 +18,7 @@ package org.springframework.data.elasticsearch.core.mapping;
 import org.elasticsearch.index.VersionType;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.core.document.Document;
+import org.springframework.data.elasticsearch.core.join.JoinField;
 import org.springframework.data.elasticsearch.core.query.SeqNoPrimaryTerm;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.lang.Nullable;
@@ -33,6 +34,7 @@ import org.springframework.lang.Nullable;
  * @author Ivan Greene
  * @author Peter-Josef Meisch
  * @author Roman Puchkovskiy
+ * @author Subhobrata Dey
  */
 public interface ElasticsearchPersistentEntity<T> extends PersistentEntity<T, ElasticsearchPersistentProperty> {
 
@@ -120,6 +122,15 @@ public interface ElasticsearchPersistentEntity<T> extends PersistentEntity<T, El
 	boolean hasSeqNoPrimaryTermProperty();
 
 	/**
+	 * Returns whether the {@link ElasticsearchPersistentEntity} has a {@link JoinField} property. If this call
+	 * returns {@literal true}, {@link #getJoinFieldProperty()} will return a non-{@literal null} value.
+	 *
+	 * @return false when {@link ElasticsearchPersistentEntity} does not define a JoinField property.
+	 * @since 4.1
+	 */
+	boolean hasJoinFieldProperty();
+
+	/**
 	 * Returns the {@link SeqNoPrimaryTerm} property of the {@link ElasticsearchPersistentEntity}. Can be {@literal null}
 	 * in case no such property is available on the entity.
 	 *
@@ -129,6 +140,17 @@ public interface ElasticsearchPersistentEntity<T> extends PersistentEntity<T, El
 	 */
 	@Nullable
 	ElasticsearchPersistentProperty getSeqNoPrimaryTermProperty();
+
+	/**
+	 * Returns the {@link JoinField} property of the {@link ElasticsearchPersistentEntity}. Can be {@literal null}
+	 * in case no such property is available on the entity.
+	 *
+	 * @return the {@link JoinField} {@link ElasticsearchPersistentProperty} of the {@link PersistentEntity} or
+	 *         {@literal null} if not defined.
+	 * @since 4.1
+	 */
+	@Nullable
+	ElasticsearchPersistentProperty getJoinFieldProperty();
 
 	/**
 	 * Returns the {@link SeqNoPrimaryTerm} property of the {@link ElasticsearchPersistentEntity} or throws an

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/IndexQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/IndexQuery.java
@@ -34,6 +34,7 @@ public class IndexQuery {
 	@Deprecated @Nullable private String parentId;
 	@Nullable private Long seqNo;
 	@Nullable private Long primaryTerm;
+	@Nullable private String routing;
 
 	@Nullable
 	public String getId() {
@@ -106,5 +107,14 @@ public class IndexQuery {
 
 	public void setPrimaryTerm(Long primaryTerm) {
 		this.primaryTerm = primaryTerm;
+	}
+
+	@Nullable
+	public String getRouting() {
+		return routing;
+	}
+
+	public void setRouting(@Nullable String routing) {
+		this.routing = routing;
 	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/IndexQueryBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/IndexQueryBuilder.java
@@ -34,6 +34,7 @@ public class IndexQueryBuilder {
 	@Deprecated @Nullable private String parentId;
 	@Nullable private Long seqNo;
 	@Nullable private Long primaryTerm;
+	@Nullable private String routing;
 
 	public IndexQueryBuilder withId(String id) {
 		this.id = id;
@@ -67,6 +68,11 @@ public class IndexQueryBuilder {
 		return this;
 	}
 
+	public IndexQueryBuilder withRouting(@Nullable String routing) {
+		this.routing = routing;
+		return this;
+	}
+
 	public IndexQuery build() {
 		IndexQuery indexQuery = new IndexQuery();
 		indexQuery.setId(id);
@@ -76,6 +82,7 @@ public class IndexQueryBuilder {
 		indexQuery.setVersion(version);
 		indexQuery.setSeqNo(seqNo);
 		indexQuery.setPrimaryTerm(primaryTerm);
+		indexQuery.setRouting(routing);
 		return indexQuery;
 	}
 }

--- a/src/test/java/org/springframework/data/elasticsearch/Utils.java
+++ b/src/test/java/org/springframework/data/elasticsearch/Utils.java
@@ -15,11 +15,13 @@
  */
 package org.springframework.data.elasticsearch;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
 
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.join.ParentJoinPlugin;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.node.NodeValidationException;
 import org.elasticsearch.transport.Netty4Plugin;
@@ -53,7 +55,7 @@ public class Utils {
 						.put("cluster.routing.allocation.disk.watermark.high", "1gb")//
 						.put("cluster.routing.allocation.disk.watermark.flood_stage", "1gb")//
 						.build(), //
-				Collections.singletonList(Netty4Plugin.class));
+				Arrays.asList(Netty4Plugin.class, ParentJoinPlugin.class));
 	}
 
 	public static Client getNodeClient() throws NodeValidationException {

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplateTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplateTests.java
@@ -19,25 +19,28 @@ import static org.assertj.core.api.Assertions.*;
 import static org.springframework.data.elasticsearch.annotations.FieldType.*;
 import static org.springframework.data.elasticsearch.utils.IdGenerator.*;
 
-import lombok.Builder;
-import lombok.Data;
-import lombok.val;
+import lombok.*;
 
 import java.lang.Object;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.query.SimpleQueryStringBuilder;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.UncategorizedElasticsearchException;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.JoinTypeRelation;
+import org.springframework.data.elasticsearch.annotations.JoinTypeRelations;
+import org.springframework.data.elasticsearch.core.join.JoinField;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
 import org.springframework.data.elasticsearch.core.query.UpdateQuery;
 import org.springframework.data.elasticsearch.junit.jupiter.ElasticsearchRestTemplateConfiguration;
 import org.springframework.data.elasticsearch.junit.jupiter.SpringIntegrationTest;
@@ -118,5 +121,4 @@ public class ElasticsearchRestTemplateTests extends ElasticsearchTemplateTests {
 		assertThat(fetchSourceContext.includes()).containsExactlyInAnyOrder("incl");
 		assertThat(fetchSourceContext.excludes()).containsExactlyInAnyOrder("excl");
 	}
-
 }


### PR DESCRIPTION
This PR adds support for join datatype in spring-data-elasticsearch.
The test case for Join is present here:

https://github.com/sbcd90/spring-data-elasticsearch/blob/es_join/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java#L3028-#L3087

- [ Yes] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ Yes] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES-433).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ Yes] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Kindly review.
