### PR TITLE
Support collection parameters in @Query methods

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/StringQueryUtil.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/StringQueryUtil.java
@@ -15,8 +15,10 @@
  */
 package org.springframework.data.elasticsearch.repository.support;
 
+import java.util.Collection;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.data.repository.query.ParameterAccessor;
@@ -24,6 +26,7 @@ import org.springframework.util.NumberUtils;
 
 /**
  * @author Peter-Josef Meisch
+ * @author Niklas Herder
  */
 final public class StringQueryUtil {
 
@@ -53,6 +56,22 @@ final public class StringQueryUtil {
 		// noinspection ConstantConditions
 		if (parameter != null) {
 
+			parameterValue = convert(parameter);
+		}
+
+		return parameterValue;
+
+	}
+
+	private static String convert(Object parameter) {
+		if (Collection.class.isAssignableFrom(parameter.getClass())) {
+			Collection<?> collectionParam = (Collection<?>) parameter;
+			StringBuilder sb = new StringBuilder("[");
+			sb.append(collectionParam.stream().map(o -> "\"" + convert(o) + "\"").collect(Collectors.joining(",")));
+			sb.append("]");
+			return sb.toString();
+		} else {
+			String parameterValue = "null";
 			if (conversionService.canConvert(parameter.getClass(), String.class)) {
 				String converted = conversionService.convert(parameter, String.class);
 
@@ -62,11 +81,10 @@ final public class StringQueryUtil {
 			} else {
 				parameterValue = parameter.toString();
 			}
+
+			parameterValue = parameterValue.replaceAll("\"", Matcher.quoteReplacement("\\\""));
+			return parameterValue;
 		}
-
-		parameterValue = parameterValue.replaceAll("\"", Matcher.quoteReplacement("\\\""));
-		return parameterValue;
-
 	}
 
 }

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/StringQueryUtil.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/StringQueryUtil.java
@@ -67,7 +67,13 @@ final public class StringQueryUtil {
 		if (Collection.class.isAssignableFrom(parameter.getClass())) {
 			Collection<?> collectionParam = (Collection<?>) parameter;
 			StringBuilder sb = new StringBuilder("[");
-			sb.append(collectionParam.stream().map(o -> "\"" + convert(o) + "\"").collect(Collectors.joining(",")));
+			sb.append(collectionParam.stream().map(o -> {
+				if (o instanceof String) {
+					return "\"" + convert(o) + "\"";
+				} else {
+					return convert(o);
+				}
+			}).collect(Collectors.joining(",")));
 			sb.append("]");
 			return sb.toString();
 		} else {

--- a/src/test/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchStringQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchStringQueryUnitTests.java
@@ -98,6 +98,28 @@ public class ElasticsearchStringQueryUnitTests {
 	}
 
 	@Test // #1858
+	@DisplayName("should only quote String query parameters")
+	void shouldOnlyEscapeStringQueryParameters() throws Exception {
+		org.springframework.data.elasticsearch.core.query.Query query = createQuery("findByAge", Integer.valueOf(30));
+
+		assertThat(query).isInstanceOf(StringQuery.class);
+		assertThat(((StringQuery) query).getSource()).isEqualTo("{ 'bool' : { 'must' : { 'term' : { 'age' : 30 } } } }");
+
+	}
+
+	@Test // #1858
+	@DisplayName("should only quote String collection query parameters")
+	void shouldOnlyEscapeStringCollectionQueryParameters() throws Exception {
+		org.springframework.data.elasticsearch.core.query.Query query = createQuery("findByAgeIn",
+				new ArrayList<>(Arrays.asList(30, 35, 40)));
+
+		assertThat(query).isInstanceOf(StringQuery.class);
+		assertThat(((StringQuery) query).getSource())
+				.isEqualTo("{ 'bool' : { 'must' : { 'term' : { 'age' : [30,35,40] } } } }");
+
+	}
+
+	@Test // #1858
 	@DisplayName("should escape Strings in collection query parameters")
 	void shouldEscapeStringsInCollectionsQueryParameters() throws Exception {
 
@@ -132,6 +154,12 @@ public class ElasticsearchStringQueryUnitTests {
 
 	private interface SampleRepository extends Repository<Person, String> {
 
+		@Query("{ 'bool' : { 'must' : { 'term' : { 'age' : ?0 } } } }")
+		List<Person> findByAge(Integer age);
+
+		@Query("{ 'bool' : { 'must' : { 'term' : { 'age' : ?0 } } } }")
+		List<Person> findByAgeIn(ArrayList<Integer> age);
+
 		@Query("{ 'bool' : { 'must' : { 'term' : { 'name' : '?0' } } } }")
 		Person findByName(String name);
 
@@ -150,15 +178,26 @@ public class ElasticsearchStringQueryUnitTests {
 	 * @author Rizwan Idrees
 	 * @author Mohsin Husen
 	 * @author Artur Konczak
+   * @author Niklas Herder
 	 */
 
 	@Document(indexName = "test-index-person-query-unittest")
 	static class Person {
 
+		@Nullable public int age;
 		@Nullable @Id private String id;
 		@Nullable private String name;
 		@Nullable @Field(type = FieldType.Nested) private List<Car> car;
 		@Nullable @Field(type = FieldType.Nested, includeInParent = true) private List<Book> books;
+
+		@Nullable
+		public int getAge() {
+			return age;
+		}
+
+		public void setAge(int age) {
+			this.age = age;
+		}
 
 		@Nullable
 		public String getId() {

--- a/src/test/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchStringQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchStringQueryUnitTests.java
@@ -18,6 +18,7 @@ package org.springframework.data.elasticsearch.repository.query;
 import static org.assertj.core.api.Assertions.*;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -51,6 +52,7 @@ import org.springframework.lang.Nullable;
 /**
  * @author Christoph Strobl
  * @author Peter-Josef Meisch
+ * @author Niklas Herder
  */
 @ExtendWith(MockitoExtension.class)
 public class ElasticsearchStringQueryUnitTests {
@@ -95,7 +97,20 @@ public class ElasticsearchStringQueryUnitTests {
 				.isEqualTo("{\"bool\":{\"must\": [{\"match\": {\"prefix\": {\"name\" : \"hello \\\"Stranger\\\"\"}}]}}");
 	}
 
-	private org.springframework.data.elasticsearch.core.query.Query createQuery(String methodName, String... args)
+	@Test // #1858
+	@DisplayName("should escape Strings in collection query parameters")
+	void shouldEscapeStringsInCollectionsQueryParameters() throws Exception {
+
+		final List<String> another_string = Arrays.asList("hello \"Stranger\"", "Another string");
+		List<String> params = new ArrayList<>(another_string);
+		org.springframework.data.elasticsearch.core.query.Query query = createQuery("findByNameIn", params);
+
+		assertThat(query).isInstanceOf(StringQuery.class);
+		assertThat(((StringQuery) query).getSource()).isEqualTo(
+				"{ 'bool' : { 'must' : { 'terms' : { 'name' : [\"hello \\\"Stranger\\\"\",\"Another string\"] } } } }");
+	}
+
+	private org.springframework.data.elasticsearch.core.query.Query createQuery(String methodName, Object... args)
 			throws NoSuchMethodException {
 
 		Class<?>[] argTypes = Arrays.stream(args).map(Object::getClass).toArray(Class[]::new);
@@ -103,6 +118,7 @@ public class ElasticsearchStringQueryUnitTests {
 		ElasticsearchStringQuery elasticsearchStringQuery = queryForMethod(queryMethod);
 		return elasticsearchStringQuery.createQuery(new ElasticsearchParametersParameterAccessor(queryMethod, args));
 	}
+
 	private ElasticsearchStringQuery queryForMethod(ElasticsearchQueryMethod queryMethod) {
 		return new ElasticsearchStringQuery(queryMethod, operations, queryMethod.getAnnotatedQuery());
 	}
@@ -118,6 +134,9 @@ public class ElasticsearchStringQueryUnitTests {
 
 		@Query("{ 'bool' : { 'must' : { 'term' : { 'name' : '?0' } } } }")
 		Person findByName(String name);
+
+		@Query("{ 'bool' : { 'must' : { 'terms' : { 'name' : ?0 } } } }")
+		Person findByNameIn(ArrayList<String> names);
 
 		@Query(value = "name:(?0, ?11, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?0, ?1)")
 		Person findWithRepeatedPlaceholder(String arg0, String arg1, String arg2, String arg3, String arg4, String arg5,


### PR DESCRIPTION
This adds a test and fix so that collection parameters are supported and quoted correctly, at least for `Collection<String>`.

Previously the `StringQueryUtil` class would just call `.toString()` on the parameter and escape the `"` characters in the result, which would cause a syntax error in the query string.

This changes so that the class checks if the parameter is a `Collection` and if so starts a Json array and adds elements to it by calling `convert()` on each element.

Closes #1858 

- [x]  You have read the Spring Data contribution guidelines.
- [x]  There is a ticket in the bug tracker for the project in our issue tracker.
- [x]  You use the code formatters provided here and have them applied to your changes. Don’t submit any formatting related changes.
- [x]  You submit test cases (unit or integration tests) that back your changes.
- [x]  You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).