### PR TITLE
Reactive initial ping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,12 @@
 			</exclusions>
 		</dependency>
 
+		<dependency>
+			<groupId>io.specto</groupId>
+			<artifactId>hoverfly-java-junit5</artifactId>
+			<version>0.13.1</version>
+		</dependency>
+
 		<!-- Upgrade xbean to 4.5 to prevent incompatibilities due to ASM versions -->
 		<dependency>
 			<groupId>org.apache.xbean</groupId>

--- a/src/main/java/org/springframework/data/elasticsearch/client/reactive/DefaultWebClientProvider.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/reactive/DefaultWebClientProvider.java
@@ -45,7 +45,7 @@ class DefaultWebClientProvider implements WebClientProvider {
 	private final @Nullable ClientHttpConnector connector;
 	private final Consumer<Throwable> errorListener;
 	private final HttpHeaders headers;
-	private final String pathPrefix;
+	private final @Nullable String pathPrefix;
 	private final Function<WebClient, WebClient> webClientConfigurer;
 
 	/**
@@ -61,11 +61,11 @@ class DefaultWebClientProvider implements WebClientProvider {
 	/**
 	 * Create new {@link DefaultWebClientProvider} with empty {@link HttpHeaders} and no-op {@literal error listener}.
 	 *
-	 * @param pathPrefix can be {@literal null}
 	 * @param scheme must not be {@literal null}.
 	 * @param connector can be {@literal null}.
 	 * @param errorListener must not be {@literal null}.
 	 * @param headers must not be {@literal null}.
+	 * @param pathPrefix can be {@literal null}
 	 * @param webClientConfigurer must not be {@literal null}.
 	 */
 	private DefaultWebClientProvider(String scheme, @Nullable ClientHttpConnector connector,
@@ -145,7 +145,6 @@ class DefaultWebClientProvider implements WebClientProvider {
 
 	}
 
-
 	protected WebClient createWebClientForSocketAddress(InetSocketAddress socketAddress) {
 
 		Builder builder = WebClient.builder().defaultHeaders(it -> it.addAll(getDefaultHeaders()));
@@ -156,7 +155,11 @@ class DefaultWebClientProvider implements WebClientProvider {
 
 		String baseUrl = String.format("%s://%s:%d%s", this.scheme, socketAddress.getHostString(), socketAddress.getPort(),
 				pathPrefix == null ? "" : '/' + pathPrefix);
-		WebClient webClient = builder.baseUrl(baseUrl).filter((request, next) -> next.exchange(request).doOnError(errorListener)).build();
+		WebClient webClient = builder //
+				.baseUrl(baseUrl) //
+				.filter((request, next) -> next.exchange(request) //
+						.doOnError(errorListener)) //
+				.build(); //
 		return webClientConfigurer.apply(webClient);
 	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/client/reactive/SingleNodeHostProvider.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/reactive/SingleNodeHostProvider.java
@@ -41,7 +41,8 @@ class SingleNodeHostProvider implements HostProvider {
 	private final InetSocketAddress endpoint;
 	private volatile ElasticsearchHost state;
 
-	SingleNodeHostProvider(WebClientProvider clientProvider, Supplier<HttpHeaders> headersSupplier, InetSocketAddress endpoint) {
+	SingleNodeHostProvider(WebClientProvider clientProvider, Supplier<HttpHeaders> headersSupplier,
+			InetSocketAddress endpoint) {
 
 		this.clientProvider = clientProvider;
 		this.headersSupplier = headersSupplier;
@@ -57,7 +58,7 @@ class SingleNodeHostProvider implements HostProvider {
 	public Mono<ClusterInformation> clusterInfo() {
 
 		return createWebClient(endpoint) //
-				.head().uri("/")
+				.head().uri("/") //
 				.headers(httpHeaders -> httpHeaders.addAll(headersSupplier.get())) //
 				.exchange() //
 				.flatMap(it -> {
@@ -68,7 +69,6 @@ class SingleNodeHostProvider implements HostProvider {
 					}
 					return it.releaseBody().thenReturn(state);
 				}).onErrorResume(throwable -> {
-
 					state = ElasticsearchHost.offline(endpoint);
 					clientProvider.getErrorListener().accept(throwable);
 					return Mono.just(state);


### PR DESCRIPTION
Using hoverfly as a proxy to test the use of a proxy in the reactive client. wiremock canot be used, as it cannot handle HTTP CONNECT requests that WebClient uses for proxied requests.