### PR TITLE
Refactor DefaultReactiveElasticsearchClient to do request customizati…

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/client/reactive/HostProvider.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/reactive/HostProvider.java
@@ -54,9 +54,9 @@ public interface HostProvider<T extends HostProvider<T>> {
 		Assert.notEmpty(endpoints, "Please provide at least one endpoint to connect to.");
 
 		if (endpoints.length == 1) {
-			return new SingleNodeHostProvider(clientProvider, headersSupplier, endpoints[0]);
+			return new SingleNodeHostProvider(clientProvider, endpoints[0]);
 		} else {
-			return new MultiNodeHostProvider(clientProvider, headersSupplier, endpoints);
+			return new MultiNodeHostProvider(clientProvider, endpoints);
 		}
 	}
 

--- a/src/main/java/org/springframework/data/elasticsearch/client/reactive/MultiNodeHostProvider.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/reactive/MultiNodeHostProvider.java
@@ -28,14 +28,12 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.elasticsearch.client.ElasticsearchHost;
 import org.springframework.data.elasticsearch.client.ElasticsearchHost.State;
 import org.springframework.data.elasticsearch.client.NoReachableHostException;
-import org.springframework.http.HttpHeaders;
 import org.springframework.lang.Nullable;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -53,14 +51,11 @@ class MultiNodeHostProvider implements HostProvider<MultiNodeHostProvider> {
 	private final static Logger LOG = LoggerFactory.getLogger(MultiNodeHostProvider.class);
 
 	private final WebClientProvider clientProvider;
-	private final Supplier<HttpHeaders> headersSupplier;
 	private final Map<InetSocketAddress, ElasticsearchHost> hosts;
 
-	MultiNodeHostProvider(WebClientProvider clientProvider, Supplier<HttpHeaders> headersSupplier,
-			InetSocketAddress... endpoints) {
+	MultiNodeHostProvider(WebClientProvider clientProvider, InetSocketAddress... endpoints) {
 
 		this.clientProvider = clientProvider;
-		this.headersSupplier = headersSupplier;
 		this.hosts = new ConcurrentHashMap<>();
 		for (InetSocketAddress endpoint : endpoints) {
 			this.hosts.put(endpoint, new ElasticsearchHost(endpoint, State.UNKNOWN));
@@ -166,7 +161,6 @@ class MultiNodeHostProvider implements HostProvider<MultiNodeHostProvider> {
 
 					Mono<ClientResponse> clientResponseMono = createWebClient(host) //
 							.head().uri("/") //
-							.headers(httpHeaders -> httpHeaders.addAll(headersSupplier.get())) //
 							.exchangeToMono(Mono::just) //
 							.timeout(Duration.ofSeconds(1)) //
 							.doOnError(throwable -> {

--- a/src/main/java/org/springframework/data/elasticsearch/client/reactive/SingleNodeHostProvider.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/reactive/SingleNodeHostProvider.java
@@ -19,12 +19,10 @@ import reactor.core.publisher.Mono;
 
 import java.net.InetSocketAddress;
 import java.util.Collections;
-import java.util.function.Supplier;
 
 import org.springframework.data.elasticsearch.client.ElasticsearchHost;
 import org.springframework.data.elasticsearch.client.ElasticsearchHost.State;
 import org.springframework.data.elasticsearch.client.NoReachableHostException;
-import org.springframework.http.HttpHeaders;
 import org.springframework.web.reactive.function.client.WebClient;
 
 /**
@@ -38,15 +36,12 @@ import org.springframework.web.reactive.function.client.WebClient;
 class SingleNodeHostProvider implements HostProvider<SingleNodeHostProvider> {
 
 	private final WebClientProvider clientProvider;
-	private final Supplier<HttpHeaders> headersSupplier;
 	private final InetSocketAddress endpoint;
 	private volatile ElasticsearchHost state;
 
-	SingleNodeHostProvider(WebClientProvider clientProvider, Supplier<HttpHeaders> headersSupplier,
-			InetSocketAddress endpoint) {
+	SingleNodeHostProvider(WebClientProvider clientProvider, InetSocketAddress endpoint) {
 
 		this.clientProvider = clientProvider;
-		this.headersSupplier = headersSupplier;
 		this.endpoint = endpoint;
 		this.state = new ElasticsearchHost(this.endpoint, State.UNKNOWN);
 	}
@@ -60,7 +55,6 @@ class SingleNodeHostProvider implements HostProvider<SingleNodeHostProvider> {
 
 		return createWebClient(endpoint) //
 				.head().uri("/") //
-				.headers(httpHeaders -> httpHeaders.addAll(headersSupplier.get())) //
 				.exchangeToMono(it -> {
 					if (it.statusCode().isError()) {
 						state = ElasticsearchHost.offline(endpoint);

--- a/src/main/java/org/springframework/data/elasticsearch/client/reactive/WebClientProvider.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/reactive/WebClientProvider.java
@@ -101,7 +101,7 @@ public interface WebClientProvider {
 
 	/**
 	 * Obtain the {@link String pathPrefix} to be used.
-	 * 
+	 *
 	 * @return the pathPrefix if set.
 	 * @since 4.0
 	 */
@@ -126,7 +126,7 @@ public interface WebClientProvider {
 
 	/**
 	 * Create a new instance of {@link WebClientProvider} where HTTP requests are called with the given path prefix.
-	 * 
+	 *
 	 * @param pathPrefix Path prefix to add to requests
 	 * @return new instance of {@link WebClientProvider}
 	 * @since 4.0
@@ -136,10 +136,20 @@ public interface WebClientProvider {
 	/**
 	 * Create a new instance of {@link WebClientProvider} calling the given {@link Function} to configure the
 	 * {@link WebClient}.
-	 * 
+	 *
 	 * @param webClientConfigurer configuration function
 	 * @return new instance of {@link WebClientProvider}
 	 * @since 4.0
 	 */
 	WebClientProvider withWebClientConfigurer(Function<WebClient, WebClient> webClientConfigurer);
+
+	/**
+	 * Create a new instance of {@link WebClientProvider} calling the given {@link Consumer} to configure the requests of
+	 * this {@link WebClient}.
+	 *
+	 * @param requestConfigurer request configuration callback
+	 * @return new instance of {@link WebClientProvider}
+	 * @since 4.3
+	 */
+	WebClientProvider withRequestConfigurer(Consumer<WebClient.RequestHeadersSpec<?>> requestConfigurer);
 }

--- a/src/test/java/org/springframework/data/elasticsearch/client/reactive/ReactiveMockClientTestsUtils.java
+++ b/src/test/java/org/springframework/data/elasticsearch/client/reactive/ReactiveMockClientTestsUtils.java
@@ -83,10 +83,10 @@ public class ReactiveMockClientTestsUtils {
 
 		if (hosts.length == 1) {
 			// noinspection unchecked
-			delegate = (T) new SingleNodeHostProvider(clientProvider, HttpHeaders::new, getInetSocketAddress(hosts[0])) {};
+			delegate = (T) new SingleNodeHostProvider(clientProvider, getInetSocketAddress(hosts[0])) {};
 		} else {
 			// noinspection unchecked
-			delegate = (T) new MultiNodeHostProvider(clientProvider, HttpHeaders::new, Arrays.stream(hosts)
+			delegate = (T) new MultiNodeHostProvider(clientProvider, Arrays.stream(hosts)
 					.map(ReactiveMockClientTestsUtils::getInetSocketAddress).toArray(InetSocketAddress[]::new)) {};
 		}
 
@@ -294,6 +294,11 @@ public class ReactiveMockClientTestsUtils {
 
 		@Override
 		public WebClientProvider withWebClientConfigurer(Function<WebClient, WebClient> webClientConfigurer) {
+			throw new UnsupportedOperationException("not implemented");
+		}
+
+		@Override
+		public WebClientProvider withRequestConfigurer(Consumer<WebClient.RequestHeadersSpec<?>> requestConfigurer) {
 			throw new UnsupportedOperationException("not implemented");
 		}
 


### PR DESCRIPTION
Moves the integration of the custom headers callback from the `ReactiveElasticsearchClient`to the underlying `WebClient`.

Closes #1794 