### PR TITLE
Feature/query annotation source filter

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/annotations/Query.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/Query.java
@@ -27,6 +27,7 @@ import java.util.Collection;
  * @author Mohsin Husen
  * @author Peter-Josef Meisch
  * @author Steven Pearce
+ * @author Alexander Torres
  */
 
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/Query.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/Query.java
@@ -17,6 +17,8 @@ package org.springframework.data.elasticsearch.annotations;
 
 import org.springframework.data.annotation.QueryAnnotation;
 import java.lang.annotation.*;
+import java.util.ArrayList;
+import java.util.Collection;
 
 /**
  * Query
@@ -44,6 +46,9 @@ public @interface Query {
 	 * @deprecated since 4.2, not implemented and used anywhere
 	 */
 	String name() default "";
+
+	String includes() default "";
+	String excludes() default "";
 
 	/**
 	 * Returns whether the query defined should be executed as count projection.

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchQueryMethod.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchQueryMethod.java
@@ -50,6 +50,7 @@ import org.springframework.util.ClassUtils;
  * @author Mark Paluch
  * @author Christoph Strobl
  * @author Peter-Josef Meisch
+ * @author Alexander Torres
  */
 public class ElasticsearchQueryMethod extends QueryMethod {
 
@@ -121,6 +122,22 @@ public class ElasticsearchQueryMethod extends QueryMethod {
 		return new HighlightQuery(
 				org.springframework.data.elasticsearch.core.query.highlight.Highlight.of(highlightAnnotation),
 				getDomainClass());
+	}
+
+	public boolean hasIncludes() {
+		return hasAnnotatedQuery() && !queryAnnotation.includes().equals("");
+	}
+
+	public boolean hasExcludes() {
+		return hasAnnotatedQuery() && !queryAnnotation.excludes().equals("");
+	}
+
+	public String getIncludes() {
+		return queryAnnotation.includes();
+	}
+
+	public String getExcludes() {
+		return queryAnnotation.excludes();
 	}
 
 	/**


### PR DESCRIPTION
This is the implementation of adding a source filter (`includes` and/or `excludes`) to the `Query` annotation. This will allow users to filter fields on an ad-hoc basis only using the additional `includes` and `excludes` arguments in `Query`. A similar approach can be used for solving #2062 to add aggregations.

Relates to #2062 
