### PR TITLE
Remove @Persistent from entity-scan include filters

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/config/ElasticsearchConfigurationSupport.java
+++ b/src/main/java/org/springframework/data/elasticsearch/config/ElasticsearchConfigurationSupport.java
@@ -120,8 +120,7 @@ public class ElasticsearchConfigurationSupport {
 	}
 
 	/**
-	 * Scans the given base package for entities, i.e. Elasticsearch specific types annotated with {@link Document} and
-	 * {@link Persistent}.
+	 * Scans the given base package for entities, i.e. Elasticsearch specific types annotated with {@link Document}.
 	 *
 	 * @param basePackage must not be {@literal null}.
 	 * @return never {@literal null}.
@@ -137,7 +136,6 @@ public class ElasticsearchConfigurationSupport {
 		ClassPathScanningCandidateComponentProvider componentProvider = new ClassPathScanningCandidateComponentProvider(
 				false);
 		componentProvider.addIncludeFilter(new AnnotationTypeFilter(Document.class));
-		componentProvider.addIncludeFilter(new AnnotationTypeFilter(Persistent.class));
 
 		for (BeanDefinition candidate : componentProvider.findCandidateComponents(basePackage)) {
 


### PR DESCRIPTION
I think this was never really used in Spring Data Elasticsearch - as we need the _indexName_ from the `@Document´ anyways.