### PR TITLE
DATAES-612 - Add support for index templates.

### DIFF
--- a/src/main/asciidoc/reference/elasticsearch-new.adoc
+++ b/src/main/asciidoc/reference/elasticsearch-new.adoc
@@ -7,6 +7,7 @@
 * Upgrade to Elasticsearch 7.8.0
 * Improved API for alias management
 * Introduction of `ReactiveIndexOperations` for index management
+* Index templates support
 
 [[new-features.4-0-0]]
 == New in Spring Data Elasticsearch 4.0

--- a/src/main/java/org/springframework/data/elasticsearch/ElasticsearchException.java
+++ b/src/main/java/org/springframework/data/elasticsearch/ElasticsearchException.java
@@ -25,7 +25,7 @@ import org.springframework.lang.Nullable;
  * @author Rizwan Idrees
  * @author Mohsin Husen
  * @author Peter-Josef Meisch
- * @deprecated since 4.0, use {@link org.springframework.dao.UncategorizedDataAccessException}
+ * @deprecated since 4.0, use {@link UncategorizedElasticsearchException}
  */
 @Deprecated
 public class ElasticsearchException extends RuntimeException {

--- a/src/main/java/org/springframework/data/elasticsearch/client/reactive/ReactiveElasticsearchClient.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/reactive/ReactiveElasticsearchClient.java
@@ -36,6 +36,7 @@ import org.elasticsearch.action.admin.indices.open.OpenIndexRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
+import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateRequest;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.delete.DeleteRequest;
@@ -50,6 +51,10 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.GetAliasesResponse;
+import org.elasticsearch.client.indices.GetIndexTemplatesRequest;
+import org.elasticsearch.client.indices.GetIndexTemplatesResponse;
+import org.elasticsearch.client.indices.IndexTemplatesExistRequest;
+import org.elasticsearch.client.indices.PutIndexTemplateRequest;
 import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
@@ -610,6 +615,7 @@ public interface ReactiveElasticsearchClient {
 	 * @param callback the {@link ReactiveElasticsearchClientCallback callback} wielding the actual command to run.
 	 * @return the {@link Mono} emitting the {@link ClientResponse} once subscribed.
 	 */
+	@SuppressWarnings("JavaDoc")
 	Mono<ClientResponse> execute(ReactiveElasticsearchClientCallback callback);
 
 	/**
@@ -1196,5 +1202,144 @@ public interface ReactiveElasticsearchClient {
 		 * @since 4.1
 		 */
 		Mono<GetAliasesResponse> getAliases(HttpHeaders headers, GetAliasesRequest getAliasesRequest);
+
+		/**
+		 * Execute the given {@link PutIndexTemplateRequest} against the {@literal indices} API.
+		 *
+		 * @param consumer never {@literal null}.
+		 * @return a {@link Mono} signalling operation completion.
+		 * @since 4.1
+		 */
+		default Mono<Boolean> putTemplate(Consumer<PutIndexTemplateRequest> consumer, String templateName) {
+			PutIndexTemplateRequest putIndexTemplateRequest = new PutIndexTemplateRequest(templateName);
+			consumer.accept(putIndexTemplateRequest);
+			return putTemplate(putIndexTemplateRequest);
+		}
+
+		/**
+		 * Execute the given {@link PutIndexTemplateRequest} against the {@literal indices} API.
+		 *
+		 * @param putIndexTemplateRequest must not be {@literal null}
+		 * @return a {@link Mono} signalling operation completion.
+		 * @since 4.1
+		 */
+		default Mono<Boolean> putTemplate(PutIndexTemplateRequest putIndexTemplateRequest) {
+			return putTemplate(HttpHeaders.EMPTY, putIndexTemplateRequest);
+		}
+
+		/**
+		 * Execute the given {@link PutIndexTemplateRequest} against the {@literal indices} API.
+		 *
+		 * @param headers Use {@link HttpHeaders} to provide eg. authentication data. Must not be {@literal null}.
+		 * @param putIndexTemplateRequest must not be {@literal null}
+		 * @return a {@link Mono} signalling operation completion.
+		 * @since 4.1
+		 */
+		Mono<Boolean> putTemplate(HttpHeaders headers, PutIndexTemplateRequest putIndexTemplateRequest);
+
+		/**
+		 * Execute the given {@link GetIndexTemplatesRequest} against the {@literal indices} API.
+		 *
+		 * @param consumer never {@literal null}.
+		 * @return a {@link Mono} with the GetIndexTemplatesResponse.
+		 * @since 4.1
+		 */
+		default Mono<GetIndexTemplatesResponse> getTemplate(Consumer<GetIndexTemplatesRequest> consumer) {
+
+			GetIndexTemplatesRequest getIndexTemplatesRequest = new GetIndexTemplatesRequest();
+			consumer.accept(getIndexTemplatesRequest);
+			return getTemplate(getIndexTemplatesRequest);
+		}
+
+		/**
+		 * Execute the given {@link GetIndexTemplatesRequest} against the {@literal indices} API.
+		 *
+		 * @param getIndexTemplatesRequest must not be {@literal null}
+		 * @return a {@link Mono} with the GetIndexTemplatesResponse.
+		 * @since 4.1
+		 */
+		default Mono<GetIndexTemplatesResponse> getTemplate(GetIndexTemplatesRequest getIndexTemplatesRequest) {
+			return getTemplate(HttpHeaders.EMPTY, getIndexTemplatesRequest);
+		}
+
+		/**
+		 * Execute the given {@link GetIndexTemplatesRequest} against the {@literal indices} API.
+		 *
+		 * @param headers Use {@link HttpHeaders} to provide eg. authentication data. Must not be {@literal null}.
+		 * @param getIndexTemplatesRequest must not be {@literal null}
+		 * @return a {@link Mono} with the GetIndexTemplatesResponse.
+		 * @since 4.1
+		 */
+		Mono<GetIndexTemplatesResponse> getTemplate(HttpHeaders headers, GetIndexTemplatesRequest getIndexTemplatesRequest);
+
+		/**
+		 * Execute the given {@link IndexTemplatesExistRequest} against the {@literal indices} API.
+		 *
+		 * @param consumer never {@literal null}.
+		 * @return the {@link Mono} emitting {@literal true} if the template exists, {@literal false} otherwise.
+		 * @since 4.1
+		 */
+		default Mono<Boolean> existsTemplate(Consumer<IndexTemplatesExistRequest> consumer) {
+
+			IndexTemplatesExistRequest indexTemplatesExistRequest = new IndexTemplatesExistRequest();
+			consumer.accept(indexTemplatesExistRequest);
+			return existsTemplate(indexTemplatesExistRequest);
+		}
+
+		/**
+		 * Execute the given {@link IndexTemplatesExistRequest} against the {@literal indices} API.
+		 *
+		 * @param indexTemplatesExistRequest must not be {@literal null}
+		 * @return the {@link Mono} emitting {@literal true} if the template exists, {@literal false} otherwise.
+		 * @since 4.1
+		 */
+		default Mono<Boolean> existsTemplate(IndexTemplatesExistRequest indexTemplatesExistRequest) {
+			return existsTemplate(HttpHeaders.EMPTY, indexTemplatesExistRequest);
+		}
+
+		/**
+		 * Execute the given {@link IndexTemplatesExistRequest} against the {@literal indices} API.
+		 *
+		 * @param headers Use {@link HttpHeaders} to provide eg. authentication data. Must not be {@literal null}.
+		 * @param indexTemplatesExistRequest must not be {@literal null}
+		 * @return the {@link Mono} emitting {@literal true} if the template exists, {@literal false} otherwise.
+		 * @since 4.1
+		 */
+		Mono<Boolean> existsTemplate(HttpHeaders headers, IndexTemplatesExistRequest indexTemplatesExistRequest);
+
+		/**
+		 * Execute the given {@link DeleteIndexTemplateRequest} against the {@literal indices} API.
+		 *
+		 * @param consumer never {@literal null}.
+		 * @return the {@link Mono} emitting {@literal true} if the template exists, {@literal false} otherwise.
+		 * @since 4.1
+		 */
+		default Mono<Boolean> deleteTemplate(Consumer<DeleteIndexTemplateRequest> consumer) {
+
+			DeleteIndexTemplateRequest deleteIndexTemplateRequest = new DeleteIndexTemplateRequest();
+			consumer.accept(deleteIndexTemplateRequest);
+			return deleteTemplate(deleteIndexTemplateRequest);
+		}
+
+		/**
+		 * Execute the given {@link DeleteIndexTemplateRequest} against the {@literal indices} API.
+		 *
+		 * @param deleteIndexTemplateRequest must not be {@literal null}
+		 * @return the {@link Mono} emitting {@literal true} if the template exists, {@literal false} otherwise.
+		 * @since 4.1
+		 */
+		default Mono<Boolean> deleteTemplate(DeleteIndexTemplateRequest deleteIndexTemplateRequest) {
+			return deleteTemplate(HttpHeaders.EMPTY, deleteIndexTemplateRequest);
+		}
+
+		/**
+		 * Execute the given {@link DeleteIndexTemplateRequest} against the {@literal indices} API.
+		 *
+		 * @param headers Use {@link HttpHeaders} to provide eg. authentication data. Must not be {@literal null}.
+		 * @param deleteIndexTemplateRequest must not be {@literal null}
+		 * @return the {@link Mono} emitting {@literal true} if the template exists, {@literal false} otherwise.
+		 * @since 4.1
+		 */
+		Mono<Boolean> deleteTemplate(HttpHeaders headers, DeleteIndexTemplateRequest deleteIndexTemplateRequest);
 	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/client/reactive/RequestCreator.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/reactive/RequestCreator.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.action.admin.indices.open.OpenIndexRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
+import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateRequest;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.get.GetRequest;
@@ -27,6 +28,9 @@ import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.core.CountRequest;
+import org.elasticsearch.client.indices.GetIndexTemplatesRequest;
+import org.elasticsearch.client.indices.IndexTemplatesExistRequest;
+import org.elasticsearch.client.indices.PutIndexTemplateRequest;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 import org.springframework.data.elasticsearch.UncategorizedElasticsearchException;
 import org.springframework.data.elasticsearch.client.util.RequestConverters;
@@ -156,7 +160,38 @@ public interface RequestCreator {
 		return RequestConverters::updateAliases;
 	}
 
+	/**
+	 * @since 4.1
+	 */
 	default Function<GetAliasesRequest, Request> getAlias() {
 		return RequestConverters::getAlias;
+	}
+
+	/**
+	 * @since 4.1
+	 */
+	default Function<PutIndexTemplateRequest, Request> putTemplate() {
+		return RequestConverters::putTemplate;
+	}
+
+	/**
+	 * @since 4.1
+	 */
+	default Function<GetIndexTemplatesRequest, Request> getTemplates() {
+		return RequestConverters::getTemplates;
+	}
+
+	/**
+	 * @since 4.1
+	 */
+	default Function<IndexTemplatesExistRequest, Request> templatesExist() {
+		return RequestConverters::templatesExist;
+	}
+
+	/**
+	 * @since 4.1
+	 */
+	default Function<DeleteIndexTemplateRequest, Request> deleteTemplate() {
+		return RequestConverters::deleteTemplate;
 	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/IndexOperations.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/IndexOperations.java
@@ -23,8 +23,14 @@ import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.springframework.data.elasticsearch.core.document.Document;
 import org.springframework.data.elasticsearch.core.index.AliasActions;
 import org.springframework.data.elasticsearch.core.index.AliasData;
+import org.springframework.data.elasticsearch.core.index.DeleteTemplateRequest;
+import org.springframework.data.elasticsearch.core.index.ExistsTemplateRequest;
+import org.springframework.data.elasticsearch.core.index.GetTemplateRequest;
+import org.springframework.data.elasticsearch.core.index.PutTemplateRequest;
+import org.springframework.data.elasticsearch.core.index.TemplateData;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.query.AliasQuery;
+import org.springframework.lang.Nullable;
 
 /**
  * The operations for the
@@ -123,6 +129,23 @@ public interface IndexOperations {
 
 	// region settings
 	/**
+	 * Creates the index settings for the entity this IndexOperations is bound to.
+	 * 
+	 * @return a settings document.
+	 * @since 4.1
+	 */
+	Document createSettings();
+
+	/**
+	 * Creates the index settings from the annotations on the given class
+	 *
+	 * @param clazz the class to create the index settings from
+	 * @return a settings document.
+	 * @since 4.1
+	 */
+	Document createSettings(Class<?> clazz);
+
+	/**
 	 * Get mapping for an index defined by a class.
 	 *
 	 * @return the mapping
@@ -157,7 +180,7 @@ public interface IndexOperations {
 	boolean addAlias(AliasQuery query);
 
 	/**
-	 * Get the alias informations for a specified index.
+	 * Get the alias information for a specified index.
 	 *
 	 * @return alias information
 	 * @deprecated since 4.1, use {@link #getAliases(String...)} or {@link #getAliasesForIndex(String...)}.
@@ -203,6 +226,87 @@ public interface IndexOperations {
 	Map<String, Set<AliasData>> getAliasesForIndex(String... indexNames);
 	// endregion
 
+	// region templates
+	/**
+	 * Creates an index template using the legacy Elasticsearch interface (@see
+	 * https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates-v1.html).
+	 * 
+	 * @param putTemplateRequest template request parameters
+	 * @return true if successful
+	 * @since 4.1
+	 */
+	boolean putTemplate(PutTemplateRequest putTemplateRequest);
+
+	/**
+	 * gets an index template using the legacy Elasticsearch
+	 * interface/Users/peter/Entwicklung/Projekte/spring-data-elasticsearch/src/main/java/org/springframework/data/elasticsearch/core/IndexOperations.java.
+	 *
+	 * @param templateName the template name
+	 * @return TemplateData, {@literal null} if no template with the given name exists.
+	 * @since 4.1
+	 */
+	@Nullable
+	default TemplateData getTemplate(String templateName) {
+		return getTemplate(new GetTemplateRequest(templateName));
+	}
+
+	/**
+	 * gets an index template using the legacy Elasticsearch
+	 * interface/Users/peter/Entwicklung/Projekte/spring-data-elasticsearch/src/main/java/org/springframework/data/elasticsearch/core/IndexOperations.java.
+	 *
+	 * @param getTemplateRequest the request parameters
+	 * @return TemplateData, {@literal null} if no template with the given name exists.
+	 * @since 4.1
+	 */
+	@Nullable
+	TemplateData getTemplate(GetTemplateRequest getTemplateRequest);
+
+	/**
+	 * check if an index template exists using the legacy Elasticsearch
+	 * interface/Users/peter/Entwicklung/Projekte/spring-data-elasticsearch/src/main/java/org/springframework/data/elasticsearch/core/IndexOperations.java.
+	 *
+	 * @param templateName the template name
+	 * @return {@literal true} if the index exists
+	 * @since 4.1
+	 */
+	default boolean existsTemplate(String templateName) {
+		return existsTemplate(new ExistsTemplateRequest(templateName));
+	}
+
+	/**
+	 * check if an index template exists using the legacy Elasticsearch
+	 * interface/Users/peter/Entwicklung/Projekte/spring-data-elasticsearch/src/main/java/org/springframework/data/elasticsearch/core/IndexOperations.java.
+	 *
+	 * @param existsTemplateRequest the request parameters
+	 * @return {@literal true} if the index exists
+	 * @since 4.1
+	 */
+	boolean existsTemplate(ExistsTemplateRequest existsTemplateRequest);
+
+	/**
+	 * Deletes an index template using the legacy Elasticsearch interface (@see
+	 * https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates-v1.html).
+	 *
+	 * @param templateName the template name
+	 * @return true if successful
+	 * @since 4.1
+	 */
+	default boolean deleteTemplate(String templateName) {
+		return deleteTemplate(new DeleteTemplateRequest(templateName));
+	}
+
+	/**
+	 * Deletes an index template using the legacy Elasticsearch interface (@see
+	 * https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates-v1.html).
+	 *
+	 * @param deleteTemplateRequest template request parameters
+	 * @return true if successful
+	 * @since 4.1
+	 */
+	boolean deleteTemplate(DeleteTemplateRequest deleteTemplateRequest);
+
+	// endregion
+
 	// region helper functions
 	/**
 	 * get the current {@link IndexCoordinates}. These may change over time when the entity class has a SpEL constructed
@@ -212,5 +316,6 @@ public interface IndexOperations {
 	 * @since 4.1
 	 */
 	IndexCoordinates getIndexCoordinates();
+
 	// endregion
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/ReactiveIndexOperations.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ReactiveIndexOperations.java
@@ -23,6 +23,11 @@ import java.util.Set;
 import org.springframework.data.elasticsearch.core.document.Document;
 import org.springframework.data.elasticsearch.core.index.AliasActions;
 import org.springframework.data.elasticsearch.core.index.AliasData;
+import org.springframework.data.elasticsearch.core.index.DeleteTemplateRequest;
+import org.springframework.data.elasticsearch.core.index.ExistsTemplateRequest;
+import org.springframework.data.elasticsearch.core.index.GetTemplateRequest;
+import org.springframework.data.elasticsearch.core.index.PutTemplateRequest;
+import org.springframework.data.elasticsearch.core.index.TemplateData;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 
 /**
@@ -127,6 +132,23 @@ public interface ReactiveIndexOperations {
 
 	// region settings
 	/**
+	 * Creates the index settings for the entity this IndexOperations is bound to.
+	 *
+	 * @return a settings document.
+	 * @since 4.1
+	 */
+	Mono<Document> createSettings();
+
+	/**
+	 * Creates the index settings from the annotations on the given class
+	 *
+	 * @param clazz the class to create the index settings from
+	 * @return a settings document.
+	 * @since 4.1
+	 */
+	Mono<Document> createSettings(Class<?> clazz);
+
+	/**
 	 * get the settings for the index
 	 * 
 	 * @return a {@link Mono} with a {@link Document} containing the index settings
@@ -173,13 +195,92 @@ public interface ReactiveIndexOperations {
 	Mono<Map<String, Set<AliasData>>> getAliasesForIndex(String... indexNames);
 	// endregion
 
+	// region templates
+	/**
+	 * Creates an index template using the legacy Elasticsearch interface (@see
+	 * https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates-v1.html)
+	 *
+	 * @param putTemplateRequest template request parameters
+	 * @return Mono of {@literal true} if the template could be stored
+	 * @since 4.1
+	 */
+	Mono<Boolean> putTemplate(PutTemplateRequest putTemplateRequest);
+
+	/**
+	 * gets an index template using the legacy Elasticsearch
+	 * interface/Users/peter/Entwicklung/Projekte/spring-data-elasticsearch/src/main/java/org/springframework/data/elasticsearch/core/IndexOperations.java.
+	 *
+	 * @param templateName the template name
+	 * @return Mono of TemplateData, {@literal Mono.empty()} if no template with the given name exists.
+	 * @since 4.1
+	 */
+	default Mono<TemplateData> getTemplate(String templateName) {
+		return getTemplate(new GetTemplateRequest(templateName));
+	}
+
+	/**
+	 * gets an index template using the legacy Elasticsearch
+	 * interface/Users/peter/Entwicklung/Projekte/spring-data-elasticsearch/src/main/java/org/springframework/data/elasticsearch/core/IndexOperations.java.
+	 *
+	 * @param getTemplateRequest the request parameters
+	 * @return Mono of TemplateData, {@literal Mono.empty()} if no template with the given name exists.
+	 * @since 4.1
+	 */
+	Mono<TemplateData> getTemplate(GetTemplateRequest getTemplateRequest);
+
+	/**
+	 * Checks if an index template exists using the legacy Elasticsearch interface (@see
+	 * https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates-v1.html)
+	 *
+	 * @param templateName the template name
+	 * @return Mono of {@literal true} if the template exists
+	 * @since 4.1
+	 */
+	default Mono<Boolean> existsTemplate(String templateName) {
+		return existsTemplate(new ExistsTemplateRequest(templateName));
+	}
+
+	/**
+	 * Checks if an index template exists using the legacy Elasticsearch interface (@see
+	 * https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates-v1.html)
+	 *
+	 * @param existsTemplateRequest template request parameters
+	 * @return Mono of {@literal true} if the template exists
+	 * @since 4.1
+	 */
+	Mono<Boolean> existsTemplate(ExistsTemplateRequest existsTemplateRequest);
+
+	/**
+	 * Deletes an index template using the legacy Elasticsearch interface (@see
+	 * https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates-v1.html)
+	 *
+	 * @param templateName the template name
+	 * @return Mono of {@literal true} if the template could be deleted
+	 * @since 4.1
+	 */
+	default Mono<Boolean> deleteTemplate(String templateName) {
+		return deleteTemplate(new DeleteTemplateRequest(templateName));
+	}
+
+	/**
+	 * Deletes an index template using the legacy Elasticsearch interface (@see
+	 * https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates-v1.html)
+	 *
+	 * @param deleteTemplateRequest template request parameters
+	 * @return Mono of {@literal true} if the template could be deleted
+	 * @since 4.1
+	 */
+	Mono<Boolean> deleteTemplate(DeleteTemplateRequest deleteTemplateRequest);
+
+	// endregion
+
 	// region helper functions
 	/**
 	 * get the current {@link IndexCoordinates}. These may change over time when the entity class has a SpEL constructed
 	 * index name. When this IndexOperations is not bound to a class, the bound IndexCoordinates are returned.
 	 *
 	 * @return IndexCoordinates
-	 * @ince 4.1
+	 * @since 4.1
 	 */
 	IndexCoordinates getIndexCoordinates();
 

--- a/src/main/java/org/springframework/data/elasticsearch/core/index/AliasActionParameters.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/index/AliasActionParameters.java
@@ -20,7 +20,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
- * Value class capturing the arguments for an {@link AliasAction}.  
+ * Value class capturing the arguments for an {@link AliasAction}.
  * 
  * @author Peter-Josef Meisch
  * @since 4.1
@@ -52,6 +52,14 @@ public class AliasActionParameters {
 
 	public static Builder builder() {
 		return new Builder();
+	}
+
+	/**
+	 * a Builder to create AliasActionParameters to be used when creating index templates. Automatically sets the index
+	 * name to an empty string, as this is not used in templates
+	 */
+	public static Builder builderForTemplate() {
+		return new Builder().withIndices("");
 	}
 
 	public String[] getIndices() {
@@ -158,7 +166,7 @@ public class AliasActionParameters {
 
 		public AliasActionParameters build() {
 
-			Assert.notNull(indices, "indices must bes set");
+			Assert.notNull(indices, "indices must be set");
 
 			return new AliasActionParameters(indices, aliases, isHidden, isWriteIndex, routing, indexRouting, searchRouting,
 					filterQuery, filterQueryClass);

--- a/src/main/java/org/springframework/data/elasticsearch/core/index/DeleteTemplateRequest.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/index/DeleteTemplateRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.elasticsearch.core.query;
+package org.springframework.data.elasticsearch.core.index;
 
-import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 
 /**
- * SourceFilter for providing includes and excludes.
- *
- * @author Jon Tsiros
  * @author Peter-Josef Meisch
  */
-public interface SourceFilter {
+public class DeleteTemplateRequest {
+	private final String templateName;
 
-	@Nullable
-	String[] getIncludes();
+	public DeleteTemplateRequest(String templateName) {
 
-	@Nullable
-	String[] getExcludes();
+		Assert.notNull(templateName, "templateName must not be null");
+
+		this.templateName = templateName;
+	}
+
+	public String getTemplateName() {
+		return templateName;
+	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/index/ExistsTemplateRequest.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/index/ExistsTemplateRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.elasticsearch.core.query;
+package org.springframework.data.elasticsearch.core.index;
 
-import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 
 /**
- * SourceFilter for providing includes and excludes.
- *
- * @author Jon Tsiros
  * @author Peter-Josef Meisch
  */
-public interface SourceFilter {
+public class ExistsTemplateRequest {
+	private final String templateName;
 
-	@Nullable
-	String[] getIncludes();
+	public ExistsTemplateRequest(String templateName) {
 
-	@Nullable
-	String[] getExcludes();
+		Assert.notNull(templateName, "templateName must not be null");
+
+		this.templateName = templateName;
+	}
+
+	public String getTemplateName() {
+		return templateName;
+	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/index/GetTemplateRequest.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/index/GetTemplateRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.elasticsearch.core.query;
+package org.springframework.data.elasticsearch.core.index;
 
-import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 
 /**
- * SourceFilter for providing includes and excludes.
- *
- * @author Jon Tsiros
  * @author Peter-Josef Meisch
  */
-public interface SourceFilter {
+public class GetTemplateRequest {
+	private final String templateName;
 
-	@Nullable
-	String[] getIncludes();
+	public GetTemplateRequest(String templateName) {
 
-	@Nullable
-	String[] getExcludes();
+		Assert.notNull(templateName, "templateName must not be null");
+
+		this.templateName = templateName;
+	}
+
+	public String getTemplateName() {
+		return templateName;
+	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/index/PutTemplateRequest.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/index/PutTemplateRequest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core.index;
+
+import org.springframework.data.elasticsearch.core.document.Document;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Request to create an index template. This is to create legacy templates (@see
+ * https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates-v1.html)
+ *
+ * @author Peter-Josef Meisch
+ * @since 4.1
+ */
+public class PutTemplateRequest {
+	private final String name;
+	private final String[] indexPatterns;
+	@Nullable final private Document settings;
+	@Nullable final private Document mappings;
+	@Nullable final AliasActions aliasActions;
+	private final int order;
+	@Nullable final Integer version;
+
+	private PutTemplateRequest(String name, String[] indexPatterns, @Nullable Document settings,
+			@Nullable Document mappings, @Nullable AliasActions aliasActions, int order, @Nullable Integer version) {
+		this.name = name;
+		this.indexPatterns = indexPatterns;
+		this.settings = settings;
+		this.mappings = mappings;
+		this.aliasActions = aliasActions;
+		this.order = order;
+		this.version = version;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public String[] getIndexPatterns() {
+		return indexPatterns;
+	}
+
+	@Nullable
+	public Document getSettings() {
+		return settings;
+	}
+
+	@Nullable
+	public Document getMappings() {
+		return mappings;
+	}
+
+	@Nullable
+	public AliasActions getAliasActions() {
+		return aliasActions;
+	}
+
+	public int getOrder() {
+		return order;
+	}
+
+	@Nullable
+	public Integer getVersion() {
+		return version;
+	}
+
+	public static TemplateRequestBuilder builder(String name, String... indexPatterns) {
+		return new TemplateRequestBuilder(name, indexPatterns);
+	}
+
+	public static final class TemplateRequestBuilder {
+		private final String name;
+		private final String[] indexPatterns;
+		@Nullable private Document settings;
+		@Nullable private Document mappings;
+		@Nullable AliasActions aliasActions;
+		private int order = 0;
+		@Nullable Integer version;
+
+		private TemplateRequestBuilder(String name, String... indexPatterns) {
+
+			Assert.notNull(name, "name must not be null");
+			Assert.notNull(indexPatterns, "indexPatterns must not be null");
+
+			this.name = name;
+			this.indexPatterns = indexPatterns;
+		}
+
+		public TemplateRequestBuilder withSettings(Document settings) {
+			this.settings = settings;
+			return this;
+		}
+
+		public TemplateRequestBuilder withMappings(Document mappings) {
+			this.mappings = mappings;
+			return this;
+		}
+
+		public TemplateRequestBuilder withAliasActions(AliasActions aliasActions) {
+
+			aliasActions.getActions().forEach(action -> Assert.isTrue(action instanceof AliasAction.Add,
+					"only alias add actions are allowed in templates"));
+
+			this.aliasActions = aliasActions;
+			return this;
+		}
+
+		public TemplateRequestBuilder withOrder(int order) {
+			this.order = order;
+			return this;
+		}
+
+		public TemplateRequestBuilder withVersion(@Nullable Integer version) {
+			this.version = version;
+			return this;
+		}
+
+		public PutTemplateRequest build() {
+			return new PutTemplateRequest(name, indexPatterns, settings, mappings, aliasActions, order, version);
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/index/TemplateData.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/index/TemplateData.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core.index;
+
+import java.util.Map;
+
+import org.springframework.data.elasticsearch.core.document.Document;
+import org.springframework.lang.Nullable;
+
+/**
+ * Data returned for template information retrieval.
+ *
+ * @author Peter-Josef Meisch
+ */
+public class TemplateData {
+	@Nullable private final String[] indexPatterns;
+	@Nullable Document settings;
+	@Nullable Document mapping;
+	@Nullable private final Map<String, AliasData> aliases;
+	int order;
+	@Nullable Integer version;
+
+	private TemplateData(@Nullable String[] indexPatterns, @Nullable Document settings, @Nullable Document mapping,
+			@Nullable Map<String, AliasData> aliases, int order, @Nullable Integer version) {
+		this.indexPatterns = indexPatterns;
+		this.settings = settings;
+		this.mapping = mapping;
+		this.order = order;
+		this.version = version;
+		this.aliases = aliases;
+	}
+
+	public static TemplateDataBuilder builder() {
+		return new TemplateDataBuilder();
+	}
+
+	@Nullable
+	public String[] getIndexPatterns() {
+		return indexPatterns;
+	}
+
+	@Nullable
+	public Document getSettings() {
+		return settings;
+	}
+
+	@Nullable
+	public Document getMapping() {
+		return mapping;
+	}
+
+	@Nullable
+	public Map<String, AliasData> getAliases() {
+		return aliases;
+	}
+
+	public int getOrder() {
+		return order;
+	}
+
+	@Nullable
+	public Integer getVersion() {
+		return version;
+	}
+
+	public static final class TemplateDataBuilder {
+		@Nullable Document settings;
+		@Nullable Document mapping;
+		int order;
+		@Nullable Integer version;
+		@Nullable private String[] indexPatterns;
+		@Nullable private Map<String, AliasData> aliases;
+
+		private TemplateDataBuilder() {}
+
+		public TemplateDataBuilder withIndexPatterns(String[] indexPatterns) {
+			this.indexPatterns = indexPatterns;
+			return this;
+		}
+
+		public TemplateDataBuilder withSettings(Document settings) {
+			this.settings = settings;
+			return this;
+		}
+
+		public TemplateDataBuilder withMapping(Document mapping) {
+			this.mapping = mapping;
+			return this;
+		}
+
+		public TemplateDataBuilder withOrder(int order) {
+			this.order = order;
+			return this;
+		}
+
+		public TemplateDataBuilder withVersion(Integer version) {
+			this.version = version;
+			return this;
+		}
+
+		public TemplateDataBuilder withAliases(Map<String, AliasData> aliases) {
+			this.aliases = aliases;
+			return this;
+		}
+
+		public TemplateData build() {
+			return new TemplateData(indexPatterns, settings, mapping, aliases, order, version);
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/FetchSourceFilter.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/FetchSourceFilter.java
@@ -15,17 +15,20 @@
  */
 package org.springframework.data.elasticsearch.core.query;
 
+import org.springframework.lang.Nullable;
+
 /**
  * SourceFilter implementation for providing includes and excludes.
  *
- * @Author Jon Tsiros
+ * @author Jon Tsiros
+ * @author Peter-Josef Meisch
  */
 public class FetchSourceFilter implements SourceFilter {
 
-	private final String[] includes;
-	private final String[] excludes;
+	@Nullable private final String[] includes;
+	@Nullable private final String[] excludes;
 
-	public FetchSourceFilter(final String[] includes, final String[] excludes) {
+	public FetchSourceFilter(@Nullable final String[] includes, @Nullable final String[] excludes) {
 		this.includes = includes;
 		this.excludes = excludes;
 	}

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/MoreLikeThisQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/MoreLikeThisQuery.java
@@ -34,14 +34,14 @@ import org.springframework.lang.Nullable;
 public class MoreLikeThisQuery {
 
 	@Nullable private String id;
-	private List<String> searchIndices = new ArrayList<>();
-	private List<String> searchTypes = new ArrayList<>();
-	private List<String> fields = new ArrayList<>();
+	private final List<String> searchIndices = new ArrayList<>();
+	private final List<String> searchTypes = new ArrayList<>();
+	private final List<String> fields = new ArrayList<>();
 	@Nullable private String routing;
 	@Nullable private Float percentTermsToMatch;
 	@Nullable private Integer minTermFreq;
 	@Nullable private Integer maxQueryTerms;
-	private List<String> stopWords = new ArrayList<>();
+	private final List<String> stopWords = new ArrayList<>();
 	@Nullable private Integer minDocFreq;
 	@Nullable private Integer maxDocFreq;
 	@Nullable private Integer minWordLen;

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/Query.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/Query.java
@@ -232,7 +232,8 @@ public interface Query {
 	boolean getTrackTotalHits();
 
 	/**
-	 * For queries that are used in delete request, these are internally handled by Elasticsearch as scroll/bulk delete queries.
+	 * For queries that are used in delete request, these are internally handled by Elasticsearch as scroll/bulk delete
+	 * queries. Must not return {@literal null} when {@link #hasScrollTime()} returns {@literal true}.
 	 * 
 	 * @return the scrolltime settings
 	 * @since 4.0
@@ -241,7 +242,8 @@ public interface Query {
 	Duration getScrollTime();
 
 	/**
-	 * For queries that are used in delete request, these are internally handled by Elasticsearch as scroll/bulk delete queries.
+	 * For queries that are used in delete request, these are internally handled by Elasticsearch as scroll/bulk delete
+	 * queries.
 	 * 
 	 * @param scrollTime the scrolltime settings
 	 * @since 4.0

--- a/src/test/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchDateConverterTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/convert/ElasticsearchDateConverterTests.java
@@ -58,7 +58,7 @@ class ElasticsearchDateConverterTests {
 	@Test // DATAES-792
 	void shouldConvertLegacyDateToString() {
 		GregorianCalendar calendar = GregorianCalendar
-				.from(ZonedDateTime.of(LocalDateTime.of(2020, 04, 19, 19, 44), ZoneId.of("UTC")));
+				.from(ZonedDateTime.of(LocalDateTime.of(2020, 4, 19, 19, 44), ZoneId.of("UTC")));
 		Date legacyDate = calendar.getTime();
 		ElasticsearchDateConverter converter = ElasticsearchDateConverter.of(DateFormat.basic_date_time);
 
@@ -70,7 +70,7 @@ class ElasticsearchDateConverterTests {
 	@Test // DATAES-792
 	void shouldParseLegacyDateFromString() {
 		GregorianCalendar calendar = GregorianCalendar
-				.from(ZonedDateTime.of(LocalDateTime.of(2020, 04, 19, 19, 44), ZoneId.of("UTC")));
+				.from(ZonedDateTime.of(LocalDateTime.of(2020, 4, 19, 19, 44), ZoneId.of("UTC")));
 		Date legacyDate = calendar.getTime();
 		ElasticsearchDateConverter converter = ElasticsearchDateConverter.of(DateFormat.basic_date_time);
 

--- a/src/test/java/org/springframework/data/elasticsearch/core/index/TemplateTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/index/TemplateTests.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core.index;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.skyscreamer.jsonassert.JSONAssert.*;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.IndexOperations;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.junit.jupiter.ElasticsearchRestTemplateConfiguration;
+import org.springframework.data.elasticsearch.junit.jupiter.SpringIntegrationTest;
+import org.springframework.lang.Nullable;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author Peter-Josef Meisch
+ */
+@SpringIntegrationTest
+@ContextConfiguration(classes = { ElasticsearchRestTemplateConfiguration.class })
+public class TemplateTests {
+
+	@Autowired ElasticsearchOperations operations;
+
+	@Test // DATAES-612
+	void shouldCreateTemplate() {
+
+		IndexOperations indexOps = operations.indexOps(IndexCoordinates.of("dont-care"));
+
+		org.springframework.data.elasticsearch.core.document.Document mapping = indexOps.createMapping(TemplateClass.class);
+		org.springframework.data.elasticsearch.core.document.Document settings = indexOps
+				.createSettings(TemplateClass.class);
+
+		AliasActions aliasActions = new AliasActions(
+				new AliasAction.Add(AliasActionParameters.builderForTemplate().withAliases("alias1", "alias2").build()));
+		PutTemplateRequest putTemplateRequest = PutTemplateRequest.builder("test-template", "log-*") //
+				.withSettings(settings) //
+				.withMappings(mapping) //
+				.withAliasActions(aliasActions) //
+				.build();
+
+		boolean acknowledged = indexOps.putTemplate(putTemplateRequest);
+
+		assertThat(acknowledged).isTrue();
+	}
+
+	@Test // DATAES-612
+	void shouldReturnNullOnNonExistingGetTemplate() {
+
+		String templateName = "template" + UUID.randomUUID().toString();
+		IndexOperations indexOps = operations.indexOps(IndexCoordinates.of("dont-care"));
+
+		GetTemplateRequest getTemplateRequest = new GetTemplateRequest(templateName);
+		TemplateData templateData = indexOps.getTemplate(getTemplateRequest);
+
+		assertThat(templateData).isNull();
+	}
+
+	@Test // DATAES-612
+	void shouldGetTemplate() throws JSONException {
+		IndexOperations indexOps = operations.indexOps(IndexCoordinates.of("dont-care"));
+
+		org.springframework.data.elasticsearch.core.document.Document mapping = indexOps.createMapping(TemplateClass.class);
+		org.springframework.data.elasticsearch.core.document.Document settings = indexOps
+				.createSettings(TemplateClass.class);
+
+		AliasActions aliasActions = new AliasActions(
+				new AliasAction.Add(AliasActionParameters.builderForTemplate().withAliases("alias1", "alias2").build()));
+		PutTemplateRequest putTemplateRequest = PutTemplateRequest.builder("test-template", "log-*") //
+				.withSettings(settings) //
+				.withMappings(mapping) //
+				.withAliasActions(aliasActions) //
+				.withOrder(11) //
+				.withVersion(42) //
+				.build();
+
+		boolean acknowledged = indexOps.putTemplate(putTemplateRequest);
+		assertThat(acknowledged).isTrue();
+
+		GetTemplateRequest getTemplateRequest = new GetTemplateRequest(putTemplateRequest.getName());
+		TemplateData templateData = indexOps.getTemplate(getTemplateRequest);
+
+		assertThat(templateData).isNotNull();
+		assertThat(templateData.getIndexPatterns()).containsExactlyInAnyOrder(putTemplateRequest.getIndexPatterns());
+		assertEquals(settings.toJson(), templateData.getSettings().toJson(), false);
+		assertEquals(mapping.toJson(), templateData.getMapping().toJson(), false);
+		Map<String, AliasData> aliases = templateData.getAliases();
+		assertThat(aliases).hasSize(2);
+		AliasData alias1 = aliases.get("alias1");
+		assertThat(alias1.getAlias()).isEqualTo("alias1");
+		AliasData alias2 = aliases.get("alias2");
+		assertThat(alias2.getAlias()).isEqualTo("alias2");
+		assertThat(templateData.getOrder()).isEqualTo(putTemplateRequest.getOrder());
+		assertThat(templateData.getVersion()).isEqualTo(putTemplateRequest.getVersion());
+	}
+
+	@Test // DATAES-612
+	void shouldCheckExists() {
+		IndexOperations indexOps = operations.indexOps(IndexCoordinates.of("dont-care"));
+
+		String templateName = "template" + UUID.randomUUID().toString();
+		ExistsTemplateRequest existsTemplateRequest = new ExistsTemplateRequest(templateName);
+
+		boolean exists = indexOps.existsTemplate(existsTemplateRequest);
+		assertThat(exists).isFalse();
+
+		PutTemplateRequest putTemplateRequest = PutTemplateRequest.builder(templateName, "log-*") //
+				.withOrder(11) //
+				.withVersion(42) //
+				.build();
+
+		boolean acknowledged = indexOps.putTemplate(putTemplateRequest);
+		assertThat(acknowledged).isTrue();
+
+		exists = indexOps.existsTemplate(existsTemplateRequest);
+		assertThat(exists).isTrue();
+	}
+
+	@Test // DATAES-612
+	void shouldDeleteTemplate() {
+
+		IndexOperations indexOps = operations.indexOps(IndexCoordinates.of("dont-care"));
+
+		String templateName = "template" + UUID.randomUUID().toString();
+		ExistsTemplateRequest existsTemplateRequest = new ExistsTemplateRequest(templateName);
+
+		PutTemplateRequest putTemplateRequest = PutTemplateRequest.builder(templateName, "log-*") //
+				.withOrder(11) //
+				.withVersion(42) //
+				.build();
+
+		boolean acknowledged = indexOps.putTemplate(putTemplateRequest);
+		assertThat(acknowledged).isTrue();
+
+		boolean exists = indexOps.existsTemplate(existsTemplateRequest);
+		assertThat(exists).isTrue();
+
+		acknowledged = indexOps.deleteTemplate(new DeleteTemplateRequest(templateName));
+		assertThat(acknowledged).isTrue();
+
+		exists = indexOps.existsTemplate(existsTemplateRequest);
+		assertThat(exists).isFalse();
+
+	}
+
+	@Document(indexName = "test-template", shards = 3, replicas = 2, refreshInterval = "5s")
+	static class TemplateClass {
+		@Id @Nullable private String id;
+		@Field(type = FieldType.Text) @Nullable private String message;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		@Nullable
+		public String getMessage() {
+			return message;
+		}
+
+		public void setMessage(String message) {
+			this.message = message;
+		}
+	}
+}

--- a/src/test/java/org/springframework/data/elasticsearch/core/index/TemplateTransportTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/index/TemplateTransportTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.elasticsearch.core.query;
+package org.springframework.data.elasticsearch.core.index;
 
-import org.springframework.lang.Nullable;
+import org.springframework.data.elasticsearch.junit.jupiter.ElasticsearchTemplateConfiguration;
+import org.springframework.test.context.ContextConfiguration;
 
 /**
- * SourceFilter for providing includes and excludes.
- *
- * @author Jon Tsiros
  * @author Peter-Josef Meisch
  */
-public interface SourceFilter {
-
-	@Nullable
-	String[] getIncludes();
-
-	@Nullable
-	String[] getExcludes();
-}
+@ContextConfiguration(classes = { ElasticsearchTemplateConfiguration.class })
+public class TemplateTransportTests extends TemplateTests {}


### PR DESCRIPTION
`IndexOperations` now have methods to manage index templates, allowing for automatic creation of indices along with mappings and settings and aliases.