### PR TITLE
DATAES-588 - Add HttpClientConfigCallback for non-reactive setup.

### DIFF
--- a/src/main/asciidoc/reference/elasticsearch-clients.adoc
+++ b/src/main/asciidoc/reference/elasticsearch-clients.adoc
@@ -150,36 +150,46 @@ Client behaviour can be changed via the `ClientConfiguration` that allows to set
 [source,java]
 ----
 HttpHeaders httpHeaders = new HttpHeaders();
-httpHeaders.add("some-header", "on every request")                      <1>
+httpHeaders.add("some-header", "on every request")                      <.>
 
 ClientConfiguration clientConfiguration = ClientConfiguration.builder()
-  .connectedTo("localhost:9200", "localhost:9291")                      <2>
-  .useSsl()                                                             <3>
-  .withProxy("localhost:8888")                                          <4>
-  .withPathPrefix("ela")                                                <5>
-  .withConnectTimeout(Duration.ofSeconds(5))                            <6>
-  .withSocketTimeout(Duration.ofSeconds(3))                             <7>
-  .withDefaultHeaders(defaultHeaders)                                   <8>
-  .withBasicAuth(username, password)                                    <9>
-  .withHeaders(() -> {                                                  <10>
+  .connectedTo("localhost:9200", "localhost:9291")                      <.>
+  .useSsl()                                                             <.>
+  .withProxy("localhost:8888")                                          <.>
+  .withPathPrefix("ela")                                                <.>
+  .withConnectTimeout(Duration.ofSeconds(5))                            <.>
+  .withSocketTimeout(Duration.ofSeconds(3))                             <.>
+  .withDefaultHeaders(defaultHeaders)                                   <.>
+  .withBasicAuth(username, password)                                    <.>
+  .withHeaders(() -> {                                                  <.>
     HttpHeaders headers = new HttpHeaders();
     headers.add("currentTime", LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
     return headers;
+  })
+  .withWebClientConfigurer(webClient -> {                               <.>
+    //...
+    return webClient;
+  })
+  .withHttpClientConfigurer(clientBuilder -> {                          <.>
+      //...
+      return clientBuilder;
   })
   . // ... other options
   .build();
 
 ----
-<1> Define default headers, if they need to be customized
-<2> Use the builder to provide cluster addresses, set default `HttpHeaders` or enable SSL.
-<3> Optionally enable SSL.
-<4> Optionally set a proxy.
-<5> Optionally set a path prefix, mostly used when different clusters a behind some reverse proxy.
-<6> Set the connection timeout. Default is 10 sec.
-<7> Set the socket timeout. Default is 5 sec.
-<8> Optionally set headers.
-<9> Add basic authentication.
-<10> A `Supplier<Header>` function can be specified which is called every time before a request is sent to Elasticsearch - here, as an example, the current time is written in a header.
+<.> Define default headers, if they need to be customized
+<.> Use the builder to provide cluster addresses, set default `HttpHeaders` or enable SSL.
+<.> Optionally enable SSL.
+<.> Optionally set a proxy.
+<.> Optionally set a path prefix, mostly used when different clusters a behind some reverse proxy.
+<.> Set the connection timeout. Default is 10 sec.
+<.> Set the socket timeout. Default is 5 sec.
+<.> Optionally set headers.
+<.> Add basic authentication.
+<.> A `Supplier<Header>` function can be specified which is called every time before a request is sent to Elasticsearch - here, as an example, the current time is written in a header.
+<.> for reactive setup a function configuring the `WebClient`
+<.> for non-reactive setup a function configuring the REST client
 ====
 
 IMPORTANT: Adding a Header supplier as shown in above example allows to inject headers that may change over the time, like authentication JWT tokens. If this is used in the reactive setup, the supplier function *must not* block!

--- a/src/main/java/org/springframework/data/elasticsearch/client/ClientConfiguration.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/ClientConfiguration.java
@@ -26,6 +26,7 @@ import java.util.function.Supplier;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 
+import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback;
 import org.springframework.http.HttpHeaders;
 import org.springframework.lang.Nullable;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -170,6 +171,12 @@ public interface ClientConfiguration {
 	 * @return the function for configuring a WebClient.
 	 */
 	Function<WebClient, WebClient> getWebClientConfigurer();
+
+	/**
+	 * @return the client configuration callback.
+	 * @since 4.2
+	 */
+	HttpClientConfigCallback getHttpClientConfigurer();
 
 	/**
 	 * @return the supplier for custom headers.
@@ -342,12 +349,21 @@ public interface ClientConfiguration {
 		TerminalClientConfigurationBuilder withWebClientConfigurer(Function<WebClient, WebClient> webClientConfigurer);
 
 		/**
+		 * Register a {HttpClientConfigCallback} to configure the non-reactive REST client.
+		 * 
+		 * @param httpClientConfigurer configuration callback, must not be null.
+		 * @return the {@link TerminalClientConfigurationBuilder}.
+		 * @since 4.2
+		 */
+		TerminalClientConfigurationBuilder withHttpClientConfigurer(HttpClientConfigCallback httpClientConfigurer);
+
+		/**
 		 * set a supplier for custom headers. This is invoked for every HTTP request to Elasticsearch to retrieve headers
 		 * that should be sent with the request. A common use case is passing in authentication headers that may change.
 		 * <br/>
 		 * Note: When used in a reactive environment, the calling of {@link Supplier#get()} function must not do any
 		 * blocking operations. It may return {@literal null}.
-		 * 
+		 *
 		 * @param headers supplier function for headers, must not be {@literal null}
 		 * @return the {@link TerminalClientConfigurationBuilder}.
 		 * @since 4.0

--- a/src/main/java/org/springframework/data/elasticsearch/client/ClientConfigurationBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/ClientConfigurationBuilder.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 
+import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback;
 import org.springframework.data.elasticsearch.client.ClientConfiguration.ClientConfigurationBuilderWithRequiredEndpoint;
 import org.springframework.data.elasticsearch.client.ClientConfiguration.MaybeSecureClientConfigurationBuilder;
 import org.springframework.data.elasticsearch.client.ClientConfiguration.TerminalClientConfigurationBuilder;
@@ -61,6 +62,7 @@ class ClientConfigurationBuilder
 	private @Nullable String proxy;
 	private Function<WebClient, WebClient> webClientConfigurer = Function.identity();
 	private Supplier<HttpHeaders> headersSupplier = () -> HttpHeaders.EMPTY;
+	private HttpClientConfigCallback httpClientConfigurer = httpClientBuilder -> httpClientBuilder;
 
 	/*
 	 * (non-Javadoc)
@@ -208,6 +210,15 @@ class ClientConfigurationBuilder
 	}
 
 	@Override
+	public TerminalClientConfigurationBuilder withHttpClientConfigurer(HttpClientConfigCallback httpClientConfigurer) {
+
+		Assert.notNull(httpClientConfigurer, "httpClientConfigurer must not be null");
+
+		this.httpClientConfigurer = httpClientConfigurer;
+		return this;
+	}
+
+	@Override
 	public TerminalClientConfigurationBuilder withHeaders(Supplier<HttpHeaders> headers) {
 
 		Assert.notNull(headers, "headersSupplier must not be null");
@@ -231,7 +242,7 @@ class ClientConfigurationBuilder
 		}
 
 		return new DefaultClientConfiguration(hosts, headers, useSsl, sslContext, soTimeout, connectTimeout, pathPrefix,
-				hostnameVerifier, proxy, webClientConfigurer, headersSupplier);
+				hostnameVerifier, proxy, webClientConfigurer, httpClientConfigurer, headersSupplier);
 	}
 
 	private static InetSocketAddress parse(String hostAndPort) {

--- a/src/main/java/org/springframework/data/elasticsearch/client/DefaultClientConfiguration.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/DefaultClientConfiguration.java
@@ -27,6 +27,7 @@ import java.util.function.Supplier;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 
+import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback;
 import org.springframework.http.HttpHeaders;
 import org.springframework.lang.Nullable;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -52,12 +53,14 @@ class DefaultClientConfiguration implements ClientConfiguration {
 	private final @Nullable HostnameVerifier hostnameVerifier;
 	private final @Nullable String proxy;
 	private final Function<WebClient, WebClient> webClientConfigurer;
+	private final HttpClientConfigCallback httpClientConfigurer;
 	private final Supplier<HttpHeaders> headersSupplier;
 
 	DefaultClientConfiguration(List<InetSocketAddress> hosts, HttpHeaders headers, boolean useSsl,
 			@Nullable SSLContext sslContext, Duration soTimeout, Duration connectTimeout, @Nullable String pathPrefix,
 			@Nullable HostnameVerifier hostnameVerifier, @Nullable String proxy,
-			Function<WebClient, WebClient> webClientConfigurer, Supplier<HttpHeaders> headersSupplier) {
+			Function<WebClient, WebClient> webClientConfigurer, HttpClientConfigCallback httpClientConfigurer,
+			Supplier<HttpHeaders> headersSupplier) {
 
 		this.hosts = Collections.unmodifiableList(new ArrayList<>(hosts));
 		this.headers = new HttpHeaders(headers);
@@ -69,6 +72,7 @@ class DefaultClientConfiguration implements ClientConfiguration {
 		this.hostnameVerifier = hostnameVerifier;
 		this.proxy = proxy;
 		this.webClientConfigurer = webClientConfigurer;
+		this.httpClientConfigurer = httpClientConfigurer;
 		this.headersSupplier = headersSupplier;
 	}
 
@@ -121,6 +125,11 @@ class DefaultClientConfiguration implements ClientConfiguration {
 	@Override
 	public Function<WebClient, WebClient> getWebClientConfigurer() {
 		return webClientConfigurer;
+	}
+
+	@Override
+	public HttpClientConfigCallback getHttpClientConfigurer() {
+		return httpClientConfigurer;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/elasticsearch/client/RestClients.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/RestClients.java
@@ -119,6 +119,8 @@ public final class RestClients {
 
 			clientConfiguration.getProxy().map(HttpHost::create).ifPresent(clientBuilder::setProxy);
 
+			clientBuilder = clientConfiguration.getHttpClientConfigurer().customizeHttpClient(clientBuilder);
+
 			return clientBuilder;
 		});
 

--- a/src/test/java/org/springframework/data/elasticsearch/client/ClientConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/client/ClientConfigurationUnitTests.java
@@ -25,6 +25,8 @@ import java.util.function.Function;
 import javax.net.ssl.SSLContext;
 
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.elasticsearch.client.RestClientBuilder;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -163,6 +165,20 @@ public class ClientConfigurationUnitTests {
 				.build();
 
 		assertThat(clientConfiguration.getWebClientConfigurer()).isEqualTo(webClientConfigurer);
+	}
+
+	@Test // DATAES-588
+	@DisplayName("should use configured httpClientConfigurer")
+	void shouldUseConfiguredHttpClientConfigurer() {
+
+		RestClientBuilder.HttpClientConfigCallback callback = httpClientBuilder -> httpClientBuilder;
+
+		ClientConfiguration clientConfiguration = ClientConfiguration.builder() //
+				.connectedTo("foo", "bar") //
+				.withHttpClientConfigurer(callback) //
+				.build();
+
+		assertThat(clientConfiguration.getHttpClientConfigurer()).isEqualTo(callback);
 	}
 
 	private static String buildBasicAuth(String username, String password) {


### PR DESCRIPTION
`ClientConfiguration` now accepts a callback for a `HttpClientConfigCallback` to allow configuration of the HttpClient (non-reactive REST setup)

```
ClientConfiguration clientConfiguration = ClientConfiguration.builder() //
    .connectedTo("localhost:9200") //
    .withHttpClientConfigurer(clientBuilder -> {
        //...
        return clientBuilder;
    })
    .build();
```