### PR TITLE
use scripted fields as ctor parameter, DocumentAdaptor improvements

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/KebabCaseFieldNamingStrategy.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/KebabCaseFieldNamingStrategy.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.core.mapping;
+
+import org.springframework.data.mapping.model.CamelCaseSplittingFieldNamingStrategy;
+
+/**
+ * @author Peter-Josef Meisch
+ * @since 4.3
+ */
+public class KebabCaseFieldNamingStrategy extends CamelCaseSplittingFieldNamingStrategy {
+	public KebabCaseFieldNamingStrategy() {
+		super("-");
+	}
+}


### PR DESCRIPTION
Java records and Kotlin data classes now work when they have a `@ScriptedField` as property.

Closes #1488 