### PR TITLE
Improve client configuration callbacks

### DIFF
--- a/src/main/asciidoc/reference/elasticsearch-clients.adoc
+++ b/src/main/asciidoc/reference/elasticsearch-clients.adoc
@@ -166,15 +166,15 @@ ClientConfiguration clientConfiguration = ClientConfiguration.builder()
     return headers;
   })
   .withClientConfigurer(                                                <.>
-    (ReactiveRestClients.WebClientConfigurationCallback) webClient -> {
+    ReactiveRestClients.WebClientConfigurationCallback.from(webClient -> {
   	  // ...
       return webClient;
-  	})
+  	}))
   .withClientConfigurer(                                                <.>
-    (RestClients.RestClientConfigurationCallback) clientBuilder -> {
+    RestClients.RestClientConfigurationCallback.from(clientBuilder -> {
   	  // ...
       return clientBuilder;
-  	})
+  	}))
   . // ... other options
   .build();
 

--- a/src/main/java/org/springframework/data/elasticsearch/client/ClientConfiguration.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/ClientConfiguration.java
@@ -176,16 +176,16 @@ public interface ClientConfiguration {
 	/**
 	 * @return the Rest Client configuration callback.
 	 * @since 4.2
-	 * @deprecated since 4.3 use {@link #getClientConfigurer()}
+	 * @deprecated since 4.3 use {@link #getClientConfigurers()}
 	 */
 	@Deprecated
 	HttpClientConfigCallback getHttpClientConfigurer();
 
 	/**
-	 * @return the client configuration callback
+	 * @return the client configuration callbacks
 	 * @since 4.3
 	 */
-	<T> ClientConfigurationCallback<T> getClientConfigurer();
+	<T> List<ClientConfigurationCallback<?>> getClientConfigurers();
 
 	/**
 	 * @return the supplier for custom headers.

--- a/src/main/java/org/springframework/data/elasticsearch/client/ClientConfigurationBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/ClientConfigurationBuilder.java
@@ -64,7 +64,7 @@ class ClientConfigurationBuilder
 	private Function<WebClient, WebClient> webClientConfigurer = Function.identity();
 	private Supplier<HttpHeaders> headersSupplier = () -> HttpHeaders.EMPTY;
 	@Deprecated private HttpClientConfigCallback httpClientConfigurer = httpClientBuilder -> httpClientBuilder;
-	private ClientConfiguration.ClientConfigurationCallback<?> clientConfigurer = t -> t;
+	private List<ClientConfiguration.ClientConfigurationCallback<?>> clientConfigurers = new ArrayList<>();
 
 	/*
 	 * (non-Javadoc)
@@ -208,7 +208,7 @@ class ClientConfigurationBuilder
 		Assert.notNull(webClientConfigurer, "webClientConfigurer must not be null");
 
 		this.webClientConfigurer = webClientConfigurer;
-		this.clientConfigurer = ReactiveRestClients.WebClientConfigurationCallback.from(webClientConfigurer);
+		this.clientConfigurers.add(ReactiveRestClients.WebClientConfigurationCallback.from(webClientConfigurer));
 		return this;
 	}
 
@@ -218,7 +218,8 @@ class ClientConfigurationBuilder
 		Assert.notNull(httpClientConfigurer, "httpClientConfigurer must not be null");
 
 		this.httpClientConfigurer = httpClientConfigurer;
-		this.clientConfigurer = RestClients.RestClientConfigurationCallback.from(httpClientConfigurer::customizeHttpClient);
+		this.clientConfigurers
+				.add(RestClients.RestClientConfigurationCallback.from(httpClientConfigurer::customizeHttpClient));
 		return this;
 	}
 
@@ -228,7 +229,7 @@ class ClientConfigurationBuilder
 
 		Assert.notNull(clientConfigurer, "clientConfigurer must not be null");
 
-		this.clientConfigurer = clientConfigurer;
+		this.clientConfigurers.add(clientConfigurer);
 		return this;
 	}
 
@@ -256,7 +257,7 @@ class ClientConfigurationBuilder
 		}
 
 		return new DefaultClientConfiguration(hosts, headers, useSsl, sslContext, soTimeout, connectTimeout, pathPrefix,
-				hostnameVerifier, proxy, webClientConfigurer, httpClientConfigurer, clientConfigurer, headersSupplier);
+				hostnameVerifier, proxy, webClientConfigurer, httpClientConfigurer, clientConfigurers, headersSupplier);
 	}
 
 	private static InetSocketAddress parse(String hostAndPort) {

--- a/src/main/java/org/springframework/data/elasticsearch/client/ClientConfigurationBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/ClientConfigurationBuilder.java
@@ -208,9 +208,7 @@ class ClientConfigurationBuilder
 		Assert.notNull(webClientConfigurer, "webClientConfigurer must not be null");
 
 		this.webClientConfigurer = webClientConfigurer;
-		// noinspection NullableProblems
-		this.clientConfigurer = (ReactiveRestClients.WebClientConfigurationCallback) webClientConfigurer::apply;
-
+		this.clientConfigurer = ReactiveRestClients.WebClientConfigurationCallback.from(webClientConfigurer);
 		return this;
 	}
 
@@ -220,9 +218,7 @@ class ClientConfigurationBuilder
 		Assert.notNull(httpClientConfigurer, "httpClientConfigurer must not be null");
 
 		this.httpClientConfigurer = httpClientConfigurer;
-		// noinspection NullableProblems
-		this.clientConfigurer = (RestClients.RestClientConfigurationCallback) httpClientConfigurer::customizeHttpClient;
-
+		this.clientConfigurer = RestClients.RestClientConfigurationCallback.from(httpClientConfigurer::customizeHttpClient);
 		return this;
 	}
 

--- a/src/main/java/org/springframework/data/elasticsearch/client/DefaultClientConfiguration.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/DefaultClientConfiguration.java
@@ -55,13 +55,13 @@ class DefaultClientConfiguration implements ClientConfiguration {
 	private final Function<WebClient, WebClient> webClientConfigurer;
 	private final HttpClientConfigCallback httpClientConfigurer;
 	private final Supplier<HttpHeaders> headersSupplier;
-	private final ClientConfigurationCallback<?> clientConfigurer;
+	private final List<ClientConfigurationCallback<?>> clientConfigurers;
 
 	DefaultClientConfiguration(List<InetSocketAddress> hosts, HttpHeaders headers, boolean useSsl,
 			@Nullable SSLContext sslContext, Duration soTimeout, Duration connectTimeout, @Nullable String pathPrefix,
 			@Nullable HostnameVerifier hostnameVerifier, @Nullable String proxy,
 			Function<WebClient, WebClient> webClientConfigurer, HttpClientConfigCallback httpClientConfigurer,
-			ClientConfigurationCallback<?> clientConfigurer, Supplier<HttpHeaders> headersSupplier) {
+			List<ClientConfigurationCallback<?>> clientConfigurers, Supplier<HttpHeaders> headersSupplier) {
 
 		this.hosts = Collections.unmodifiableList(new ArrayList<>(hosts));
 		this.headers = new HttpHeaders(headers);
@@ -74,7 +74,7 @@ class DefaultClientConfiguration implements ClientConfiguration {
 		this.proxy = proxy;
 		this.webClientConfigurer = webClientConfigurer;
 		this.httpClientConfigurer = httpClientConfigurer;
-		this.clientConfigurer = clientConfigurer;
+		this.clientConfigurers = clientConfigurers;
 		this.headersSupplier = headersSupplier;
 	}
 
@@ -136,8 +136,8 @@ class DefaultClientConfiguration implements ClientConfiguration {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public <T> ClientConfigurationCallback<T> getClientConfigurer() {
-		return (ClientConfigurationCallback<T>) clientConfigurer;
+	public <T> List<ClientConfigurationCallback<?>> getClientConfigurers() {
+		return clientConfigurers;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/elasticsearch/client/RestClients.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/RestClients.java
@@ -22,6 +22,7 @@ import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -242,5 +243,15 @@ public final class RestClients {
 	 * @since 4.3
 	 */
 	public interface RestClientConfigurationCallback
-			extends ClientConfiguration.ClientConfigurationCallback<HttpAsyncClientBuilder> {}
+			extends ClientConfiguration.ClientConfigurationCallback<HttpAsyncClientBuilder> {
+
+		static RestClientConfigurationCallback from(
+				Function<HttpAsyncClientBuilder, HttpAsyncClientBuilder> clientBuilderCallback) {
+
+			Assert.notNull(clientBuilderCallback, "clientBuilderCallback must not be null");
+
+			// noinspection NullableProblems
+			return clientBuilderCallback::apply;
+		}
+	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/client/RestClients.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/RestClients.java
@@ -121,7 +121,13 @@ public final class RestClients {
 
 			clientConfiguration.getProxy().map(HttpHost::create).ifPresent(clientBuilder::setProxy);
 
-			clientBuilder = clientConfiguration.<HttpAsyncClientBuilder> getClientConfigurer().configure(clientBuilder);
+			for (ClientConfiguration.ClientConfigurationCallback<?> clientConfigurer : clientConfiguration
+					.getClientConfigurers()) {
+				if (clientConfigurer instanceof RestClientConfigurationCallback) {
+					RestClientConfigurationCallback restClientConfigurationCallback = (RestClientConfigurationCallback) clientConfigurer;
+					clientBuilder = restClientConfigurationCallback.configure(clientBuilder);
+				}
+			}
 
 			return clientBuilder;
 		});

--- a/src/main/java/org/springframework/data/elasticsearch/client/reactive/DefaultReactiveElasticsearchClient.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/reactive/DefaultReactiveElasticsearchClient.java
@@ -288,9 +288,21 @@ public class DefaultReactiveElasticsearchClient implements ReactiveElasticsearch
 			provider = provider.withPathPrefix(clientConfiguration.getPathPrefix());
 		}
 
+		Function<WebClient, WebClient> webClientConfigurer = webClient -> {
+			for (ClientConfiguration.ClientConfigurationCallback<?> clientConfigurer : clientConfiguration
+					.getClientConfigurers()) {
+
+				if (clientConfigurer instanceof ReactiveRestClients.WebClientConfigurationCallback) {
+					ReactiveRestClients.WebClientConfigurationCallback webClientConfigurationCallback = (ReactiveRestClients.WebClientConfigurationCallback) clientConfigurer;
+					webClient = webClientConfigurationCallback.configure(webClient);
+				}
+			}
+			return webClient;
+		};
+
 		provider = provider //
 				.withDefaultHeaders(clientConfiguration.getDefaultHeaders()) //
-				.withWebClientConfigurer(clientConfiguration.<WebClient> getClientConfigurer()::configure) //
+				.withWebClientConfigurer(webClientConfigurer) //
 				.withRequestConfigurer(requestHeadersSpec -> requestHeadersSpec.headers(httpHeaders -> {
 					HttpHeaders suppliedHeaders = clientConfiguration.getHeadersSupplier().get();
 

--- a/src/main/java/org/springframework/data/elasticsearch/client/reactive/ReactiveRestClients.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/reactive/ReactiveRestClients.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.elasticsearch.client.reactive;
 
+import java.util.function.Function;
+
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
 import org.springframework.util.Assert;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -69,5 +71,14 @@ public final class ReactiveRestClients {
 	 *
 	 * @since 4.3
 	 */
-	public interface WebClientConfigurationCallback extends ClientConfiguration.ClientConfigurationCallback<WebClient> {}
+	public interface WebClientConfigurationCallback extends ClientConfiguration.ClientConfigurationCallback<WebClient> {
+
+		static WebClientConfigurationCallback from(Function<WebClient, WebClient> webClientCallback) {
+
+			Assert.notNull(webClientCallback, "webClientCallback must not be null");
+
+			// noinspection NullableProblems
+			return webClientCallback::apply;
+		}
+	}
 }

--- a/src/test/java/org/springframework/data/elasticsearch/client/ClientConfigurationUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/client/ClientConfigurationUnitTests.java
@@ -30,6 +30,7 @@ import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.elasticsearch.client.reactive.ReactiveRestClients;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -172,10 +173,10 @@ public class ClientConfigurationUnitTests {
 				}) //
 				.build();
 
-		ClientConfiguration.ClientConfigurationCallback<HttpAsyncClientBuilder> clientConfigurer = clientConfiguration
-				.getClientConfigurer();
+		ClientConfiguration.ClientConfigurationCallback<?> clientConfigurer = clientConfiguration.getClientConfigurers()
+				.get(0);
 
-		clientConfigurer.configure(HttpAsyncClientBuilder.create());
+		((RestClients.RestClientConfigurationCallback) clientConfigurer).configure(HttpAsyncClientBuilder.create());
 		assertThat(callCounter.get()).isEqualTo(1);
 	}
 
@@ -193,10 +194,10 @@ public class ClientConfigurationUnitTests {
 				}) //
 				.build();
 
-		ClientConfiguration.ClientConfigurationCallback<WebClient> clientConfigurer = clientConfiguration
-				.getClientConfigurer();
+		ClientConfiguration.ClientConfigurationCallback<?> clientConfigurer = clientConfiguration.getClientConfigurers()
+				.get(0);
 
-		clientConfigurer.configure(WebClient.builder().build());
+		((ReactiveRestClients.WebClientConfigurationCallback) clientConfigurer).configure(WebClient.builder().build());
 		assertThat(callCounter.get()).isEqualTo(1);
 	}
 
@@ -214,10 +215,10 @@ public class ClientConfigurationUnitTests {
 				}) //
 				.build();
 
-		ClientConfiguration.ClientConfigurationCallback<Object> clientConfigurer = clientConfiguration
-				.getClientConfigurer();
+		ClientConfiguration.ClientConfigurationCallback<?> clientConfigurer = clientConfiguration.getClientConfigurers()
+				.get(0);
 
-		clientConfigurer.configure(new Object());
+		((ClientConfiguration.ClientConfigurationCallback<Object>) clientConfigurer).configure(new Object());
 		assertThat(callCounter.get()).isEqualTo(1);
 	}
 

--- a/src/test/java/org/springframework/data/elasticsearch/client/RestClientsTest.java
+++ b/src/test/java/org/springframework/data/elasticsearch/client/RestClientsTest.java
@@ -118,15 +118,16 @@ public class RestClientsTest {
 					});
 
 			if (clientUnderTestFactory instanceof RestClientUnderTestFactory) {
-				configurationBuilder.withClientConfigurer((RestClients.RestClientConfigurationCallback) httpClientBuilder -> {
-					clientConfigurerCount.incrementAndGet();
-					return httpClientBuilder;
-				});
+				configurationBuilder
+						.withClientConfigurer(RestClients.RestClientConfigurationCallback.from(httpClientBuilder -> {
+							clientConfigurerCount.incrementAndGet();
+							return httpClientBuilder;
+						}));
 			} else if (clientUnderTestFactory instanceof ReactiveElasticsearchClientUnderTestFactory) {
-				configurationBuilder.withClientConfigurer((ReactiveRestClients.WebClientConfigurationCallback) webClient -> {
+				configurationBuilder.withClientConfigurer(ReactiveRestClients.WebClientConfigurationCallback.from(webClient -> {
 					clientConfigurerCount.incrementAndGet();
 					return webClient;
-				});
+				}));
 			}
 
 			ClientConfiguration clientConfiguration = configurationBuilder.build();


### PR DESCRIPTION
Client configuration: 

```java
        @Bean
	public ClientConfiguration clientConfiguration() {
		return ClientConfiguration.builder() //
			.connectedTo("localhost:9200") //
			.withClientConfigurer(ReactiveRestClients.WebClientConfigurationCallback.from(webClient -> {
				// will be called when a reactive client is created
				return webClient;
			}))
			.withClientConfigurer(ReactiveRestClients.WebClientConfigurationCallback.from(webClient -> {
				// will also be called when a reactive client is created
				return webClient;
			}))
			.withClientConfigurer(RestClients.RestClientConfigurationCallback.from(clientBuilder -> {
				// will be called when an imperative client is created
				return clientBuilder;
			}))
			.build();
	}
```

Closes #1929 