### PR TITLE
Better sizes for StringBuilder

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/client/reactive/DefaultReactiveElasticsearchClient.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/reactive/DefaultReactiveElasticsearchClient.java
@@ -912,7 +912,7 @@ public class DefaultReactiveElasticsearchClient implements ReactiveElasticsearch
 		ElasticsearchException exception = getElasticsearchException(content, mediaType, status);
 
 		if (exception != null) {
-			StringBuilder sb = new StringBuilder();
+			StringBuilder sb = new StringBuilder(128);
 			buildExceptionMessages(sb, exception);
 			return Mono.error(new ElasticsearchStatusException(sb.toString(), status, exception));
 		}


### PR DESCRIPTION
StringBuilder by default has size 16, however that already create larger
strings. for efficiency and garbage reduction it would be better to have
larger sizes to bigin with.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.
Make sure that:

-->

- [ ] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] There is a ticket in the bug tracker for the project in our [issue tracker](https://github.com/spring-projects/spring-data-elasticsearch/issues).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
