### PR TITLE
DATAES-908 - Fill version on an indexed entity.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplate.java
@@ -149,7 +149,8 @@ public class ElasticsearchRestTemplate extends AbstractElasticsearchTemplate {
 		Object queryObject = query.getObject();
 		if (queryObject != null) {
 			updateIndexedObject(queryObject,
-					IndexedObjectInformation.of(indexResponse.getId(), indexResponse.getSeqNo(), indexResponse.getPrimaryTerm()));
+					IndexedObjectInformation.of(indexResponse.getId(), indexResponse.getSeqNo(),
+							indexResponse.getPrimaryTerm(), indexResponse.getVersion()));
 		}
 
 		maybeCallbackAfterSaveWithQuery(query, index);
@@ -243,6 +244,7 @@ public class ElasticsearchRestTemplate extends AbstractElasticsearchTemplate {
 		BulkRequest bulkRequest = requestFactory.bulkRequest(queries, bulkOptions, index);
 		List<IndexedObjectInformation> indexedObjectInformations = checkForBulkOperationFailure(
 				execute(client -> client.bulk(bulkRequest, RequestOptions.DEFAULT)));
+		updateIndexedObjectsWithQueries(queries, indexedObjectInformations);
 		maybeCallbackAfterSaveWithQueries(queries, index);
 		return indexedObjectInformations;
 	}

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplate.java
@@ -163,7 +163,8 @@ public class ElasticsearchTemplate extends AbstractElasticsearchTemplate {
 		Object queryObject = query.getObject();
 		if (queryObject != null) {
 			updateIndexedObject(queryObject,
-					IndexedObjectInformation.of(documentId, response.getSeqNo(), response.getPrimaryTerm()));
+					IndexedObjectInformation.of(documentId, response.getSeqNo(), response.getPrimaryTerm(),
+							response.getVersion()));
 		}
 
 		maybeCallbackAfterSaveWithQuery(query, index);
@@ -209,6 +210,8 @@ public class ElasticsearchTemplate extends AbstractElasticsearchTemplate {
 		Assert.notNull(bulkOptions, "BulkOptions must not be null");
 
 		List<IndexedObjectInformation> indexedObjectInformations = doBulkOperation(queries, bulkOptions, index);
+
+		updateIndexedObjectsWithQueries(queries, indexedObjectInformations);
 
 		maybeCallbackAfterSaveWithQueries(queries, index);
 

--- a/src/main/java/org/springframework/data/elasticsearch/core/IndexedObjectInformation.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/IndexedObjectInformation.java
@@ -21,32 +21,44 @@ import org.springframework.lang.Nullable;
  * Value class capturing information about a newly indexed document in Elasticsearch.
  *
  * @author Peter-Josef Meisch
+ * @author Roman Puchkovskiy
  * @since 4.1
  */
 public class IndexedObjectInformation {
 	private final String id;
 	@Nullable private final Long seqNo;
 	@Nullable private final Long primaryTerm;
+	@Nullable private final Long version;
 
-	private IndexedObjectInformation(String id, @Nullable Long seqNo, @Nullable Long primaryTerm) {
+	private IndexedObjectInformation(String id, @Nullable Long seqNo, @Nullable Long primaryTerm,
+			@Nullable Long version) {
 		this.id = id;
 		this.seqNo = seqNo;
 		this.primaryTerm = primaryTerm;
+		this.version = version;
 	}
 
-	public static IndexedObjectInformation of(String id, @Nullable Long seqNo, @Nullable Long primaryTerm) {
-		return new IndexedObjectInformation(id, seqNo, primaryTerm);
+	public static IndexedObjectInformation of(String id, @Nullable Long seqNo, @Nullable Long primaryTerm,
+			@Nullable Long version) {
+		return new IndexedObjectInformation(id, seqNo, primaryTerm, version);
 	}
 
 	public String getId() {
 		return id;
 	}
 
-	public long getSeqNo() {
+	@Nullable
+	public Long getSeqNo() {
 		return seqNo;
 	}
 
-	public long getPrimaryTerm() {
+	@Nullable
+	public Long getPrimaryTerm() {
 		return primaryTerm;
+	}
+
+	@Nullable
+	public Long getVersion() {
+		return version;
 	}
 }

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTemplateTests.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -3448,6 +3449,68 @@ public abstract class ElasticsearchTemplateTests {
 		return ((AbstractElasticsearchTemplate) operations).getRequestFactory();
 	}
 
+	@Test // DATAES-908
+	void shouldFillVersionOnSaveOne() {
+		VersionedEntity saved = operations.save(new VersionedEntity());
+
+		assertThat(saved.getVersion()).isNotNull();
+	}
+
+	@Test // DATAES-908
+	void shouldFillVersionOnSaveIterable() {
+		List<VersionedEntity> iterable = Arrays.asList(new VersionedEntity(), new VersionedEntity());
+		Iterator<VersionedEntity> results = operations.save(iterable).iterator();
+		VersionedEntity saved1 = results.next();
+		VersionedEntity saved2 = results.next();
+
+		assertThat(saved1.getVersion()).isNotNull();
+		assertThat(saved2.getVersion()).isNotNull();
+	}
+
+	@Test // DATAES-908
+	void shouldFillVersionOnSaveArray() {
+		VersionedEntity[] array = {new VersionedEntity(), new VersionedEntity()};
+		Iterator<VersionedEntity> results = operations.save(array).iterator();
+		VersionedEntity saved1 = results.next();
+		VersionedEntity saved2= results.next();
+
+		assertThat(saved1.getVersion()).isNotNull();
+		assertThat(saved2.getVersion()).isNotNull();
+	}
+
+	@Test // DATAES-908
+	void shouldFillVersionOnIndexOne() {
+		VersionedEntity entity = new VersionedEntity();
+		IndexQuery query = new IndexQueryBuilder().withObject(entity).build();
+		operations.index(query, operations.getIndexCoordinatesFor(VersionedEntity.class));
+
+		assertThat(entity.getVersion()).isNotNull();
+	}
+
+	@Test // DATAES-908
+	void shouldFillVersionOnBulkIndex() {
+		VersionedEntity entity1 = new VersionedEntity();
+		VersionedEntity entity2= new VersionedEntity();
+		IndexQuery query1 = new IndexQueryBuilder().withObject(entity1).build();
+		IndexQuery query2 = new IndexQueryBuilder().withObject(entity2).build();
+		operations.bulkIndex(Arrays.asList(query1, query2), VersionedEntity.class);
+
+		assertThat(entity1.getVersion()).isNotNull();
+		assertThat(entity2.getVersion()).isNotNull();
+	}
+
+	@Test // DATAES-908
+	void shouldFillSeqNoPrimaryKeyOnBulkIndex() {
+		OptimisticEntity entity1 = new OptimisticEntity();
+		OptimisticEntity entity2 = new OptimisticEntity();
+		IndexQuery query1 = new IndexQueryBuilder().withObject(entity1).build();
+		IndexQuery query2 = new IndexQueryBuilder().withObject(entity2).build();
+		operations.bulkIndex(Arrays.asList(query1, query2), OptimisticEntity.class);
+
+		assertThatSeqNoPrimaryTermIsFilled(entity1);
+		assertThatSeqNoPrimaryTermIsFilled(entity2);
+	}
+
 	@Data
 	@NoArgsConstructor
 	@AllArgsConstructor
@@ -3622,6 +3685,13 @@ public abstract class ElasticsearchTemplateTests {
 		@Id private String id;
 		private String message;
 		private SeqNoPrimaryTerm seqNoPrimaryTerm;
+		@Version private Long version;
+	}
+
+	@Data
+	@Document(indexName = "test-index-versioned-entity-template")
+	static class VersionedEntity {
+		@Id private String id;
 		@Version private Long version;
 	}
 


### PR DESCRIPTION
Elasticsearch returns version of a document after it has been indexed, so we can (and probably should) fill it on the entity, like we do it for SeqNoPrimaryTerm (this behavior was added in DATAES-876).

Also, SeqNoPrimaryTerm was not filled in a couple of places on indexing.

This still has some issues.

1. 2 tests fail, namely ElasticsearchTemplateTests.shouldReturnObjectsForGivenIdsUsingMultiGet() and ElasticsearchTemplateTests.shouldReturnNullObjectForNotExistingIdUsingMultiGet(). Both seem to check for too much: they both require the version field to remain unchanged. According to their names, I would simply remove the version field from the test entity. On the other hand, if an intention of the tests is to make sure that the @Version property is actually providing the value for the version that should be used by ES to index the documents, this should be discussed and fixed, because spring-data-elasticsearch currently does not do this (and in my opinion, it shouldn't).
What would you advise here?
2. `IndexedObjectInformation` seems to have a problem: all its fields are nullable, and in one case they are really initialized with nulls, but all the getters return primitive values. Should that null-initializing place (`AbstractElasticsearchTemplate:499`) be rewritten to avoid such null initialization?

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [JIRA](https://jira.spring.io/browse/DATAES).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
