### PR TITLE
Change mapping of connectionRequestTimeout to ConnPool leaseTimeout

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/client/RestClients.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/RestClients.java
@@ -55,6 +55,7 @@ import org.springframework.util.Assert;
  * @author Huw Ayling-Miller
  * @author Henrique Amaral
  * @author Peter-Josef Meisch
+ * @author Nic Hines
  * @since 3.2
  */
 public final class RestClients {
@@ -105,15 +106,14 @@ public final class RestClients {
 			Duration connectTimeout = clientConfiguration.getConnectTimeout();
 
 			if (!connectTimeout.isNegative()) {
-
 				requestConfigBuilder.setConnectTimeout(Math.toIntExact(connectTimeout.toMillis()));
-				requestConfigBuilder.setConnectionRequestTimeout(Math.toIntExact(connectTimeout.toMillis()));
 			}
 
 			Duration timeout = clientConfiguration.getSocketTimeout();
 
 			if (!timeout.isNegative()) {
 				requestConfigBuilder.setSocketTimeout(Math.toIntExact(timeout.toMillis()));
+				requestConfigBuilder.setConnectionRequestTimeout(Math.toIntExact(connectTimeout.toMillis()));
 			}
 
 			clientBuilder.setDefaultRequestConfig(requestConfigBuilder.build());


### PR DESCRIPTION
Currently the RestClients.create() method sets the underlying RequestConfig connectTimeout and connectionRequestTimeout properties to the value of the ClientConfiguration connectTimeout property. 

The connectionRequestTimeout is used as the leaseTimeout parameter when calling the AbstractNIOConnPool lease method, which can lead to a "TimeoutException: Connection lease request time out" on an establised connection.  

The correct behavior is to use the sockerTimeout property for the leastTimeout parameter.