### PR TITLE
DATAES-921 - Favour RequestHeadersSpec.exchangeToMono over deprecated RequestHeadersSpec.exchange.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-elasticsearch</artifactId>
-	<version>4.1.0-SNAPSHOT</version>
+	<version>4.1.0-DATAES-921-SNAPSHOT</version>
 
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
@@ -117,6 +117,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-webflux</artifactId>
+			<version>5.3.0-SNAPSHOT</version>
 			<optional>true</optional>
 		</dependency>
 

--- a/src/main/java/org/springframework/data/elasticsearch/client/reactive/ReactiveElasticsearchClient.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/reactive/ReactiveElasticsearchClient.java
@@ -616,7 +616,7 @@ public interface ReactiveElasticsearchClient {
 	 * @return the {@link Mono} emitting the {@link ClientResponse} once subscribed.
 	 */
 	@SuppressWarnings("JavaDoc")
-	Mono<ClientResponse> execute(ReactiveElasticsearchClientCallback callback);
+	<T> Mono<T> execute(ReactiveElasticsearchClientCallback<T> callback);
 
 	/**
 	 * Get the current client {@link Status}. <br />
@@ -633,8 +633,8 @@ public interface ReactiveElasticsearchClient {
 	 * @author Christoph Strobl
 	 * @since 3.2
 	 */
-	interface ReactiveElasticsearchClientCallback {
-		Mono<ClientResponse> doWithClient(WebClient client);
+	interface ReactiveElasticsearchClientCallback<T> {
+		Mono<T> doWithClient(WebClient client);
 	}
 
 	/**

--- a/src/test/java/org/springframework/data/elasticsearch/client/reactive/DefaultReactiveElasticsearchClientTest.java
+++ b/src/test/java/org/springframework/data/elasticsearch/client/reactive/DefaultReactiveElasticsearchClientTest.java
@@ -19,8 +19,8 @@ import static org.assertj.core.api.Assertions.*;
 import static org.elasticsearch.search.internal.SearchContext.*;
 import static org.mockito.Mockito.*;
 
-import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import java.util.function.Function;
 
@@ -28,14 +28,14 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.web.reactive.function.client.ClientResponse;
-import reactor.test.StepVerifier;
+import org.springframework.web.reactive.function.client.WebClient.ResponseSpec;
 
 /**
  * @author Peter-Josef Meisch
@@ -58,7 +58,7 @@ class DefaultReactiveElasticsearchClientTest {
 			}
 		}) {
 			@Override
-			public Mono<ClientResponse> execute(ReactiveElasticsearchClientCallback callback) {
+			public Mono<ResponseSpec> execute(ReactiveElasticsearchClientCallback callback) {
 				return Mono.empty();
 			}
 		};


### PR DESCRIPTION
`RequestHeadersSpec.exchange()` got deprecated in 5.3 and seeks replacement with either `.retrieve()` or `.exchangeTo*(...)`.

This PR switches to `exchangeToMono` which requires minimal changes in both the current execution flow as well as public API changes. 

Using `.retrieve()` would offer better response body consumption options but requires more extensive changes esp. around ES responses that contain 404 error codes and have a response body with additional information (eg. the response to a `GetRequest`)

--- 

Depends on: [Spring 5.3 RC2](https://github.com/spring-projects/spring-framework/milestone/250)