### PR TITLE
DATAES-988 Allow specifying max results in NativeSearchQueryBuilder

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/query/NativeSearchQueryBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/NativeSearchQueryBuilder.java
@@ -66,6 +66,7 @@ public class NativeSearchQueryBuilder {
 	@Nullable private SearchType searchType;
 	@Nullable private IndicesOptions indicesOptions;
 	@Nullable private String preference;
+	@Nullable private Integer maxResults;
 
 	public NativeSearchQueryBuilder withQuery(QueryBuilder queryBuilder) {
 		this.queryBuilder = queryBuilder;
@@ -167,6 +168,11 @@ public class NativeSearchQueryBuilder {
 		return this;
 	}
 
+	public NativeSearchQueryBuilder withMaxResults(Integer maxResults) {
+		this.maxResults = maxResults;
+		return this;
+	}
+
 	public NativeSearchQuery build() {
 
 		NativeSearchQuery nativeSearchQuery = new NativeSearchQuery(queryBuilder, filterBuilder, sortBuilders,
@@ -218,8 +224,13 @@ public class NativeSearchQueryBuilder {
 		if (indicesOptions != null) {
 			nativeSearchQuery.setIndicesOptions(indicesOptions);
 		}
+
 		if (preference != null) {
 			nativeSearchQuery.setPreference(preference);
+		}
+
+		if (maxResults != null) {
+			nativeSearchQuery.setMaxResults(maxResults);
 		}
 
 		return nativeSearchQuery;

--- a/src/test/java/org/springframework/data/elasticsearch/core/aggregation/ElasticsearchTemplateAggregationTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/aggregation/ElasticsearchTemplateAggregationTests.java
@@ -118,6 +118,7 @@ public class ElasticsearchTemplateAggregationTests {
 				.withQuery(matchAllQuery()) //
 				.withSearchType(SearchType.DEFAULT) //
 				.addAggregation(terms("subjects").field("subject")) //
+				.withMaxResults(0) //
 				.build();
 		// when
 		SearchHits<ArticleEntity> searchHits = operations.search(searchQuery, ArticleEntity.class,
@@ -127,6 +128,7 @@ public class ElasticsearchTemplateAggregationTests {
 		// then
 		assertThat(aggregations).isNotNull();
 		assertThat(aggregations.asMap().get("subjects")).isNotNull();
+		assertThat(searchHits.hasSearchHits()).isFalse();
 	}
 
 	/**


### PR DESCRIPTION
Add a withMaxResults method to NativeSearchQueryBuilder for specifying the maxResults
on the built Query. This is common for aggregation queries where search hits are not
needed.

Having the builder method for setting maxResults is a minor ergonomic improvement, e.g.

NativeSearchQuery searchQuery = NativeSearchQueryBuilder()
        .withQuery(matchAllQuery())
        .addAggregation(terms("examples").field("example"))
        .withMaxResults(0)
        .build();

versus what was required before:

NativeSearchQuery searchQuery = NativeSearchQueryBuilder()
        .withQuery(matchAllQuery())
        .addAggregation(terms("examples").field("example"))
        .build();
searchQuery.setMaxResults(0);
