### PR TITLE
Expose a public method to add logging Interceptor

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/backend/elasticsearch7/client/RestClients.java
+++ b/src/main/java/org/springframework/data/elasticsearch/backend/elasticsearch7/client/RestClients.java
@@ -99,7 +99,9 @@ public final class RestClients {
 			clientConfiguration.getHostNameVerifier().ifPresent(clientBuilder::setSSLHostnameVerifier);
 			clientBuilder.addInterceptorLast(new CustomHeaderInjector(clientConfiguration.getHeadersSupplier()));
 
-			addLoggingInterceptor(clientBuilder);
+			if (ClientLogger.isEnabled()) {
+				addLoggingInterceptor(clientBuilder);
+			}
 
 			Builder requestConfigBuilder = RequestConfig.custom();
 			Duration connectTimeout = clientConfiguration.getConnectTimeout();


### PR DESCRIPTION
changes
1. Expose a public method to add logging Interceptor.

For example, when work with spring boot we can just add a customizer call this method

```java
import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
import org.elasticsearch.client.RestClientBuilder;
import org.springframework.boot.autoconfigure.elasticsearch.RestClientBuilderCustomizer;
import org.springframework.data.elasticsearch.client.RestClients;
import org.springframework.stereotype.Component;

@Component
public class RestClientBuilderLoggingCustomizer implements RestClientBuilderCustomizer {

    @Override
    public void customize(RestClientBuilder builder) {

    }

    @Override
    public void customize(HttpAsyncClientBuilder builder) {
        RestClients.addLoggingInterceptor(builder);
    }
}
```

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] **There is a ticket in the bug tracker for the project in our [issue tracker](https://github.
  com/spring-projects/spring-data-elasticsearch/issues)**. Add the issue number to the _Closes #issue-number_ line below
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Closes #2012
