### PR TITLE
#1218 - Add routing parameter to ElasticsearchOperations.

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -33,6 +33,8 @@ include::reference/elasticsearch-auditing.adoc[]
 include::{spring-data-commons-docs}/entity-callbacks.adoc[]
 include::reference/elasticsearch-entity-callbacks.adoc[leveloffset=+1]
 
+include::reference/elasticsearch-join-types.adoc[]
+include::reference/elasticsearch-routing.adoc[]
 include::reference/elasticsearch-misc.adoc[]
 :leveloffset: -1
 

--- a/src/main/asciidoc/reference/elasticsearch-join-types.adoc
+++ b/src/main/asciidoc/reference/elasticsearch-join-types.adoc
@@ -1,0 +1,229 @@
+[[elasticsearch.jointype]]
+= Join-Type implementation
+
+Spring Data Elasticsearch supports the https://www.elastic.co/guide/en/elasticsearch/reference/current/parent-join.html[Join data type] for creating the corresponding index mappings and for storing the relevant information.
+
+== Setting up the data
+
+For an entity to be used in a parent child join relationship, it must have a property of type `JoinField` which must be annotated.
+Let's assume a `Statement` entity where a statement may be a _question_, an _answer_, a _comment_ or a _vote_ (a _Builder_ is also shown in this example, it's not necessary, but later used in the sample code):
+
+====
+[source,java]
+----
+@Document(indexName = "statements")
+@Routing("routing")                                                                       <.>
+public class Statement {
+    @Id
+    private String id;
+
+    @Field(type = FieldType.Text)
+    private String text;
+
+    @Field(type = FieldType.Keyword)
+    private String routing;
+
+    @JoinTypeRelations(
+        relations =
+            {
+                @JoinTypeRelation(parent = "question", children = {"answer", "comment"}), <.>
+                @JoinTypeRelation(parent = "answer", children = "vote")                   <.>
+            }
+    )
+    private JoinField<String> relation;                                                   <.>
+
+    private Statement() {
+    }
+
+    public static StatementBuilder builder() {
+        return new StatementBuilder();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getRouting() {
+        return routing;
+    }
+
+    public void setRouting(Routing routing) {
+        this.routing = routing;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public JoinField<String> getRelation() {
+        return relation;
+    }
+
+    public void setRelation(JoinField<String> relation) {
+        this.relation = relation;
+    }
+
+    public static final class StatementBuilder {
+        private String id;
+        private String text;
+        private String routing;
+        private JoinField<String> relation;
+
+        private StatementBuilder() {
+        }
+
+        public StatementBuilder withId(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public StatementBuilder withRouting(String routing) {
+            this.routing = routing;
+            return this;
+        }
+
+        public StatementBuilder withText(String text) {
+            this.text = text;
+            return this;
+        }
+
+        public StatementBuilder withRelation(JoinField<String> relation) {
+            this.relation = relation;
+            return this;
+        }
+
+        public Statement build() {
+            Statement statement = new Statement();
+            statement.setId(id);
+            statement.setRouting(routing);
+            statement.setText(text);
+            statement.setRelation(relation);
+            return statement;
+        }
+    }
+}
+----
+<.> for routing related info see <<elasticsearch.routing>>
+<.> a question can have answers and comments
+<.> an answer can have votes
+<.> the `JoinField` property is used to combine the name (_question_, _answer_, _comment_ or _vote_) of the relation with the parent id.
+The generic type must be the same as the `@Id` annotated property.
+====
+
+Spring Data Elasticsearch will build the following mapping for this class:
+
+====
+[source,json]
+----
+{
+  "statements": {
+    "mappings": {
+      "properties": {
+        "_class": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "routing": {
+          "type": "keyword"
+        },
+        "relation": {
+          "type": "join",
+          "eager_global_ordinals": true,
+          "relations": {
+            "question": [
+              "answer",
+              "comment"
+            ],
+            "answer": "vote"
+          }
+        },
+        "text": {
+          "type": "text"
+        }
+      }
+    }
+  }
+}
+----
+====
+
+==  Storing data
+
+Given a repository for this class the following code inserts a question, two answers, a comment and a vote:
+
+====
+[source,java]
+----
+void init() {
+    repository.deleteAll();
+
+    Statement savedWeather = repository.save(
+        Statement.builder()
+            .withText("How is the weather?")
+            .withRelation(new JoinField<>("question"))                          <1>
+            .build());
+
+    Statement sunnyAnswer = repository.save(
+        Statement.builder()
+            .withText("sunny")
+            .withRelation(new JoinField<>("answer", savedWeather.getId()))      <2>
+            .build());
+
+    repository.save(
+        Statement.builder()
+            .withText("rainy")
+            .withRelation(new JoinField<>("answer", savedWeather.getId()))      <3>
+            .build());
+
+    repository.save(
+        Statement.builder()
+            .withText("I don't like the rain")
+            .withRelation(new JoinField<>("comment", savedWeather.getId()))     <4>
+            .build());
+
+    repository.save(
+        Statement.builder()
+            .withText("+1 for the sun")
+            ,withRouting(savedWeather.getId())
+            .withRelation(new JoinField<>("vote", sunnyAnswer.getId()))         <5>
+            .build());
+}
+----
+<1> create a question statement
+<2> the first answer to the question
+<3> the second answer
+<4> a comment to the question
+<5> a vote for the first answer, this needs to have the routing set to the weather document, see <<elasticsearch.routing>>.
+====
+
+==  Retrieving data
+
+Currently native search queries must be used to query the data, so there is no support from standard repository methods. <<repositories.custom-implementations>> can be used instead.
+
+The following code shows as an example how to retrieve all entries that have a _vote_ (which must be _answers_, because only answers can have a vote) using an `ElasticsearchOperations` instance:
+
+====
+[source,java]
+----
+SearchHits<Statement> hasVotes() {
+    NativeSearchQuery query = new NativeSearchQueryBuilder()
+        .withQuery(hasChildQuery("vote", matchAllQuery(), ScoreMode.None))
+        .build();
+
+    return operations.search(query, Statement.class);
+}
+----
+====

--- a/src/main/asciidoc/reference/elasticsearch-misc.adoc
+++ b/src/main/asciidoc/reference/elasticsearch-misc.adoc
@@ -1,7 +1,8 @@
 [[elasticsearch.misc]]
 = Miscellaneous Elasticsearch Operation Support
 
-This chapter covers additional support for Elasticsearch operations that cannot be directly accessed via the repository interface. It is recommended to add those operations as custom implementation as described in <<repositories.custom-implementations>> .
+This chapter covers additional support for Elasticsearch operations that cannot be directly accessed via the repository interface.
+It is recommended to add those operations as custom implementation as described in <<repositories.custom-implementations>> .
 
 [[elasticsearch.misc.filter]]
 == Filter Builder
@@ -27,7 +28,8 @@ Page<SampleEntity> sampleEntities = operations.searchForPage(searchQuery, Sample
 [[elasticsearch.scroll]]
 == Using Scroll For Big Result Set
 
-Elasticsearch has a scroll API for getting big result set in chunks. This is internally used by Spring Data Elasticsearch to provide the implementations of the `<T> SearchHitsIterator<T> SearchOperations.searchForStream(Query query, Class<T> clazz, IndexCoordinates index)` method.
+Elasticsearch has a scroll API for getting big result set in chunks.
+This is internally used by Spring Data Elasticsearch to provide the implementations of the `<T> SearchHitsIterator<T> SearchOperations.searchForStream(Query query, Class<T> clazz, IndexCoordinates index)` method.
 
 [source,java]
 ----
@@ -76,7 +78,8 @@ while (scroll.hasSearchHits()) {
 template.searchScrollClear(scrollId);
 ----
 
-To use the Scroll API with repository methods, the return type must defined as `Stream` in the Elasticsearch Repository. The implementation of the method will then use the scroll methods from the ElasticsearchTemplate.
+To use the Scroll API with repository methods, the return type must defined as `Stream` in the Elasticsearch Repository.
+The implementation of the method will then use the scroll methods from the ElasticsearchTemplate.
 
 [source,java]
 ----
@@ -98,209 +101,3 @@ If the class to be retrieved has a `GeoPoint` property named _location_, the fol
 ----
 Sort.by(new GeoDistanceOrder("location", new GeoPoint(48.137154, 11.5761247)))
 ----
-
-[[elasticsearch.misc.jointype]]
-== Join-Type implementation
-
-Spring Data Elasticsearch supports the https://www.elastic.co/guide/en/elasticsearch/reference/current/parent-join.html[Join data type] for creating the corresponding index mappings and for storing the relevant information.
-
-=== Setting up the data
-
-For an entity to be used in a parent child join relationship, it must have a property of type `JoinField` which must be annotated.
-Let's assume a `Statement` entity where a statement may be a _question_, an _answer_, a _comment_ or a _vote_ (a _Builder_ is also shown in this example, it's not necessary, but later used in the sample code):
-
-====
-[source,java]
-----
-@Document(indexName = "statements")
-public class Statement {
-    @Id
-    private String id;
-
-    @Field(type = FieldType.Text)
-    private String text;
-
-    @JoinTypeRelations(
-        relations =
-            {
-                @JoinTypeRelation(parent = "question", children = {"answer", "comment"}), <1>
-                @JoinTypeRelation(parent = "answer", children = "vote")                   <2>
-            }
-    )
-    private JoinField<String> relation;                                                   <3>
-
-    private Statement() {
-    }
-
-    public static StatementBuilder builder() {
-        return new StatementBuilder();
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public String getText() {
-        return text;
-    }
-
-    public void setText(String text) {
-        this.text = text;
-    }
-
-    public JoinField<String> getRelation() {
-        return relation;
-    }
-
-    public void setRelation(JoinField<String> relation) {
-        this.relation = relation;
-    }
-
-    public static final class StatementBuilder {
-        private String id;
-        private String text;
-        private JoinField<String> relation;
-
-        private StatementBuilder() {
-        }
-
-        public StatementBuilder withId(String id) {
-            this.id = id;
-            return this;
-        }
-
-        public StatementBuilder withText(String text) {
-            this.text = text;
-            return this;
-        }
-
-        public StatementBuilder withRelation(JoinField<String> relation) {
-            this.relation = relation;
-            return this;
-        }
-
-        public Statement build() {
-            Statement statement = new Statement();
-            statement.setId(id);
-            statement.setText(text);
-            statement.setRelation(relation);
-            return statement;
-        }
-    }
-}
-----
-<1> a question can have answers and comments
-<2> an answer can have votes
-<3> the `JoinField` property is used to combine the name (_question_, _answer_, _comment_ or _vote_) of the relation with the parent id. The generic type must be the same as the `@Id` annotated property.
-====
-
-Spring Data Elasticsearch will build the following mapping for this class:
-
-====
-[source,json]
-----
-{
-  "statements": {
-    "mappings": {
-      "properties": {
-        "_class": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256
-            }
-          }
-        },
-        "relation": {
-          "type": "join",
-          "eager_global_ordinals": true,
-          "relations": {
-            "question": [
-              "answer",
-              "comment"
-            ],
-            "answer": "vote"
-          }
-        },
-        "text": {
-          "type": "text"
-        }
-      }
-    }
-  }
-}
-----
-====
-
-=== Storing data
-
-Given a repository for this class the following code inserts a question, two answers, a comment and a vote:
-
-====
-[source,java]
-----
-void init() {
-    repository.deleteAll();
-
-    Statement savedWeather = repository.save(
-        Statement.builder()
-            .withText("How is the weather?")
-            .withRelation(new JoinField<>("question"))                          <1>
-            .build());
-
-    Statement sunnyAnswer = repository.save(
-        Statement.builder()
-            .withText("sunny")
-            .withRelation(new JoinField<>("answer", savedWeather.getId()))      <2>
-            .build());
-
-    repository.save(
-        Statement.builder()
-            .withText("rainy")
-            .withRelation(new JoinField<>("answer", savedWeather.getId()))      <3>
-            .build());
-
-    repository.save(
-        Statement.builder()
-            .withText("I don't like the rain")
-            .withRelation(new JoinField<>("comment", savedWeather.getId()))     <4>
-            .build());
-
-    repository.save(
-        Statement.builder()
-            .withText("+1 for the sun")
-            .withRelation(new JoinField<>("vote", sunnyAnswer.getId()))         <5>
-            .build());
-}
-----
-<1> create a question statement
-<2> the first answer to the question
-<3> the second answer
-<4> a comment to the question
-<5> a vote for the first answer
-====
-
-=== Retrieving data
-
-Currently native search queries must be used to query the data, so there is no support from standard repository methods. <<repositories.custom-implementations>> can be used instead.
-
-The following code shows as an example how to retrieve all entries that have a _vote_ (which must be _answers_, because only answers can have a vote) using an `ElasticsearchOperations` instance:
-
-====
-[source,java]
-----
-SearchHits<Statement> hasVotes() {
-    NativeSearchQuery query = new NativeSearchQueryBuilder()
-        .withQuery(hasChildQuery("vote", matchAllQuery(), ScoreMode.None))
-        .build();
-
-    return operations.search(query, Statement.class);
-}
-----
-====
-

--- a/src/main/asciidoc/reference/elasticsearch-new.adoc
+++ b/src/main/asciidoc/reference/elasticsearch-new.adoc
@@ -5,6 +5,7 @@
 == New in Spring Data Elasticsearch 4.2
 
 * Upgrade to Elasticsearch 7.10.0.
+* Support for custom routing values
 
 [[new-features.4-1-0]]
 == New in Spring Data Elasticsearch 4.1

--- a/src/main/asciidoc/reference/elasticsearch-routing.adoc
+++ b/src/main/asciidoc/reference/elasticsearch-routing.adoc
@@ -1,0 +1,106 @@
+
+[[elasticsearch.routing]]
+= Routing values
+
+When Elasticsearch stores a document in an index that has multiple shards, it determines the shard to you use based on the _id_ of the document.
+Sometimes it is necessary to predefine that multiple documents should be indexed on the same shard (join-types, faster search for related data).
+For this Elasticsearch offers the possibility to define a routing, which is the value that should be used to calculate the shard from instead of the _id_.
+
+Spring Data Elasticsearch supports routing definitions on storing and retrieving data in the following ways:
+
+== Routing on join-types
+
+When using join-types (see <<elasticsearch.jointype>>), Spring Data Elasticsearch will automatically use the `parent` property of the entity's `JoinField` property as the value for the routing.
+
+This is correct for all the use-cases where the parent-child relationship has just one level.
+If it is deeper, like a child-parent-grandparent relationship - like in the above example from _vote_ -> _answer_ -> _question_ - then the routing needs to explicitly specified by using the techniques described in the next section (the _vote_ needs the _question.id_ as routing value).
+
+== Custom routing values
+
+To define a custom routing for an entity, Spring Data Elasticsearch provides a `@Routing` annotation (reusing the `Statement` class from above):
+
+====
+[source,java]
+----
+@Document(indexName = "statements")
+@Routing("routing")                  <.>
+public class Statement {
+    @Id
+    private String id;
+
+    @Field(type = FieldType.Text)
+    private String text;
+
+    @JoinTypeRelations(
+        relations =
+            {
+                @JoinTypeRelation(parent = "question", children = {"answer", "comment"}),
+                @JoinTypeRelation(parent = "answer", children = "vote")
+            }
+    )
+    private JoinField<String> relation;
+
+    @Nullable
+    @Field(type = FieldType.Keyword)
+    private String routing;          <.>
+
+    // getter/setter...
+}
+----
+<.> This defines _"routing"_ as routing specification
+<.> a property with the name _routing_
+====
+
+If the `routing` specification of the annotation is a plain string and not a SpEL expression, it is interpreted as the name of a property of the entity, in the example it's the _routing_ property.
+The value of this property will then be used as the routing value for all requests that use the entity.
+
+It is also possible to us a SpEL expression in the `@Document` annotation like this:
+
+====
+[source,java]
+----
+@Document(indexName = "statements")
+@Routing("@myBean.getRouting(#entity)")
+public class Statement{
+    // all the needed stuff
+}
+----
+====
+
+In this case the user needs to provide a bean with the name _myBean_ that has a method `String getRouting(Object)`. To reference the entity _"#entity"_ must be used in the SpEL expression, and the return value must be `null` or the routing value as a String.
+
+If plain property's names and SpEL expressions are not enough to customize the routing definitions, it is possible to define provide an implementation of the `RoutingResolver` interface. This can then be set on the `ElasticOperations` instance:
+
+====
+[source,java]
+----
+RoutingResolver resolver = ...;
+
+ElasticsearchOperations customOperations= operations.withRouting(resolver);
+
+----
+====
+
+The `withRouting()` functions return a copy of the original `ElasticsearchOperations` instance with the customized routing set.
+
+
+When a routing has been defined on an entity when it is stored in Elasticsearch, the same value must be provided when doing a _get_ or _delete_ operation. For methods that do not use an entity - like `get(ID)` or `delete(ID)` - the `ElasticsearchOperations.withRouting(RoutingResolver)` method can be used like this:
+
+====
+[source,java]
+----
+String id = "someId";
+String routing = "theRoutingValue";
+
+// get an entity
+Statement s = operations
+                .withRouting(RoutingResolver.just(routing))       <.>
+                .get(id, Statement.class);
+
+// delete an entity
+operations.withRouting(RoutingResolver.just(routing)).delete(id);
+
+----
+<.> `RoutingResolver.just(s)` returns a resolver that will just return the given String.
+====
+

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/Routing.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/Routing.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.data.annotation.Persistent;
+
+/**
+ * Annotation to enable custom routing values for an entity.
+ * 
+ * @author Peter-Josef Meisch
+ * @since 4.2
+ */
+@Persistent
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE })
+public @interface Routing {
+
+	/**
+	 * defines how the routing is determined. Can be either the name of a property or a SpEL expression. See the reference
+	 * documentation for examples how to use this annotation.
+	 */
+	String value();
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/DocumentOperations.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/DocumentOperations.java
@@ -25,6 +25,7 @@ import org.springframework.data.elasticsearch.core.query.IndexQuery;
 import org.springframework.data.elasticsearch.core.query.Query;
 import org.springframework.data.elasticsearch.core.query.UpdateQuery;
 import org.springframework.data.elasticsearch.core.query.UpdateResponse;
+import org.springframework.data.elasticsearch.core.routing.RoutingResolver;
 import org.springframework.lang.Nullable;
 
 /**
@@ -227,9 +228,7 @@ public interface DocumentOperations {
 	 * @param index the index from which to delete
 	 * @return documentId of the document deleted
 	 */
-	default String delete(String id, IndexCoordinates index) {
-		return delete(id, null, index);
-	}
+	String delete(String id, IndexCoordinates index);
 
 	/**
 	 * Delete the one object with provided id.
@@ -239,7 +238,10 @@ public interface DocumentOperations {
 	 * @param index the index from which to delete
 	 * @return documentId of the document deleted
 	 * @since 4.1
+	 * @deprecated since 4.2, use {@link ElasticsearchOperations#withRouting(RoutingResolver)} and
+	 *             {@link #delete(String, IndexCoordinates)}
 	 */
+	@Deprecated
 	String delete(String id, @Nullable String routing, IndexCoordinates index);
 
 	/**

--- a/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchOperations.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchOperations.java
@@ -24,6 +24,7 @@ import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverte
 import org.springframework.data.elasticsearch.core.document.Document;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.query.AliasQuery;
+import org.springframework.data.elasticsearch.core.routing.RoutingResolver;
 import org.springframework.lang.Nullable;
 
 /**
@@ -416,4 +417,16 @@ public interface ElasticsearchOperations extends DocumentOperations, SearchOpera
 		return Objects.toString(id, null);
 	}
 	// endregion
+
+	//region routing
+	/**
+	 * Returns a copy of this instance with the same configuration, but that uses a different {@link RoutingResolver} to
+	 * obtain routing information.
+	 *
+	 * @param routingResolver the {@link RoutingResolver} value, must not be {@literal null}.
+	 * @return DocumentOperations instance
+	 * @since 4.2
+	 */
+	ElasticsearchOperations withRouting(RoutingResolver routingResolver);
+	//endregion
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/ReactiveDocumentOperations.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ReactiveDocumentOperations.java
@@ -301,7 +301,7 @@ public interface ReactiveDocumentOperations {
 	 * @param entityType must not be {@literal null}.
 	 * @param index the target index, must not be {@literal null}
 	 * @return a {@link Mono} emitting the {@literal id} of the removed document.
-	 * @deprecated since 4.0, use {@link #delete(String, Class)} or {@link #deleteById(String, IndexCoordinates)}
+	 * @deprecated since 4.0, use {@link #delete(String, Class)} or {@link #delete(String, IndexCoordinates)}
 	 */
 	@Deprecated
 	default Mono<String> delete(String id, Class<?> entityType, IndexCoordinates index) {

--- a/src/main/java/org/springframework/data/elasticsearch/core/ReactiveElasticsearchOperations.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ReactiveElasticsearchOperations.java
@@ -20,6 +20,7 @@ import org.springframework.data.elasticsearch.client.reactive.ReactiveElasticsea
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentEntity;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.routing.RoutingResolver;
 import org.springframework.lang.Nullable;
 
 /**
@@ -87,6 +88,17 @@ public interface ReactiveElasticsearchOperations extends ReactiveDocumentOperati
 	 * @since 4.1
 	 */
 	ReactiveIndexOperations indexOps(Class<?> clazz);
+
+	//region routing
+	/**
+	 * Returns a copy of this instance with the same configuration, but that uses a different {@link RoutingResolver} to
+	 * obtain routing information.
+	 *
+	 * @param routingResolver the {@link RoutingResolver} value, must not be {@literal null}.
+	 * @return DocumentOperations instance
+	 */
+	ReactiveElasticsearchOperations withRouting(RoutingResolver routingResolver);
+	//endregion
 
 	/**
 	 * Callback interface to be used with {@link #execute(ClientCallback)} for operating directly on

--- a/src/main/java/org/springframework/data/elasticsearch/core/RequestFactory.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/RequestFactory.java
@@ -833,12 +833,17 @@ class RequestFactory {
 	// endregion
 
 	// region get
-	public GetRequest getRequest(String id, IndexCoordinates index) {
-		return new GetRequest(index.getIndexName(), id);
+	public GetRequest getRequest(String id, @Nullable String routing, IndexCoordinates index) {
+		GetRequest getRequest = new GetRequest(index.getIndexName(), id);
+		getRequest.routing(routing);
+		return getRequest;
 	}
 
-	public GetRequestBuilder getRequestBuilder(Client client, String id, IndexCoordinates index) {
-		return client.prepareGet(index.getIndexName(), null, id);
+	public GetRequestBuilder getRequestBuilder(Client client, String id, @Nullable String routing,
+			IndexCoordinates index) {
+		GetRequestBuilder getRequestBuilder = client.prepareGet(index.getIndexName(), null, id);
+		getRequestBuilder.setRouting(routing);
+		return getRequestBuilder;
 	}
 
 	public MultiGetRequest multiGetRequest(Query query, Class<?> clazz, IndexCoordinates index) {

--- a/src/main/java/org/springframework/data/elasticsearch/core/SearchHit.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/SearchHit.java
@@ -44,17 +44,19 @@ public class SearchHit<T> {
 	private final Map<String, List<String>> highlightFields = new LinkedHashMap<>();
 	private final Map<String, SearchHits<?>> innerHits = new LinkedHashMap<>();
 	@Nullable private final NestedMetaData nestedMetaData;
+	@Nullable private String routing;
 
-	public SearchHit(@Nullable String index, @Nullable String id, float score, @Nullable Object[] sortValues,
-			@Nullable Map<String, List<String>> highlightFields, T content) {
-		this(index, id, score, sortValues, highlightFields, null, null, content);
+	public SearchHit(@Nullable String index, @Nullable String id, @Nullable String routing, float score,
+			@Nullable Object[] sortValues, @Nullable Map<String, List<String>> highlightFields, T content) {
+		this(index, id, routing, score, sortValues, highlightFields, null, null, content);
 	}
 
-	public SearchHit(@Nullable String index, @Nullable String id, float score, @Nullable Object[] sortValues,
-			@Nullable Map<String, List<String>> highlightFields, @Nullable Map<String, SearchHits<?>> innerHits,
-			@Nullable NestedMetaData nestedMetaData, T content) {
+	public SearchHit(@Nullable String index, @Nullable String id, @Nullable String routing, float score,
+			@Nullable Object[] sortValues, @Nullable Map<String, List<String>> highlightFields,
+			@Nullable Map<String, SearchHits<?>> innerHits, @Nullable NestedMetaData nestedMetaData, T content) {
 		this.index = index;
 		this.id = id;
+		this.routing = routing;
 		this.score = score;
 		this.sortValues = (sortValues != null) ? Arrays.asList(sortValues) : new ArrayList<>();
 
@@ -164,5 +166,14 @@ public class SearchHit<T> {
 	public String toString() {
 		return "SearchHit{" + "id='" + id + '\'' + ", score=" + score + ", sortValues=" + sortValues + ", content="
 				+ content + ", highlightFields=" + highlightFields + '}';
+	}
+
+	/**
+	 * @return the routing for this SearchHit, may be {@literal null}.
+	 * @since 4.2
+	 */
+	@Nullable
+	public String getRouting() {
+		return routing;
 	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/SearchHitMapping.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/SearchHitMapping.java
@@ -107,6 +107,7 @@ class SearchHitMapping<T> {
 
 		return new SearchHit<T>(searchDocument.getIndex(), //
 				searchDocument.hasId() ? searchDocument.getId() : null, //
+				searchDocument.getRouting(), //
 				searchDocument.getScore(), //
 				searchDocument.getSortValues(), //
 				getHighlightsAndRemapFieldNames(searchDocument), //
@@ -189,6 +190,7 @@ class SearchHitMapping<T> {
 					Object targetObject = converter.read(targetType, searchDocument);
 					convertedSearchHits.add(new SearchHit<Object>(searchDocument.getIndex(), //
 							searchDocument.getId(), //
+							searchDocument.getRouting(), //
 							searchDocument.getScore(), //
 							searchDocument.getSortValues(), //
 							searchDocument.getHighlightFields(), //

--- a/src/main/java/org/springframework/data/elasticsearch/core/document/SearchDocument.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/document/SearchDocument.java
@@ -89,4 +89,13 @@ public interface SearchDocument extends Document {
 	default NestedMetaData getNestedMetaData() {
 		return null;
 	}
+
+	/**
+	 * @return the routing value for the document
+	 * @since 4.2
+	 */
+	@Nullable
+	default String getRouting() {
+		return getFieldValue("_routing");
+	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentEntity.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentEntity.java
@@ -171,9 +171,18 @@ public interface ElasticsearchPersistentEntity<T> extends PersistentEntity<T, El
 
 	/**
 	 * returns the default settings for an index.
-	 * 
+	 *
 	 * @return settings as {@link Document}
 	 * @since 4.1
 	 */
 	Document getDefaultSettings();
+
+	/**
+	 * Resolves the routing for a bean.
+	 * 
+	 * @param bean the bean to resolve the routing for
+	 * @return routing value, may be {@literal null}
+	 */
+	@Nullable
+	String resolveRouting(T bean);
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/routing/DefaultRoutingResolver.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/routing/DefaultRoutingResolver.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core.routing;
+
+import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentEntity;
+import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentProperty;
+import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.lang.Nullable;
+
+/**
+ * Default implementation of the {@link RoutingResolver} interface. Returns {@literal null} for the non-bean method and
+ * delegates to the corresponding persistent entity for the bean-method.
+ * 
+ * @author Peter-Josef Meisch
+ * @since 4.2
+ */
+public class DefaultRoutingResolver implements RoutingResolver {
+
+	private final MappingContext<? extends ElasticsearchPersistentEntity, ? extends ElasticsearchPersistentProperty> mappingContext;
+
+	public DefaultRoutingResolver(
+			MappingContext<? extends ElasticsearchPersistentEntity, ? extends ElasticsearchPersistentProperty> mappingContext) {
+		this.mappingContext = mappingContext;
+	}
+
+	@Override
+	public String getRouting() {
+		return null;
+	}
+
+	@Override
+	@Nullable
+	public <T> String getRouting(T bean) {
+
+		ElasticsearchPersistentEntity<T> persistentEntity = (ElasticsearchPersistentEntity<T>) mappingContext
+				.getPersistentEntity(bean.getClass());
+
+		if (persistentEntity != null) {
+			return persistentEntity.resolveRouting(bean);
+		}
+
+		return null;
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/routing/RoutingResolver.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/routing/RoutingResolver.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core.routing;
+
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * @author Peter-Josef Meisch
+ * @since 4.2
+ */
+public interface RoutingResolver {
+
+	/**
+	 * returns the routing when no entity is available.
+	 *
+	 * @return the routing value
+	 */
+	@Nullable
+	String getRouting();
+
+	/**
+	 * Returns the routing for a bean.
+	 * 
+	 * @param bean the bean to get the routing for
+	 * @return the routing value
+	 */
+	@Nullable
+	<T> String getRouting(T bean);
+
+	/**
+	 * Returns a {@link RoutingResolver that always retuns a fixed value}
+	 * 
+	 * @param value the value to return
+	 * @return the fixed-value {@link RoutingResolver}
+	 */
+	static RoutingResolver just(String value) {
+
+		Assert.notNull(value, "value must not be null");
+
+		return new RoutingResolver() {
+			@Override
+			public String getRouting() {
+				return value;
+			}
+
+			@Override
+			public String getRouting(Object bean) {
+				return value;
+			}
+		};
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/routing/package-info.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/routing/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * classes/interfaces for specification and implementation of Elasticsearch routing.
+ */
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package org.springframework.data.elasticsearch.core.routing;

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplateTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchRestTemplateTests.java
@@ -58,7 +58,6 @@ import org.springframework.test.context.ContextConfiguration;
  * @author Don Wellington
  * @author Peter-Josef Meisch
  */
-@SpringIntegrationTest
 @ContextConfiguration(classes = { ElasticsearchRestTemplateConfiguration.class })
 @DisplayName("ElasticsearchRestTemplate")
 public class ElasticsearchRestTemplateTests extends ElasticsearchTemplateTests {

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTransportTemplateTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchTransportTemplateTests.java
@@ -48,14 +48,12 @@ import org.springframework.data.elasticsearch.core.query.NativeSearchQuery;
 import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
 import org.springframework.data.elasticsearch.core.query.UpdateQuery;
 import org.springframework.data.elasticsearch.junit.jupiter.ElasticsearchTemplateConfiguration;
-import org.springframework.data.elasticsearch.junit.jupiter.SpringIntegrationTest;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
  * @author Peter-Josef Meisch
  * @author Sascha Woo
  */
-@SpringIntegrationTest
 @ContextConfiguration(classes = { ElasticsearchTemplateConfiguration.class })
 @DisplayName("ElasticsearchTransportTemplate")
 public class ElasticsearchTransportTemplateTests extends ElasticsearchTemplateTests {

--- a/src/test/java/org/springframework/data/elasticsearch/core/EntityOperationsTest.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/EntityOperationsTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core;
+
+import static org.assertj.core.api.Assertions.*;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.support.GenericConversionService;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Routing;
+import org.springframework.data.elasticsearch.core.convert.MappingElasticsearchConverter;
+import org.springframework.data.elasticsearch.core.join.JoinField;
+import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
+import org.springframework.data.elasticsearch.core.routing.DefaultRoutingResolver;
+import org.springframework.lang.Nullable;
+
+/**
+ * @author Peter-Josef Meisch
+ */
+class EntityOperationsTest {
+
+	@Nullable private static ConversionService conversionService;
+	@Nullable private static EntityOperations entityOperations;
+	@Nullable private static SimpleElasticsearchMappingContext mappingContext;
+
+	@BeforeAll
+	static void setUpAll() {
+		mappingContext = new SimpleElasticsearchMappingContext();
+		mappingContext.setInitialEntitySet(new HashSet<>(Arrays.asList(EntityWithRouting.class)));
+		mappingContext.afterPropertiesSet();
+		entityOperations = new EntityOperations(mappingContext);
+
+		MappingElasticsearchConverter converter = new MappingElasticsearchConverter(mappingContext,
+				new GenericConversionService());
+		converter.afterPropertiesSet();
+
+		conversionService = converter.getConversionService();
+	}
+
+	@Test // #1218
+	@DisplayName("should return routing from DefaultRoutingAccessor")
+	void shouldReturnRoutingFromDefaultRoutingAccessor() {
+
+		EntityWithRouting entity = EntityWithRouting.builder().id("42").routing("theRoute").build();
+		EntityOperations.AdaptibleEntity<EntityWithRouting> adaptibleEntity = entityOperations.forEntity(entity,
+				conversionService, new DefaultRoutingResolver(mappingContext));
+
+		String routing = adaptibleEntity.getRouting();
+
+		assertThat(routing).isEqualTo("theRoute");
+	}
+
+	@Test // #1218
+	@DisplayName("should return routing from JoinField when routing value is null")
+	void shouldReturnRoutingFromJoinFieldWhenRoutingValueIsNull() {
+
+		EntityWithRoutingAndJoinField entity = EntityWithRoutingAndJoinField.builder().id("42")
+				.joinField(new JoinField<>("foo", "foo-routing")).build();
+
+		EntityOperations.AdaptibleEntity<EntityWithRoutingAndJoinField> adaptibleEntity = entityOperations.forEntity(entity,
+				conversionService, new DefaultRoutingResolver(mappingContext));
+
+		String routing = adaptibleEntity.getRouting();
+
+		assertThat(routing).isEqualTo("foo-routing");
+	}
+
+	@Test // #1218
+	@DisplayName("should return routing from routing when JoinField is set")
+	void shouldReturnRoutingFromRoutingWhenJoinFieldIsSet() {
+		EntityWithRoutingAndJoinField entity = EntityWithRoutingAndJoinField.builder().id("42").routing("theRoute")
+				.joinField(new JoinField<>("foo", "foo-routing")).build();
+
+		EntityOperations.AdaptibleEntity<EntityWithRoutingAndJoinField> adaptibleEntity = entityOperations.forEntity(entity,
+				conversionService, new DefaultRoutingResolver(mappingContext));
+
+		String routing = adaptibleEntity.getRouting();
+
+		assertThat(routing).isEqualTo("theRoute");
+	}
+
+	@Data
+	@Builder
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Document(indexName = "entity-operations-test")
+	@Routing("routing")
+	static class EntityWithRouting {
+		@Id private String id;
+		private String routing;
+	}
+
+	@Data
+	@Builder
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Document(indexName = "entity-operations-test")
+	@Routing("routing")
+	static class EntityWithRoutingAndJoinField {
+		@Id private String id;
+		private String routing;
+		private JoinField<String> joinField;
+	}
+}

--- a/src/test/java/org/springframework/data/elasticsearch/core/SearchHitSupportTest.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/SearchHitSupportTest.java
@@ -59,11 +59,11 @@ class SearchHitSupportTest {
 	void shouldReturnTheSameListInstanceInSearchHitsAndGetContent() {
 
 		List<SearchHit<String>> hits = new ArrayList<>();
-		hits.add(new SearchHit<>(null, null, 0, null, null, "one"));
-		hits.add(new SearchHit<>(null, null, 0, null, null, "two"));
-		hits.add(new SearchHit<>(null, null, 0, null, null, "three"));
-		hits.add(new SearchHit<>(null, null, 0, null, null, "four"));
-		hits.add(new SearchHit<>(null, null, 0, null, null, "five"));
+		hits.add(new SearchHit<>(null, null, null, 0, null, null, "one"));
+		hits.add(new SearchHit<>(null, null, null, 0, null, null, "two"));
+		hits.add(new SearchHit<>(null, null, null, 0, null, null, "three"));
+		hits.add(new SearchHit<>(null, null, null, 0, null, null, "four"));
+		hits.add(new SearchHit<>(null, null, null, 0, null, null, "five"));
 
 		SearchHits<String> originalSearchHits = new SearchHitsImpl<>(hits.size(), TotalHitsRelation.EQUAL_TO, 0, "scroll",
 				hits, null);
@@ -112,7 +112,7 @@ class SearchHitSupportTest {
 		@Override
 		public SearchHit<String> next() {
 			String nextString = iterator.next();
-			return new SearchHit<>("index", "id", 1.0f, new Object[0], emptyMap(), nextString);
+			return new SearchHit<>("index", "id", null, 1.0f, new Object[0], emptyMap(), nextString);
 		}
 	}
 

--- a/src/test/java/org/springframework/data/elasticsearch/core/StreamQueriesTest.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/StreamQueriesTest.java
@@ -38,7 +38,7 @@ public class StreamQueriesTest {
 
 		// given
 		List<SearchHit<String>> hits = new ArrayList<>();
-		hits.add(new SearchHit<String>(null, null, 0, null, null, "one"));
+		hits.add(getOneSearchHit());
 
 		SearchScrollHits<String> searchHits = newSearchScrollHits(hits, "1234");
 
@@ -61,12 +61,16 @@ public class StreamQueriesTest {
 
 	}
 
+	private SearchHit<String> getOneSearchHit() {
+		return new SearchHit<String>(null, null, null, 0, null, null, "one");
+	}
+
 	@Test // DATAES-766
 	public void shouldReturnTotalHits() {
 
 		// given
 		List<SearchHit<String>> hits = new ArrayList<>();
-		hits.add(new SearchHit<String>(null, null, 0, null, null, "one"));
+		hits.add(getOneSearchHit());
 
 		SearchScrollHits<String> searchHits = newSearchScrollHits(hits, "1234");
 
@@ -85,12 +89,9 @@ public class StreamQueriesTest {
 	@Test // DATAES-817
 	void shouldClearAllScrollIds() {
 
-		SearchScrollHits<String> searchHits1 = newSearchScrollHits(
-				Collections.singletonList(new SearchHit<String>(null, null, 0, null, null, "one")), "s-1");
-		SearchScrollHits<String> searchHits2 = newSearchScrollHits(
-				Collections.singletonList(new SearchHit<String>(null, null, 0, null, null, "one")), "s-2");
-		SearchScrollHits<String> searchHits3 = newSearchScrollHits(
-				Collections.singletonList(new SearchHit<String>(null, null, 0, null, null, "one")), "s-2");
+		SearchScrollHits<String> searchHits1 = newSearchScrollHits(Collections.singletonList(getOneSearchHit()), "s-1");
+		SearchScrollHits<String> searchHits2 = newSearchScrollHits(Collections.singletonList(getOneSearchHit()), "s-2");
+		SearchScrollHits<String> searchHits3 = newSearchScrollHits(Collections.singletonList(getOneSearchHit()), "s-2");
 		SearchScrollHits<String> searchHits4 = newSearchScrollHits(Collections.emptyList(), "s-3");
 
 		Iterator<SearchScrollHits<String>> searchScrollHitsIterator = Arrays
@@ -114,12 +115,9 @@ public class StreamQueriesTest {
 	@Test // DATAES-831
 	void shouldReturnAllForRequestedSizeOf0() {
 
-		SearchScrollHits<String> searchHits1 = newSearchScrollHits(
-				Collections.singletonList(new SearchHit<String>(null, null, 0, null, null, "one")), "s-1");
-		SearchScrollHits<String> searchHits2 = newSearchScrollHits(
-				Collections.singletonList(new SearchHit<String>(null, null, 0, null, null, "one")), "s-2");
-		SearchScrollHits<String> searchHits3 = newSearchScrollHits(
-				Collections.singletonList(new SearchHit<String>(null, null, 0, null, null, "one")), "s-2");
+		SearchScrollHits<String> searchHits1 = newSearchScrollHits(Collections.singletonList(getOneSearchHit()), "s-1");
+		SearchScrollHits<String> searchHits2 = newSearchScrollHits(Collections.singletonList(getOneSearchHit()), "s-2");
+		SearchScrollHits<String> searchHits3 = newSearchScrollHits(Collections.singletonList(getOneSearchHit()), "s-2");
 		SearchScrollHits<String> searchHits4 = newSearchScrollHits(Collections.emptyList(), "s-3");
 
 		Iterator<SearchScrollHits<String>> searchScrollHitsIterator = Arrays
@@ -139,12 +137,9 @@ public class StreamQueriesTest {
 	@Test // DATAES-831
 	void shouldOnlyReturnRequestedCount() {
 
-		SearchScrollHits<String> searchHits1 = newSearchScrollHits(
-				Collections.singletonList(new SearchHit<String>(null, null, 0, null, null, "one")), "s-1");
-		SearchScrollHits<String> searchHits2 = newSearchScrollHits(
-				Collections.singletonList(new SearchHit<String>(null, null, 0, null, null, "one")), "s-2");
-		SearchScrollHits<String> searchHits3 = newSearchScrollHits(
-				Collections.singletonList(new SearchHit<String>(null, null, 0, null, null, "one")), "s-2");
+		SearchScrollHits<String> searchHits1 = newSearchScrollHits(Collections.singletonList(getOneSearchHit()), "s-1");
+		SearchScrollHits<String> searchHits2 = newSearchScrollHits(Collections.singletonList(getOneSearchHit()), "s-2");
+		SearchScrollHits<String> searchHits3 = newSearchScrollHits(Collections.singletonList(getOneSearchHit()), "s-2");
 		SearchScrollHits<String> searchHits4 = newSearchScrollHits(Collections.emptyList(), "s-3");
 
 		Iterator<SearchScrollHits<String>> searchScrollHitsIterator = Arrays

--- a/src/test/java/org/springframework/data/elasticsearch/core/routing/DefaultRoutingResolverUnitTest.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/routing/DefaultRoutingResolverUnitTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core.routing;
+
+import static org.assertj.core.api.Assertions.*;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Routing;
+import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
+import org.springframework.lang.Nullable;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * @author Peter-Josef Meisch
+ */
+@SpringJUnitConfig({ DefaultRoutingResolverUnitTest.Config.class })
+class DefaultRoutingResolverUnitTest {
+
+	@Autowired private ApplicationContext applicationContext;
+	private SimpleElasticsearchMappingContext mappingContext;
+
+	@Nullable private RoutingResolver routingResolver;
+
+	@Configuration
+	static class Config {
+		@Bean
+		SpelRouting spelRouting() {
+			return new SpelRouting();
+		}
+	}
+
+	@BeforeEach
+	void setUp() {
+		mappingContext = new SimpleElasticsearchMappingContext();
+		mappingContext.setApplicationContext(applicationContext);
+
+		routingResolver = new DefaultRoutingResolver(mappingContext);
+	}
+
+	@Test // #1218
+	@DisplayName("should throw an exception on unknown property")
+	void shouldThrowAnExceptionOnUnknownProperty() {
+
+		InvalidRoutingEntity entity = new InvalidRoutingEntity("42", "route 66");
+
+		assertThatThrownBy(() -> routingResolver.getRouting(entity)).isInstanceOf(InvalidDataAccessApiUsageException.class);
+	}
+
+	@Test // #1218
+	@DisplayName("should return the routing from the entity")
+	void shouldReturnTheRoutingFromTheEntity() {
+
+		ValidRoutingEntity entity = new ValidRoutingEntity("42", "route 66");
+
+		String routing = routingResolver.getRouting(entity);
+
+		assertThat(routing).isEqualTo("route 66");
+	}
+
+	@Test // #1218
+	@DisplayName("should return routing from SpEL expression")
+	void shouldReturnRoutingFromSpElExpression() {
+
+		ValidSpelRoutingEntity entity = new ValidSpelRoutingEntity("42", "route 42");
+
+		String routing = routingResolver.getRouting(entity);
+
+		assertThat(routing).isEqualTo("route 42");
+	}
+
+	@Data
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Document(indexName = "routing-resolver-test")
+	@Routing("theRouting")
+	static class ValidRoutingEntity {
+		@Id private String id;
+		private String theRouting;
+	}
+
+	@Data
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Document(indexName = "routing-resolver-test")
+	@Routing(value = "@spelRouting.getRouting(#entity)")
+	static class ValidSpelRoutingEntity {
+		@Id private String id;
+		private String theRouting;
+	}
+
+	@Data
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Document(indexName = "routing-resolver-test")
+	@Routing("unknownProperty")
+	static class InvalidRoutingEntity {
+		@Id private String id;
+		private String theRouting;
+	}
+
+	static class SpelRouting {
+
+		@Nullable
+		public String getRouting(Object o) {
+
+			if (o instanceof ValidSpelRoutingEntity) {
+				return ((ValidSpelRoutingEntity) o).getTheRouting();
+			}
+
+			return null;
+		}
+	}
+}

--- a/src/test/java/org/springframework/data/elasticsearch/core/routing/ElasticsearchOperationsRoutingTransportTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/routing/ElasticsearchOperationsRoutingTransportTests.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core.routing;
+
+import org.springframework.data.elasticsearch.junit.jupiter.ElasticsearchTemplateConfiguration;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author Peter-Josef Meisch
+ */
+@ContextConfiguration(classes = { ElasticsearchTemplateConfiguration.class })
+public class ElasticsearchOperationsRoutingTransportTests extends ElasticsearchOperationsRoutingTests {}

--- a/src/test/java/org/springframework/data/elasticsearch/core/routing/ReactiveElasticsearchOperationsRoutingTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/routing/ReactiveElasticsearchOperationsRoutingTests.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core.routing;
+
+import static org.assertj.core.api.Assertions.*;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.function.Function;
+
+import org.elasticsearch.cluster.routing.Murmur3HashFunction;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Routing;
+import org.springframework.data.elasticsearch.core.ReactiveElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.ReactiveIndexOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.Query;
+import org.springframework.data.elasticsearch.junit.jupiter.ReactiveElasticsearchRestTemplateConfiguration;
+import org.springframework.data.elasticsearch.junit.jupiter.SpringIntegrationTest;
+import org.springframework.lang.Nullable;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author Peter-Josef Meisch
+ */
+@SpringIntegrationTest
+@ContextConfiguration(classes = { ReactiveElasticsearchRestTemplateConfiguration.class })
+public class ReactiveElasticsearchOperationsRoutingTests {
+
+	private static final String INDEX = "routing-test";
+	private static final String ID_1 = "id1";
+	private static final String ID_2 = "id2";
+	private static final String ID_3 = "id3";
+
+	@Autowired ReactiveElasticsearchOperations operations;
+	@Nullable private ReactiveIndexOperations indexOps;
+
+	@BeforeAll
+	static void beforeAll() {
+		// check that the used id values go to different shards of the index which is configured to have 5 shards.
+		// Elasticsearch uses the following function:
+		Function<String, Integer> calcShard = routing -> Math.floorMod(Murmur3HashFunction.hash(routing), 5);
+
+		Integer shard1 = calcShard.apply(ID_1);
+		Integer shard2 = calcShard.apply(ID_2);
+		Integer shard3 = calcShard.apply(ID_3);
+
+		assertThat(shard1).isNotEqualTo(shard2);
+		assertThat(shard1).isNotEqualTo(shard3);
+		assertThat(shard2).isNotEqualTo(shard3);
+	}
+
+	@BeforeEach
+	void setUp() {
+		indexOps = operations.indexOps(RoutingEntity.class);
+		indexOps.delete().then(indexOps.create()).then(indexOps.putMapping()).block();
+	}
+
+	@Test // #1218
+	@DisplayName("should store data with different routing and be able to get it")
+	void shouldStoreDataWithDifferentRoutingAndBeAbleToGetIt() {
+
+		RoutingEntity entity = RoutingEntity.builder().id(ID_1).routing(ID_2).build();
+		operations.save(entity).then(indexOps.refresh()).block();
+
+		RoutingEntity savedEntity = operations.withRouting(RoutingResolver.just(ID_2)).get(entity.id, RoutingEntity.class)
+				.block();
+
+		assertThat(savedEntity).isEqualTo(entity);
+	}
+
+	@Test // #1218
+	@DisplayName("should store data with different routing and be able to delete it")
+	void shouldStoreDataWithDifferentRoutingAndBeAbleToDeleteIt() {
+
+		RoutingEntity entity = RoutingEntity.builder().id(ID_1).routing(ID_2).build();
+		operations.save(entity).then(indexOps.refresh()).block();
+
+		String deletedId = operations.withRouting(RoutingResolver.just(ID_2)).delete(entity.id, IndexCoordinates.of(INDEX))
+				.block();
+
+		assertThat(deletedId).isEqualTo(entity.getId());
+	}
+
+	@Test // #1218
+	@DisplayName("should store data with different routing and get the routing in the search result")
+	void shouldStoreDataWithDifferentRoutingAndGetTheRoutingInTheSearchResult() {
+
+		RoutingEntity entity = RoutingEntity.builder().id(ID_1).routing(ID_2).build();
+		operations.save(entity).then(indexOps.refresh()).block();
+
+		List<SearchHit<RoutingEntity>> searchHits = operations.search(Query.findAll(), RoutingEntity.class).collectList()
+				.block();
+
+		assertThat(searchHits).hasSize(1);
+		assertThat(searchHits.get(0).getRouting()).isEqualTo(ID_2);
+	}
+
+	@Data
+	@Builder
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Document(indexName = INDEX, shards = 5)
+	@Routing("routing")
+	static class RoutingEntity {
+		@Id private String id;
+		private String routing;
+	}
+}

--- a/src/test/java/org/springframework/data/elasticsearch/junit/jupiter/ReactiveElasticsearchRestTemplateConfiguration.java
+++ b/src/test/java/org/springframework/data/elasticsearch/junit/jupiter/ReactiveElasticsearchRestTemplateConfiguration.java
@@ -43,6 +43,11 @@ public class ReactiveElasticsearchRestTemplateConfiguration extends AbstractReac
 		ClientConfiguration.TerminalClientConfigurationBuilder configurationBuilder = ClientConfiguration.builder() //
 				.connectedTo(elasticsearchHostPort);
 
+		String proxy = System.getenv("DATAES_ELASTICSEARCH_PROXY");
+
+		if (proxy != null) {
+			configurationBuilder = configurationBuilder.withProxy(proxy);
+		}
 		if (clusterConnectionInfo.isUseSsl()) {
 			configurationBuilder = ((ClientConfiguration.MaybeSecureClientConfigurationBuilder) configurationBuilder)
 					.usingSsl();


### PR DESCRIPTION
The `MappingContext` now has a `RoutingAccessorFactory`.

The `@Document` annotation has a `routing` parameter (I call that the routing specification) that will be passed together with the bean to the `RoutingAccessorFactory` which then can produce a `RoutingAccessor` for the bean.

The default implementation first checks if the routing specification is the name of an `PersistentProperty` for the bean. If so, the value of that property will be used for routing. If not, the routing specification will be evaluated as a SpEL expression with the bean as root object, allowing to define some bean that will resolve to a routing value.

If this is not enough, a user can set a custom `RoutingAccessorFactory` in the `ConfigurationSupport`.

Where a routing is needed, but no bean/entity available (get/delete by id), I introduced additional methods taking a _routing_ parameter.