### PR TITLE
add timeout to search query

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/RequestFactory.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/RequestFactory.java
@@ -1172,6 +1172,11 @@ class RequestFactory {
 		if (StringUtils.hasLength(query.getRoute())) {
 			request.routing(query.getRoute());
 		}
+		
+		TimeValue timeout = query.getTimeout();
+		if (timeout !=null) {
+			sourceBuilder.timeout(timeout);
+		}
 
 		request.source(sourceBuilder);
 		return request;
@@ -1246,6 +1251,11 @@ class RequestFactory {
 
 		if (StringUtils.hasLength(query.getRoute())) {
 			searchRequestBuilder.setRouting(query.getRoute());
+		}
+		
+		TimeValue timeout = query.getTimeout();
+		if (timeout !=null) {
+			searchRequestBuilder.setTimeout(timeout);
 		}
 
 		return searchRequestBuilder;

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/AbstractQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/AbstractQuery.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.common.unit.TimeValue;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.lang.Nullable;
@@ -59,6 +60,7 @@ abstract class AbstractQuery implements Query {
 	@Nullable private Boolean trackTotalHits;
 	@Nullable private Integer trackTotalHitsUpTo;
 	@Nullable private Duration scrollTime;
+	@Nullable private TimeValue timeout;
 
 	@Override
 	@Nullable
@@ -251,5 +253,15 @@ abstract class AbstractQuery implements Query {
 	@Override
 	public void setScrollTime(@Nullable Duration scrollTime) {
 		this.scrollTime = scrollTime;
+	}
+	
+	@Nullable
+	@Override
+	public TimeValue getTimeout() {
+		return timeout;
+	}
+
+	public void setTimeout(TimeValue timeout) {
+		this.timeout = timeout;
 	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/NativeSearchQueryBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/NativeSearchQueryBuilder.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.collapse.CollapseBuilder;
@@ -68,6 +69,7 @@ public class NativeSearchQueryBuilder {
 	@Nullable private String preference;
 	@Nullable private Integer maxResults;
 	@Nullable private Boolean trackTotalHits;
+	@Nullable private TimeValue timeout;
 
 	public NativeSearchQueryBuilder withQuery(QueryBuilder queryBuilder) {
 		this.queryBuilder = queryBuilder;
@@ -181,6 +183,11 @@ public class NativeSearchQueryBuilder {
 		this.trackTotalHits = trackTotalHits;
 		return this;
 	}
+	
+	public NativeSearchQueryBuilder withTimeout(TimeValue timeout) {   
+		this.timeout = timeout;
+		return this;
+	}
 
 	public NativeSearchQuery build() {
 
@@ -243,6 +250,10 @@ public class NativeSearchQueryBuilder {
 		}
 
 		nativeSearchQuery.setTrackTotalHits(trackTotalHits);
+		
+		if (timeout != null) {
+			nativeSearchQuery.setTimeout(timeout);
+		}
 
 		return nativeSearchQuery;
 	}

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/Query.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/Query.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -275,4 +276,12 @@ public interface Query {
 	default boolean hasScrollTime() {
 		return getScrollTime() != null;
 	}
+	
+	/**
+	 * Get timeout
+	 *
+	 * @return null if not set
+	 */
+	@Nullable
+	TimeValue getTimeout();
 }


### PR DESCRIPTION
Hi,

We are using  ReactiveElasticsearchOperations search methods with  nativeSearchQueries.
 
It seems that there is no way to provide query timeout for search request.

Elasticsearch api provides this option but I don't see any way to achieve this using spring-data-es.

Indeed very similar question was previously asked on SO:

https://stackoverflow.com/questions/54201598/how-to-define-a-query-timeout-for-a-spring-data-elastic-search-query

This pr tries to add that option to api.

Best regards

