### PR TITLE
DATAES-935 - Setup integration tests separate from unit tests.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
 			    sh 'mkdir -p /tmp/jenkins-home'
             	sh 'chown -R 1001:1001 .'
 				sh 'rm -rf ?'
-				sh 'MAVEN_OPTS="-Duser.name=jenkins -Duser.home=/tmp/jenkins-home" ./mvnw clean dependency:list test -Dsort -U -B'
+				sh 'MAVEN_OPTS="-Duser.name=jenkins -Duser.home=/tmp/jenkins-home" ./mvnw clean dependency:list verify -Dsort -U -B'
             	sh 'chown -R 1001:1001 .'
 			}
 		}
@@ -59,7 +59,7 @@ pipeline {
                         sh 'mkdir -p /tmp/jenkins-home'
                         sh 'chown -R 1001:1001 .'
 						sh 'rm -rf ?'
-						sh 'MAVEN_OPTS="-Duser.name=jenkins -Duser.home=/tmp/jenkins-home" ./mvnw -Pjava11 clean dependency:list test -Dsort -U -B'
+						sh 'MAVEN_OPTS="-Duser.name=jenkins -Duser.home=/tmp/jenkins-home" ./mvnw -Pjava11 clean dependency:list verify -Dsort -U -B'
                         sh 'chown -R 1001:1001 .'
 					}
 				}
@@ -78,7 +78,7 @@ pipeline {
                         sh 'mkdir -p /tmp/jenkins-home'
                         sh 'chown -R 1001:1001 .'
 						sh 'rm -rf ?'
-						sh 'MAVEN_OPTS="-Duser.name=jenkins -Duser.home=/tmp/jenkins-home" ./mvnw -Pjava11 clean dependency:list test -Dsort -U -B'
+						sh 'MAVEN_OPTS="-Duser.name=jenkins -Duser.home=/tmp/jenkins-home" ./mvnw -Pjava11 clean dependency:list verify -Dsort -U -B'
                         sh 'chown -R 1001:1001 .'
 					}
 				}

--- a/pom.xml
+++ b/pom.xml
@@ -1,396 +1,419 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <modelVersion>4.0.0</modelVersion>
+	<modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.springframework.data</groupId>
-    <artifactId>spring-data-elasticsearch</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+	<groupId>org.springframework.data</groupId>
+	<artifactId>spring-data-elasticsearch</artifactId>
+	<version>4.1.0-SNAPSHOT</version>
 
-    <parent>
-        <groupId>org.springframework.data.build</groupId>
-        <artifactId>spring-data-parent</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
-    </parent>
+	<parent>
+		<groupId>org.springframework.data.build</groupId>
+		<artifactId>spring-data-parent</artifactId>
+		<version>2.4.0-SNAPSHOT</version>
+	</parent>
 
-    <name>Spring Data Elasticsearch</name>
-    <description>Spring Data Implementation for Elasticsearch</description>
-    <url>https://github.com/spring-projects/spring-data-elasticsearch</url>
+	<name>Spring Data Elasticsearch</name>
+	<description>Spring Data Implementation for Elasticsearch</description>
+	<url>https://github.com/spring-projects/spring-data-elasticsearch</url>
 
-    <properties>
-        <commonslang>2.6</commonslang>
-        <elasticsearch>7.9.1</elasticsearch>
-        <log4j>2.13.3</log4j>
-        <netty>4.1.50.Final</netty>
-        <springdata.commons>2.4.0-SNAPSHOT</springdata.commons>
-        <testcontainers>1.14.3</testcontainers>
-        <java-module-name>spring.data.elasticsearch</java-module-name>
-    </properties>
+	<properties>
+		<commonslang>2.6</commonslang>
+		<elasticsearch>7.9.1</elasticsearch>
+		<log4j>2.13.3</log4j>
+		<netty>4.1.50.Final</netty>
+		<springdata.commons>2.4.0-SNAPSHOT</springdata.commons>
+		<testcontainers>1.14.3</testcontainers>
+		<java-module-name>spring.data.elasticsearch</java-module-name>
+	</properties>
 
-    <developers>
-        <developer>
-            <id>biomedcentral</id>
-            <name>BioMed Central Development Team</name>
-            <timezone>+0</timezone>
-        </developer>
-        <developer>
-            <id>cstrobl</id>
-            <name>Christoph Strobl</name>
-            <email>cstrobl at pivotal.io</email>
-            <organization>Pivotal</organization>
-            <organizationUrl>https://www.pivotal.io</organizationUrl>
-            <roles>
-                <role>Developer</role>
-            </roles>
-            <timezone>+1</timezone>
-        </developer>
-        <developer>
-            <id>mpaluch</id>
-            <name>Mark Paluch</name>
-            <email>mpaluch at pivotal.io</email>
-            <organization>Pivotal</organization>
-            <organizationUrl>https://www.pivotal.io</organizationUrl>
-            <roles>
-                <role>Developer</role>
-            </roles>
-            <timezone>+1</timezone>
-        </developer>
-    </developers>
+	<developers>
+		<developer>
+			<id>biomedcentral</id>
+			<name>BioMed Central Development Team</name>
+			<timezone>+0</timezone>
+		</developer>
+		<developer>
+			<id>cstrobl</id>
+			<name>Christoph Strobl</name>
+			<email>cstrobl at pivotal.io</email>
+			<organization>Pivotal</organization>
+			<organizationUrl>https://www.pivotal.io</organizationUrl>
+			<roles>
+				<role>Developer</role>
+			</roles>
+			<timezone>+1</timezone>
+		</developer>
+		<developer>
+			<id>mpaluch</id>
+			<name>Mark Paluch</name>
+			<email>mpaluch at pivotal.io</email>
+			<organization>Pivotal</organization>
+			<organizationUrl>https://www.pivotal.io</organizationUrl>
+			<roles>
+				<role>Developer</role>
+			</roles>
+			<timezone>+1</timezone>
+		</developer>
+	</developers>
 
-    <scm>
-        <url>https://github.com/spring-projects/spring-data-elasticsearch</url>
-        <connection>scm:git:git://github.com/spring-projects/spring-data-elasticsearch.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-data-elasticsearch.git
-        </developerConnection>
-    </scm>
+	<scm>
+		<url>https://github.com/spring-projects/spring-data-elasticsearch</url>
+		<connection>scm:git:git://github.com/spring-projects/spring-data-elasticsearch.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-data-elasticsearch.git
+		</developerConnection>
+	</scm>
 
-    <ciManagement>
-        <system>Bamboo</system>
-        <url>https://build.spring.io/browse/SPRINGDATAES</url>
-    </ciManagement>
+	<ciManagement>
+		<system>Bamboo</system>
+		<url>https://build.spring.io/browse/SPRINGDATAES</url>
+	</ciManagement>
 
-    <issueManagement>
-        <system>JIRA</system>
-        <url>https://jira.spring.io/browse/DATAES</url>
-    </issueManagement>
+	<issueManagement>
+		<system>JIRA</system>
+		<url>https://jira.spring.io/browse/DATAES</url>
+	</issueManagement>
 
-    <dependencyManagement>
+	<dependencyManagement>
 
-        <dependencies>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>${netty}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-bom</artifactId>
+				<version>${netty}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
-    <dependencies>
+	<dependencies>
 
-        <!-- Spring -->
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+		<!-- Spring -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-tx</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-tx</artifactId>
+		</dependency>
 
-        <!-- SPRING DATA -->
-        <dependency>
-            <groupId>org.springframework.data</groupId>
-            <artifactId>spring-data-commons</artifactId>
-            <version>${springdata.commons}</version>
-        </dependency>
+		<!-- SPRING DATA -->
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-commons</artifactId>
+			<version>${springdata.commons}</version>
+		</dependency>
 
-        <!-- Reactive Infrastructure -->
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-webflux</artifactId>
-            <optional>true</optional>
-        </dependency>
+		<!-- Reactive Infrastructure -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-webflux</artifactId>
+			<optional>true</optional>
+		</dependency>
 
-        <dependency>
-            <groupId>io.projectreactor.netty</groupId>
-            <artifactId>reactor-netty-http</artifactId>
-            <optional>true</optional>
-        </dependency>
+		<dependency>
+			<groupId>io.projectreactor.netty</groupId>
+			<artifactId>reactor-netty-http</artifactId>
+			<optional>true</optional>
+		</dependency>
 
-        <dependency>
-            <groupId>io.projectreactor</groupId>
-            <artifactId>reactor-test</artifactId>
-            <scope>test</scope>
-        </dependency>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 
-        <!-- APACHE -->
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>${commonslang}</version>
-            <scope>test</scope>
-        </dependency>
+		<!-- APACHE -->
+		<dependency>
+			<groupId>commons-lang</groupId>
+			<artifactId>commons-lang</artifactId>
+			<version>${commonslang}</version>
+			<scope>test</scope>
+		</dependency>
 
-        <!-- JODA Time -->
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>${jodatime}</version>
-            <optional>true</optional>
-        </dependency>
+		<!-- JODA Time -->
+		<dependency>
+			<groupId>joda-time</groupId>
+			<artifactId>joda-time</artifactId>
+			<version>${jodatime}</version>
+			<optional>true</optional>
+		</dependency>
 
-        <!-- Elasticsearch -->
-        <dependency>
-            <groupId>org.elasticsearch.client</groupId>
-            <artifactId>transport</artifactId>
-            <version>${elasticsearch}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+		<!-- Elasticsearch -->
+		<dependency>
+			<groupId>org.elasticsearch.client</groupId>
+			<artifactId>transport</artifactId>
+			<version>${elasticsearch}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 
-        <dependency>
-            <!-- required by elasticsearch -->
-            <groupId>org.elasticsearch.plugin</groupId>
-            <artifactId>transport-netty4-client</artifactId>
-            <version>${elasticsearch}</version>
-        </dependency>
+		<dependency>
+			<!-- required by elasticsearch -->
+			<groupId>org.elasticsearch.plugin</groupId>
+			<artifactId>transport-netty4-client</artifactId>
+			<version>${elasticsearch}</version>
+		</dependency>
 
-        <dependency>
-            <groupId>org.elasticsearch.client</groupId>
-            <artifactId>elasticsearch-rest-high-level-client</artifactId>
-            <version>${elasticsearch}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+		<dependency>
+			<groupId>org.elasticsearch.client</groupId>
+			<artifactId>elasticsearch-rest-high-level-client</artifactId>
+			<version>${elasticsearch}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>log4j-over-slf4j</artifactId>
-            <version>${slf4j}</version>
-            <scope>test</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>log4j-over-slf4j</artifactId>
+			<version>${slf4j}</version>
+			<scope>test</scope>
+		</dependency>
 
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>${log4j}</version>
-            <scope>test</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>${log4j}</version>
+			<scope>test</scope>
+		</dependency>
 
-        <!-- Jackson JSON Mapper -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
+		<!-- Jackson JSON Mapper -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
 
-        <!-- CDI -->
-        <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-            <version>${cdi}</version>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
+		<!-- CDI -->
+		<dependency>
+			<groupId>javax.enterprise</groupId>
+			<artifactId>cdi-api</artifactId>
+			<version>${cdi}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
 
-        <!-- Test -->
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>ch.qos.logback</groupId>
-                    <artifactId>logback-classic</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+		<!-- Test -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>ch.qos.logback</groupId>
+					<artifactId>logback-classic</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 
-        <dependency>
-            <groupId>org.apache.openwebbeans.test</groupId>
-            <artifactId>cditest-owb</artifactId>
-            <version>1.2.8</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.geronimo.specs</groupId>
-                    <artifactId>geronimo-jcdi_1.0_spec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.geronimo.specs</groupId>
-                    <artifactId>geronimo-atinject_1.0_spec</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+		<dependency>
+			<groupId>org.apache.openwebbeans.test</groupId>
+			<artifactId>cditest-owb</artifactId>
+			<version>1.2.8</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.geronimo.specs</groupId>
+					<artifactId>geronimo-jcdi_1.0_spec</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.geronimo.specs</groupId>
+					<artifactId>geronimo-atinject_1.0_spec</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 
-        <dependency>
-            <groupId>org.skyscreamer</groupId>
-            <artifactId>jsonassert</artifactId>
-            <version>1.5.0</version>
-            <scope>test</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.skyscreamer</groupId>
+			<artifactId>jsonassert</artifactId>
+			<version>1.5.0</version>
+			<scope>test</scope>
+		</dependency>
 
-        <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
-            <version>2.26.3</version>
-            <scope>test</scope>
-            <exclusions>
-                <!-- these exclusions are needed because of Elasticsearch JarHell-->
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.ow2.asm</groupId>
-                    <artifactId>asm</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+		<dependency>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-jre8</artifactId>
+			<version>2.26.3</version>
+			<scope>test</scope>
+			<exclusions>
+				<!-- these exclusions are needed because of Elasticsearch JarHell-->
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.ow2.asm</groupId>
+					<artifactId>asm</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 
-        <!-- Upgrade xbean to 4.5 to prevent incompatibilities due to ASM versions -->
-        <dependency>
-            <groupId>org.apache.xbean</groupId>
-            <artifactId>xbean-asm5-shaded</artifactId>
-            <version>4.5</version>
-            <scope>test</scope>
-        </dependency>
+		<!-- Upgrade xbean to 4.5 to prevent incompatibilities due to ASM versions -->
+		<dependency>
+			<groupId>org.apache.xbean</groupId>
+			<artifactId>xbean-asm5-shaded</artifactId>
+			<version>4.5</version>
+			<scope>test</scope>
+		</dependency>
 
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>test</scope>
-        </dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>3.1.0</version>
+			<scope>test</scope>
+		</dependency>
 
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
-            <version>${mockito}</version>
-            <scope>test</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<version>${mockito}</version>
+			<scope>test</scope>
+		</dependency>
 
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>elasticsearch</artifactId>
-            <version>${testcontainers}</version>
-            <scope>test</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>elasticsearch</artifactId>
+			<version>${testcontainers}</version>
+			<scope>test</scope>
+		</dependency>
 
-    </dependencies>
+	</dependencies>
 
-    <build>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <filtering>true</filtering>
-                <includes>
-                    <include>**/versions.properties</include>
-                </includes>
-            </resource>
-            <resource>
-                <directory>src/main/resources</directory>
-                <filtering>false</filtering>
-                <excludes>
-                    <exclude>**/versions.properties</exclude>
-                </excludes>
-            </resource>
-        </resources>
+	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>**/versions.properties</include>
+				</includes>
+			</resource>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>false</filtering>
+				<excludes>
+					<exclude>**/versions.properties</exclude>
+				</excludes>
+			</resource>
+		</resources>
 
-        <plugins>
-            <!--
-            please do not remove this configuration for surefire - we need that to avoid issue with jar hell
-            -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <useSystemClassLoader>true</useSystemClassLoader>
-                    <useFile>false</useFile>
-                    <includes>
-                        <include>**/*Tests.java</include>
-                        <include>**/*Test.java</include>
-                    </includes>
-                    <systemPropertyVariables>
-                        <es.set.netty.runtime.available.processors>false</es.set.netty.runtime.available.processors>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.asciidoctor</groupId>
-                <artifactId>asciidoctor-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
+		<plugins>
+			<!--
+			please do not remove this configuration for surefire - we need that to avoid issue with jar hell
+			-->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<useSystemClassLoader>true</useSystemClassLoader>
+					<useFile>false</useFile>
+					<includes>
+						<include>**/*Tests.java</include>
+						<include>**/*Test.java</include>
+					</includes>
+					<systemPropertyVariables>
+						<es.set.netty.runtime.available.processors>false</es.set.netty.runtime.available.processors>
+					</systemPropertyVariables>
+				</configuration>
+				<executions>
+					<!-- the default-test execution runs only the unit tests -->
+					<execution>
+						<id>default-test</id>
+						<phase>test</phase>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<configuration>
+							<excludedGroups>integration-test</excludedGroups>
+						</configuration>
+					</execution>
+					<!-- execution to run the integration tests -->
+					<execution>
+						<id>integration-test</id>
+						<phase>integration-test</phase>
+						<goals>
+							<goal>test</goal>
+						</goals>
+						<configuration>
+							<groups>integration-test</groups>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-assembly-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.asciidoctor</groupId>
+				<artifactId>asciidoctor-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
 
-    <profiles>
-        <profile>
+	<profiles>
+		<profile>
 
-            <id>ci</id>
+			<id>ci</id>
 
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-checkstyle-plugin</artifactId>
-                        <configuration>
-                            <checkstyleRules>
-                                <module name="Checker">
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-checkstyle-plugin</artifactId>
+						<configuration>
+							<checkstyleRules>
+								<module name="Checker">
 
-                                    <!-- Configure checker to use UTF-8 encoding -->
-                                    <property name="charset" value="UTF-8"/>
+									<!-- Configure checker to use UTF-8 encoding -->
+									<property name="charset" value="UTF-8"/>
 
-                                    <module name="io.spring.nohttp.checkstyle.check.NoHttpCheck"/>
-                                </module>
-                            </checkstyleRules>
-                            <includes>**/*</includes>
-                            <excludes>.git/**/*,target/**/*,**/target/**/*,.idea/**/*,**/spring.schemas,**/*.svg,mvnw,mvnw.cmd,**/*.policy</excludes>
-                            <sourceDirectories>./</sourceDirectories>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
+									<module name="io.spring.nohttp.checkstyle.check.NoHttpCheck"/>
+								</module>
+							</checkstyleRules>
+							<includes>**/*</includes>
+							<excludes>.git/**/*,target/**/*,**/target/**/*,.idea/**/*,**/spring.schemas,**/*.svg,mvnw,mvnw.cmd,**/*.policy</excludes>
+							<sourceDirectories>./</sourceDirectories>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
 
-        </profile>
+		</profile>
 
-    </profiles>
+	</profiles>
 
-    <repositories>
-        <repository>
-            <id>spring-libs-snapshot</id>
-            <url>https://repo.spring.io/libs-snapshot</url>
-        </repository>
-    </repositories>
+	<repositories>
+		<repository>
+			<id>spring-libs-snapshot</id>
+			<url>https://repo.spring.io/libs-snapshot</url>
+		</repository>
+	</repositories>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>spring-plugins-release</id>
-            <url>https://repo.spring.io/plugins-release</url>
-        </pluginRepository>
-    </pluginRepositories>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>spring-plugins-release</id>
+			<url>https://repo.spring.io/plugins-release</url>
+		</pluginRepository>
+	</pluginRepositories>
 
 </project>

--- a/src/test/java/org/springframework/data/elasticsearch/core/RequestFactoryTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/RequestFactoryTests.java
@@ -434,7 +434,7 @@ class RequestFactoryTests {
 		PutIndexTemplateRequest putIndexTemplateRequest = requestFactory.putIndexTemplateRequest(putTemplateRequest);
 
 		String json = requestToString(putIndexTemplateRequest);
-		System.out.println(json);
+
 		assertEquals(expected, json, false);
 	}
 

--- a/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderIntegrationTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderIntegrationTests.java
@@ -1,0 +1,624 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.elasticsearch.core.index;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.elasticsearch.index.query.QueryBuilders.*;
+import static org.springframework.data.elasticsearch.annotations.FieldType.*;
+import static org.springframework.data.elasticsearch.annotations.FieldType.Object;
+import static org.springframework.data.elasticsearch.utils.IndexBuilder.*;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.lang.Integer;
+import java.math.BigDecimal;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.assertj.core.data.Percentage;
+import org.elasticsearch.search.suggest.completion.context.ContextMapping;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.*;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.IndexOperations;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.completion.Completion;
+import org.springframework.data.elasticsearch.core.geo.GeoPoint;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.IndexQuery;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQuery;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
+import org.springframework.data.elasticsearch.core.query.SeqNoPrimaryTerm;
+import org.springframework.data.elasticsearch.junit.jupiter.ElasticsearchRestTemplateConfiguration;
+import org.springframework.data.elasticsearch.junit.jupiter.SpringIntegrationTest;
+import org.springframework.data.geo.Box;
+import org.springframework.data.geo.Circle;
+import org.springframework.data.geo.Point;
+import org.springframework.data.geo.Polygon;
+import org.springframework.lang.Nullable;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author Stuart Stevenson
+ * @author Jakub Vavrik
+ * @author Mohsin Husen
+ * @author Keivn Leturc
+ * @author Nordine Bittich
+ * @author Don Wellington
+ * @author Sascha Woo
+ * @author Peter-Josef Meisch
+ * @author Xiao Yu
+ * @author Roman Puchkovskiy
+ */
+@SpringIntegrationTest
+@ContextConfiguration(classes = { ElasticsearchRestTemplateConfiguration.class })
+public class MappingBuilderIntegrationTests extends MappingContextBaseTests {
+
+	@Autowired private ElasticsearchOperations operations;
+	private IndexOperations indexOperations;
+
+	@AfterEach
+	@BeforeEach
+	public void deleteIndices() {
+		indexOperations = operations.indexOps(SimpleRecursiveEntity.class);
+		indexOperations.delete();
+		operations.indexOps(StockPrice.class).delete();
+		operations.indexOps(SampleInheritedEntity.class).delete();
+		operations.indexOps(User.class).delete();
+		operations.indexOps(Group.class).delete();
+		operations.indexOps(Book.class).delete();
+		operations.indexOps(NormalizerEntity.class).delete();
+		operations.indexOps(CopyToEntity.class).delete();
+	}
+
+	@Test
+	public void shouldNotFailOnCircularReference() {
+
+		operations.indexOps(SimpleRecursiveEntity.class).create();
+		indexOperations.putMapping(SimpleRecursiveEntity.class);
+		indexOperations.refresh();
+	}
+
+	@Test // DATAES-530
+	public void shouldAddStockPriceDocumentToIndex() {
+
+		// Given
+		IndexOperations indexOps = operations.indexOps(StockPrice.class);
+
+		// When
+		indexOps.create();
+		indexOps.putMapping(StockPrice.class);
+		String symbol = "AU";
+		double price = 2.34;
+		String id = "abc";
+
+		IndexCoordinates index = IndexCoordinates.of("test-index-stock-mapping-builder");
+		operations.index(buildIndex(StockPrice.builder() //
+				.id(id) //
+				.symbol(symbol) //
+				.price(BigDecimal.valueOf(price)) //
+				.build()), index);
+		operations.indexOps(StockPrice.class).refresh();
+
+		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
+		SearchHits<StockPrice> result = operations.search(searchQuery, StockPrice.class, index);
+
+		// Then
+		assertThat(result).hasSize(1);
+		StockPrice entry = result.getSearchHit(0).getContent();
+		assertThat(entry.getSymbol()).isEqualTo(symbol);
+		assertThat(entry.getPrice()).isCloseTo(BigDecimal.valueOf(price), Percentage.withPercentage(0.01));
+	}
+
+	@Test // DATAES-76
+	public void shouldAddSampleInheritedEntityDocumentToIndex() {
+		// given
+		IndexCoordinates index = IndexCoordinates.of("test-index-sample-inherited-mapping-builder");
+		IndexOperations indexOps = operations.indexOps(index);
+
+		// when
+		indexOps.create();
+		indexOps.putMapping(SampleInheritedEntity.class);
+		Date createdDate = new Date();
+		String message = "msg";
+		String id = "abc";
+		operations.index(new SampleInheritedEntityBuilder(id).createdDate(createdDate).message(message).buildIndex(),
+				index);
+		operations.indexOps(SampleInheritedEntity.class).refresh();
+
+		NativeSearchQuery searchQuery = new NativeSearchQueryBuilder().withQuery(matchAllQuery()).build();
+		SearchHits<SampleInheritedEntity> result = operations.search(searchQuery, SampleInheritedEntity.class, index);
+
+		// then
+		assertThat(result).hasSize(1);
+
+		SampleInheritedEntity entry = result.getSearchHit(0).getContent();
+		assertThat(entry.getCreatedDate()).isEqualTo(createdDate);
+		assertThat(entry.getMessage()).isEqualTo(message);
+	}
+
+	@Test // DATAES-260 - StackOverflow when two reverse relationship.
+	public void shouldHandleReverseRelationship() {
+
+		// given
+		IndexOperations indexOpsUser = operations.indexOps(User.class);
+		indexOpsUser.create();
+		indexOpsUser.putMapping(User.class);
+
+		IndexOperations indexOpsGroup = operations.indexOps(Group.class);
+		indexOpsGroup.create();
+		indexOpsGroup.putMapping(Group.class);
+
+		// when
+
+		// then
+	}
+
+	@Test // DATAES-420
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public void shouldUseBothAnalyzer() {
+
+		// given
+		IndexOperations indexOps = this.operations.indexOps(Book.class);
+		indexOps.create();
+		indexOps.putMapping(Book.class);
+
+		// when
+		Map mapping = indexOps.getMapping();
+		Map descriptionMapping = (Map) ((Map) mapping.get("properties")).get("description");
+		Map prefixDescription = (Map) ((Map) descriptionMapping.get("fields")).get("prefix");
+
+		// then
+		assertThat(prefixDescription).hasSize(3);
+		assertThat(prefixDescription.get("type")).isEqualTo("text");
+		assertThat(prefixDescription.get("analyzer")).isEqualTo("stop");
+		assertThat(prefixDescription.get("search_analyzer")).isEqualTo("standard");
+		assertThat(descriptionMapping.get("type")).isEqualTo("text");
+		assertThat(descriptionMapping.get("analyzer")).isEqualTo("whitespace");
+	}
+
+	@Test // DATAES-492
+	@SuppressWarnings("rawtypes")
+	public void shouldUseKeywordNormalizer() {
+
+		// given
+		operations.createIndex(NormalizerEntity.class);
+		operations.putMapping(NormalizerEntity.class);
+
+		// when
+		Map mapping = operations.getMapping(NormalizerEntity.class);
+		Map properties = (Map) mapping.get("properties");
+		Map fieldName = (Map) properties.get("name");
+		Map fieldDescriptionLowerCase = (Map) ((Map) ((Map) properties.get("description")).get("fields")).get("lower_case");
+
+		// then
+		assertThat(fieldName.get("type")).isEqualTo("keyword");
+		assertThat(fieldName.get("normalizer")).isEqualTo("lower_case_normalizer");
+		assertThat(fieldDescriptionLowerCase.get("type")).isEqualTo("keyword");
+		assertThat(fieldDescriptionLowerCase.get("normalizer")).isEqualTo("lower_case_normalizer");
+	}
+
+	@Test // DATAES-503
+	@SuppressWarnings("rawtypes")
+	public void shouldUseCopyTo() {
+
+		// given
+		IndexOperations indexOps = operations.indexOps(CopyToEntity.class);
+		indexOps.create();
+		indexOps.putMapping(CopyToEntity.class);
+
+		// when
+		Map mapping = indexOps.getMapping();
+		Map properties = (Map) mapping.get("properties");
+		Map fieldFirstName = (Map) properties.get("firstName");
+		Map fieldLastName = (Map) properties.get("lastName");
+
+		// then
+		List<String> copyToValue = Collections.singletonList("name");
+		assertThat(fieldFirstName.get("copy_to")).isEqualTo(copyToValue);
+		assertThat(fieldLastName.get("copy_to")).isEqualTo(copyToValue);
+	}
+
+	/**
+	 * @author Xiao Yu
+	 */
+	@Setter
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	@Document(indexName = "ignore-above-index")
+	static class IgnoreAboveEntity {
+
+		@Id private String id;
+
+		@Field(type = FieldType.Keyword, ignoreAbove = 10) private String message;
+	}
+
+	/**
+	 * @author Peter-Josef Meisch
+	 */
+	static class FieldNameEntity {
+
+		@Document(indexName = "fieldname-index")
+		static class IdEntity {
+			@Nullable @Id @Field("id-property") private String id;
+		}
+
+		@Document(indexName = "fieldname-index")
+		static class TextEntity {
+
+			@Nullable @Id @Field("id-property") private String id;
+
+			@Field(name = "text-property", type = FieldType.Text) //
+			@Nullable private String textProperty;
+		}
+
+		@Document(indexName = "fieldname-index")
+		static class MappingEntity {
+
+			@Nullable @Id @Field("id-property") private String id;
+
+			@Field("mapping-property") @Mapping(mappingPath = "/mappings/test-field-analyzed-mappings.json") //
+			@Nullable private byte[] mappingProperty;
+		}
+
+		@Document(indexName = "fieldname-index")
+		static class GeoPointEntity {
+
+			@Nullable @Id @Field("id-property") private String id;
+
+			@Nullable @Field("geopoint-property") private GeoPoint geoPoint;
+		}
+
+		@Document(indexName = "fieldname-index")
+		static class CircularEntity {
+
+			@Nullable @Id @Field("id-property") private String id;
+
+			@Nullable @Field(name = "circular-property", type = FieldType.Object, ignoreFields = { "circular-property" }) //
+			private CircularEntity circularProperty;
+		}
+
+		@Document(indexName = "fieldname-index")
+		static class CompletionEntity {
+
+			@Nullable @Id @Field("id-property") private String id;
+
+			@Nullable @Field("completion-property") @CompletionField(maxInputLength = 100) //
+			private Completion suggest;
+		}
+
+		@Document(indexName = "fieldname-index")
+		static class MultiFieldEntity {
+
+			@Nullable @Id @Field("id-property") private String id;
+
+			@Nullable //
+			@MultiField(mainField = @Field(name = "main-field", type = FieldType.Text, analyzer = "whitespace"),
+					otherFields = {
+							@InnerField(suffix = "suff-ix", type = FieldType.Text, analyzer = "stop", searchAnalyzer = "standard") }) //
+			private String description;
+		}
+	}
+
+	/**
+	 * @author Rizwan Idrees
+	 * @author Mohsin Husen
+	 * @author Nordine Bittich
+	 */
+	@Setter
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	@Document(indexName = "test-index-book-mapping-builder", replicas = 0, refreshInterval = "-1")
+	static class Book {
+
+		@Id private String id;
+		private String name;
+		@Field(type = FieldType.Object) private Author author;
+		@Field(type = FieldType.Nested) private Map<Integer, Collection<String>> buckets = new HashMap<>();
+		@MultiField(mainField = @Field(type = FieldType.Text, analyzer = "whitespace"),
+				otherFields = { @InnerField(suffix = "prefix", type = FieldType.Text, analyzer = "stop",
+						searchAnalyzer = "standard") }) private String description;
+	}
+
+	/**
+	 * @author Stuart Stevenson
+	 * @author Mohsin Husen
+	 */
+	@Data
+	@Document(indexName = "test-index-simple-recursive-mapping-builder", replicas = 0, refreshInterval = "-1")
+	static class SimpleRecursiveEntity {
+
+		@Nullable @Id private String id;
+		@Nullable @Field(type = FieldType.Object,
+				ignoreFields = { "circularObject" }) private SimpleRecursiveEntity circularObject;
+	}
+
+	/**
+	 * @author Sascha Woo
+	 */
+	@Setter
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	@Document(indexName = "test-copy-to-mapping-builder", replicas = 0, refreshInterval = "-1")
+	static class CopyToEntity {
+
+		@Id private String id;
+
+		@Field(type = FieldType.Keyword, copyTo = "name") private String firstName;
+
+		@Field(type = FieldType.Keyword, copyTo = "name") private String lastName;
+
+		@Field(type = FieldType.Keyword) private String name;
+	}
+
+	/**
+	 * @author Sascha Woo
+	 */
+	@Setter
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	@Document(indexName = "test-index-normalizer-mapping-builder", replicas = 0, refreshInterval = "-1")
+	@Setting(settingPath = "/settings/test-normalizer.json")
+	static class NormalizerEntity {
+
+		@Id private String id;
+
+		@Field(type = FieldType.Keyword, normalizer = "lower_case_normalizer") private String name;
+
+		@MultiField(mainField = @Field(type = FieldType.Text), otherFields = { @InnerField(suffix = "lower_case",
+				type = FieldType.Keyword, normalizer = "lower_case_normalizer") }) private String description;
+	}
+
+	/**
+	 * @author Rizwan Idrees
+	 * @author Mohsin Husen
+	 */
+	static class Author {
+
+		@Nullable private String id;
+		@Nullable private String name;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		@Nullable
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+	/**
+	 * @author Kevin Leturc
+	 */
+	@Document(indexName = "test-index-sample-inherited-mapping-builder", replicas = 0, refreshInterval = "-1")
+	static class SampleInheritedEntity extends AbstractInheritedEntity {
+
+		@Nullable @Field(type = Text, index = false, store = true, analyzer = "standard") private String message;
+
+		@Nullable
+		public String getMessage() {
+			return message;
+		}
+
+		public void setMessage(String message) {
+			this.message = message;
+		}
+	}
+
+	/**
+	 * @author Kevin Leturc
+	 */
+	static class SampleInheritedEntityBuilder {
+
+		private final SampleInheritedEntity result;
+
+		public SampleInheritedEntityBuilder(String id) {
+			result = new SampleInheritedEntity();
+			result.setId(id);
+		}
+
+		public SampleInheritedEntityBuilder createdDate(Date createdDate) {
+			result.setCreatedDate(createdDate);
+			return this;
+		}
+
+		public SampleInheritedEntityBuilder message(String message) {
+			result.setMessage(message);
+			return this;
+		}
+
+		public SampleInheritedEntity build() {
+			return result;
+		}
+
+		public IndexQuery buildIndex() {
+			IndexQuery indexQuery = new IndexQuery();
+			indexQuery.setId(Objects.requireNonNull(result.getId()));
+			indexQuery.setObject(result);
+			return indexQuery;
+		}
+	}
+
+	/**
+	 * @author Artur Konczak
+	 * @author Mohsin Husen
+	 */
+	@Setter
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	@Document(indexName = "test-index-stock-mapping-builder", replicas = 0, refreshInterval = "-1")
+	static class StockPrice {
+
+		@Id private String id;
+
+		private String symbol;
+
+		@Field(type = FieldType.Double) private BigDecimal price;
+	}
+
+	/**
+	 * @author Kevin Letur
+	 */
+	static class AbstractInheritedEntity {
+
+		@Nullable @Id private String id;
+
+		@Nullable @Field(type = FieldType.Date, format = DateFormat.date_time, index = false) private Date createdDate;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		@Nullable
+		public Date getCreatedDate() {
+			return createdDate;
+		}
+
+		public void setCreatedDate(Date createdDate) {
+			this.createdDate = createdDate;
+		}
+	}
+
+	@Setter
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	@Document(indexName = "test-index-geo-mapping-builder", replicas = 0, refreshInterval = "-1")
+	static class GeoEntity {
+
+		@Id private String id;
+
+		// geo shape - Spring Data
+		private Box box;
+		private Circle circle;
+		private Polygon polygon;
+
+		// geo point - Custom implementation + Spring Data
+		@GeoPointField private Point pointA;
+		private GeoPoint pointB;
+		@GeoPointField private String pointC;
+		@GeoPointField private double[] pointD;
+
+		// geo shape, until e have the classes for this, us a strng
+		@GeoShapeField private String shape1;
+		@GeoShapeField(coerce = true, ignoreMalformed = true, ignoreZValue = false,
+				orientation = GeoShapeField.Orientation.clockwise) private String shape2;
+	}
+
+	/**
+	 * Created by akonczak on 21/08/2016.
+	 */
+	@Document(indexName = "test-index-user-mapping-builder")
+	static class User {
+		@Nullable @Id private String id;
+
+		@Field(type = FieldType.Nested, ignoreFields = { "users" }) private Set<Group> groups = new HashSet<>();
+	}
+
+	/**
+	 * Created by akonczak on 21/08/2016.
+	 */
+	@Document(indexName = "test-index-group-mapping-builder")
+	static class Group {
+
+		@Nullable @Id String id;
+
+		@Field(type = FieldType.Nested, ignoreFields = { "groups" }) private Set<User> users = new HashSet<>();
+	}
+
+	static class ValueObject {
+		private String value;
+
+		public ValueObject(String value) {
+			this.value = value;
+		}
+
+		public String getValue() {
+			return value;
+		}
+	}
+
+	@Getter
+	@Setter
+	@Document(indexName = "completion")
+	static class CompletionDocument {
+		@Id private String id;
+
+		@CompletionField(contexts = { @CompletionContext(name = "location", type = ContextMapping.Type.GEO,
+				path = "proppath") }) private Completion suggest;
+	}
+
+	@Data
+	@Document(indexName = "test-index-entity-with-seq-no-primary-term-mapping-builder")
+	static class EntityWithSeqNoPrimaryTerm {
+
+		@Field(type = Object) private SeqNoPrimaryTerm seqNoPrimaryTerm;
+	}
+
+	@Data
+	static class RankFeatureEntity {
+		@Id private String id;
+
+		@Field(type = FieldType.Rank_Feature) private Integer pageRank;
+
+		@Field(type = FieldType.Rank_Feature, positiveScoreImpact = false) private Integer urlLength;
+
+		@Field(type = FieldType.Rank_Features) private Map<String, Integer> topics;
+	}
+}

--- a/src/test/java/org/springframework/data/elasticsearch/junit/jupiter/ElasticsearchRestTemplateConfiguration.java
+++ b/src/test/java/org/springframework/data/elasticsearch/junit/jupiter/ElasticsearchRestTemplateConfiguration.java
@@ -55,8 +55,8 @@ public class ElasticsearchRestTemplateConfiguration extends AbstractElasticsearc
 		}
 
 		return RestClients.create(configurationBuilder //
-				.withConnectTimeout(Duration.ofSeconds(5)) //
-				.withSocketTimeout(Duration.ofSeconds(3)) //
+				.withConnectTimeout(Duration.ofSeconds(20)) //
+				.withSocketTimeout(Duration.ofSeconds(20)) //
 				.build()) //
 				.rest();
 	}

--- a/src/test/java/org/springframework/data/elasticsearch/junit/jupiter/ReactiveElasticsearchRestTemplateConfiguration.java
+++ b/src/test/java/org/springframework/data/elasticsearch/junit/jupiter/ReactiveElasticsearchRestTemplateConfiguration.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.elasticsearch.junit.jupiter;
 
+import java.time.Duration;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
@@ -45,7 +47,9 @@ public class ReactiveElasticsearchRestTemplateConfiguration extends AbstractReac
 					.usingSsl();
 		}
 
-		return ReactiveRestClients.create(configurationBuilder.build());
-
+		return ReactiveRestClients.create(configurationBuilder //
+				.withConnectTimeout(Duration.ofSeconds(20)) //
+				.withSocketTimeout(Duration.ofSeconds(20)) //
+				.build());
 	}
 }

--- a/src/test/java/org/springframework/data/elasticsearch/junit/jupiter/SpringIntegrationTest.java
+++ b/src/test/java/org/springframework/data/elasticsearch/junit/jupiter/SpringIntegrationTest.java
@@ -20,6 +20,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -32,5 +33,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @Target(ElementType.TYPE)
 @ExtendWith(SpringDataElasticsearchExtension.class)
 @ExtendWith(SpringExtension.class)
+@Tag(Tags.INTEGRATION_TEST)
 public @interface SpringIntegrationTest {
 }

--- a/src/test/java/org/springframework/data/elasticsearch/junit/jupiter/Tags.java
+++ b/src/test/java/org/springframework/data/elasticsearch/junit/jupiter/Tags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,22 +15,9 @@
  */
 package org.springframework.data.elasticsearch.junit.jupiter;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.extension.ExtendWith;
-
 /**
- * Wraps the {@link SpringDataElasticsearchExtension}.
- *
  * @author Peter-Josef Meisch
  */
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
-@ExtendWith(SpringDataElasticsearchExtension.class)
-@Tag(Tags.INTEGRATION_TEST)
-public @interface IntegrationTest {
+public interface Tags {
+	String INTEGRATION_TEST = "integration-test";
 }

--- a/src/test/java/org/springframework/data/elasticsearch/repositories/cdi/CdiRepositoryTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repositories/cdi/CdiRepositoryTests.java
@@ -35,14 +35,13 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 import org.springframework.data.elasticsearch.annotations.InnerField;
 import org.springframework.data.elasticsearch.annotations.MultiField;
-import org.springframework.data.elasticsearch.junit.jupiter.SpringDataElasticsearchExtension;
+import org.springframework.data.elasticsearch.junit.jupiter.IntegrationTest;
 import org.springframework.lang.Nullable;
 
 /**
@@ -51,7 +50,7 @@ import org.springframework.lang.Nullable;
  * @author Christoph Strobl
  * @author Peter-Josef Meisch
  */
-@ExtendWith(SpringDataElasticsearchExtension.class)
+@IntegrationTest
 public class CdiRepositoryTests {
 
 	@Nullable private static CdiTestContainer cdiContainer;


### PR DESCRIPTION
integration tests are run by the surefire plugin as failsafe had problems with the classpath. As we are setting up the Testcontainer - and tearing it down at the end of all tests, failsafe does not offer anything we'd need in comparison to surefire.