### PR TITLE
Adds support for dense_vector type

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/annotations/Field.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/Field.java
@@ -34,6 +34,8 @@ import org.springframework.core.annotation.AliasFor;
  * @author Peter-Josef Meisch
  * @author Xiao Yu
  * @author Aleksei Arsenev
+ * @author Brian Kimmig
+ * @author Morgan Lutz
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.FIELD, ElementType.ANNOTATION_TYPE })
@@ -185,4 +187,11 @@ public @interface Field {
 	 * @since 4.1
 	 */
 	NullValueType nullValueType() default NullValueType.String;
+
+	/**
+   	 * to be used in combination with {@link FieldType#Dense_Vector}
+	 *
+	 * @since 4.2
+	 */
+	int dims() default -1;
 }

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/FieldType.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/FieldType.java
@@ -22,6 +22,8 @@ package org.springframework.data.elasticsearch.annotations;
  * @author Zeng Zetang
  * @author Peter-Josef Meisch
  * @author Aleksei Arsenev
+ * @author Brian Kimmig
+ * @author Morgan Lutz
  */
 public enum FieldType {
 	Auto, //
@@ -57,5 +59,7 @@ public enum FieldType {
 	/** @since 4.1 */
 	Rank_Features, //
 	/** since 4.2 */
-	Wildcard //
+	Wildcard, //
+  	/** @since 4.2 */
+  	Dense_Vector //
 }

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/InnerField.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/InnerField.java
@@ -27,6 +27,8 @@ import java.lang.annotation.Target;
  * @author Xiao Yu
  * @author Peter-Josef Meisch
  * @author Aleksei Arsenev
+ * @author Brian Kimmig
+ * @author Morgan Lutz
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.ANNOTATION_TYPE)
@@ -140,4 +142,11 @@ public @interface InnerField {
 	 * @since 4.1
 	 */
 	NullValueType nullValueType() default NullValueType.String;
+
+	/**
+	 * to be used in combination with {@link FieldType#Dense_Vector}
+	 *
+	 * @since 4.2
+	 */
+	int dims() default -1;
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/index/MappingParameters.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/index/MappingParameters.java
@@ -39,6 +39,8 @@ import org.springframework.util.StringUtils;
  *
  * @author Peter-Josef Meisch
  * @author Aleksei Arsenev
+ * @author Brian Kimmig
+ * @author Morgan Lutz
  * @since 4.0
  */
 public final class MappingParameters {
@@ -65,6 +67,7 @@ public final class MappingParameters {
 	static final String FIELD_PARAM_NULL_VALUE = "null_value";
 	static final String FIELD_PARAM_POSITION_INCREMENT_GAP = "position_increment_gap";
 	static final String FIELD_PARAM_POSITIVE_SCORE_IMPACT = "positive_score_impact";
+  	static final String FIELD_PARAM_DIMS = "dims";
 	static final String FIELD_PARAM_SCALING_FACTOR = "scaling_factor";
 	static final String FIELD_PARAM_SEARCH_ANALYZER = "search_analyzer";
 	static final String FIELD_PARAM_STORE = "store";
@@ -94,6 +97,7 @@ public final class MappingParameters {
 	private final NullValueType nullValueType;
 	private final Integer positionIncrementGap;
 	private final boolean positiveScoreImpact;
+  	private final Integer dims;
 	private final String searchAnalyzer;
 	private final double scalingFactor;
 	private final Similarity similarity;
@@ -153,6 +157,10 @@ public final class MappingParameters {
 				|| (maxShingleSize >= 2 && maxShingleSize <= 4), //
 				"maxShingleSize must be in inclusive range from 2 to 4 for field type search_as_you_type");
 		positiveScoreImpact = field.positiveScoreImpact();
+		dims = field.dims();
+		if (type == FieldType.Dense_Vector) {
+			Assert.isTrue(dims >= 1 && dims <= 2048, "Invalid required parameter! Dense_Vector value \"dims\" must be between 1 and 2048.");
+		}
 		Assert.isTrue(field.enabled() || type == FieldType.Object, "enabled false is only allowed for field type object");
 		enabled = field.enabled();
 		eagerGlobalOrdinals = field.eagerGlobalOrdinals();
@@ -191,6 +199,10 @@ public final class MappingParameters {
 				|| (maxShingleSize >= 2 && maxShingleSize <= 4), //
 				"maxShingleSize must be in inclusive range from 2 to 4 for field type search_as_you_type");
 		positiveScoreImpact = field.positiveScoreImpact();
+		dims = field.dims();
+		if (type == FieldType.Dense_Vector) {
+			Assert.isTrue(dims >= 1 && dims <= 2048, "Invalid required parameter! Dense_Vector value \"dims\" must be between 1 and 2048.");
+		}
 		enabled = true;
 		eagerGlobalOrdinals = field.eagerGlobalOrdinals();
 	}
@@ -321,6 +333,10 @@ public final class MappingParameters {
 
 		if (!positiveScoreImpact) {
 			builder.field(FIELD_PARAM_POSITIVE_SCORE_IMPACT, positiveScoreImpact);
+		}
+
+		if (type == FieldType.Dense_Vector) {
+			builder.field(FIELD_PARAM_DIMS, dims);
 		}
 
 		if (!enabled) {

--- a/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderIntegrationTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderIntegrationTests.java
@@ -82,6 +82,8 @@ import org.springframework.test.context.ContextConfiguration;
  * @author Peter-Josef Meisch
  * @author Xiao Yu
  * @author Roman Puchkovskiy
+ * @author Brian Kimmig
+ * @author Morgan Lutz
  */
 @SpringIntegrationTest
 @ContextConfiguration(classes = { ElasticsearchRestTemplateConfiguration.class })
@@ -269,6 +271,16 @@ public class MappingBuilderIntegrationTests extends MappingContextBaseTests {
 		IndexOperations indexOps = operations.indexOps(WildcardEntity.class);
 		indexOps.create();
 		indexOps.putMapping();
+	}
+
+	@Test // #1700
+	@DisplayName("should write dense_vector field mapping")
+	void shouldWriteDenseVectorFieldMapping() {
+
+		IndexOperations indexOps = operations.indexOps(DenseVectorEntity.class);
+		indexOps.create();
+		indexOps.putMapping();
+		indexOps.delete();
 	}
 
 	@Test // #1370
@@ -656,5 +668,12 @@ public class MappingBuilderIntegrationTests extends MappingContextBaseTests {
 		@Id private String id;
 		@Field(type = Text) private String text;
 		@Mapping(enabled = false) @Field(type = Object) private Object object;
+	}
+
+	@Data
+	@Document(indexName = "densevector-test")
+	static class DenseVectorEntity {
+		@Id private String id;
+		@Field(type = Dense_Vector, dims = 3) private float[] dense_vector;
 	}
 }

--- a/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderUnitTests.java
@@ -69,6 +69,8 @@ import org.springframework.lang.Nullable;
  * @author Peter-Josef Meisch
  * @author Xiao Yu
  * @author Roman Puchkovskiy
+ * @author Brian Kimmig
+ * @author Morgan Lutz
  */
 public class MappingBuilderUnitTests extends MappingContextBaseTests {
 
@@ -502,6 +504,23 @@ public class MappingBuilderUnitTests extends MappingContextBaseTests {
 				"}\n"; //
 
 		String mapping = getMappingBuilder().buildPropertyMapping(RankFeatureEntity.class);
+
+		assertEquals(expected, mapping, false);
+	}
+
+  	@Test // #1700
+	@DisplayName("should write dense_vector properties")
+	void shouldWriteDenseVectorProperties() throws JSONException {
+		String expected = "{\n" + //
+				"  \"properties\": {\n" + //
+				"    \"my_vector\": {\n" + //
+				"      \"type\": \"dense_vector\",\n" + //
+				"      \"dims\": 16\n" + //
+				"    }\n" + //
+				"  }\n" + //
+				"}\n"; //
+
+		String mapping = getMappingBuilder().buildPropertyMapping(DenseVectorEntity.class);
 
 		assertEquals(expected, mapping, false);
 	}
@@ -961,6 +980,13 @@ public class MappingBuilderUnitTests extends MappingContextBaseTests {
 		@Field(type = FieldType.Rank_Feature) private Integer pageRank;
 		@Field(type = FieldType.Rank_Feature, positiveScoreImpact = false) private Integer urlLength;
 		@Field(type = FieldType.Rank_Features) private Map<String, Integer> topics;
+	}
+
+  	@Data
+	static class DenseVectorEntity {
+
+		@Id private String id;
+		@Field(type = FieldType.Dense_Vector, dims = 16) private float[] my_vector;
 	}
 
 	@Data

--- a/src/test/java/org/springframework/data/elasticsearch/core/index/MappingParametersTest.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/index/MappingParametersTest.java
@@ -1,6 +1,7 @@
 package org.springframework.data.elasticsearch.core.index;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.springframework.data.elasticsearch.annotations.FieldType.Dense_Vector;
 import static org.springframework.data.elasticsearch.annotations.FieldType.Object;
 
 import java.lang.annotation.Annotation;
@@ -17,6 +18,8 @@ import org.springframework.lang.Nullable;
 
 /**
  * @author Peter-Josef Meisch
+ * @author Brian Kimmig
+ * @author Morgan Lutz
  */
 public class MappingParametersTest extends MappingContextBaseTests {
 
@@ -66,6 +69,26 @@ public class MappingParametersTest extends MappingContextBaseTests {
 		assertThatThrownBy(() -> MappingParameters.from(annotation)).isInstanceOf(IllegalArgumentException.class);
 	}
 
+	@Test // #1700
+	@DisplayName("should not allow dims length greater than 2048 for dense_vector type")
+	void shouldNotAllowDimsLengthGreaterThan2048ForDenseVectorType() {
+		ElasticsearchPersistentEntity<?> failEntity = elasticsearchConverter.get().getMappingContext()
+				.getRequiredPersistentEntity(DenseVectorInvalidDimsClass.class);
+		Annotation annotation = failEntity.getRequiredPersistentProperty("dense_vector").findAnnotation(Field.class);
+
+		assertThatThrownBy(() -> MappingParameters.from(annotation)).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test // #1700
+	@DisplayName("should require dims parameter for dense_vector type")
+	void shouldRequireDimsParameterForDenseVectorType() {
+		ElasticsearchPersistentEntity<?> failEntity = elasticsearchConverter.get().getMappingContext()
+				.getRequiredPersistentEntity(DenseVectorMissingDimsClass.class);
+		Annotation annotation = failEntity.getRequiredPersistentProperty("dense_vector").findAnnotation(Field.class);
+
+		assertThatThrownBy(() -> MappingParameters.from(annotation)).isInstanceOf(IllegalArgumentException.class);
+	}
+
 	static class AnnotatedClass {
 		@Nullable @Field private String field;
 		@Nullable @MultiField(mainField = @Field,
@@ -78,5 +101,13 @@ public class MappingParametersTest extends MappingContextBaseTests {
 
 	static class InvalidEnabledFieldClass {
 		@Nullable @Field(type = FieldType.Text, enabled = false) private String disabledObject;
+	}
+
+	static class DenseVectorInvalidDimsClass {
+		@Field(type = Dense_Vector, dims = 2049) private float[] dense_vector;
+	}
+
+	static class DenseVectorMissingDimsClass {
+		@Field(type = Dense_Vector) private float[] dense_vector;
 	}
 }


### PR DESCRIPTION
Hi all. We need to support a `dense_vector` field for our elastic search implementation. I saw you have an open ticket to support this here #1700. I only included `dense_vector` since `sparse_vector` is deprecated and both `rank_feature` and `rank_features` appear to already be supported.

Closes #1700

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] There is a ticket in the bug tracker for the project in our [issue tracker](https://github.com/spring-projects/spring-data-elasticsearch/issues).  - #1700 
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
