### PR TITLE
Feature/query annotation source filter and aggs

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/annotations/Query.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/Query.java
@@ -27,6 +27,7 @@ import java.util.Collection;
  * @author Mohsin Husen
  * @author Peter-Josef Meisch
  * @author Steven Pearce
+ * @author Alexander Torres
  */
 
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/Query.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/Query.java
@@ -47,7 +47,7 @@ public @interface Query {
 	 * @deprecated since 4.2, not implemented and used anywhere
 	 */
 	String name() default "";
-
+	String valueParams() default "";
 	String includes() default "";
 	String excludes() default "";
 

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/Query.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/Query.java
@@ -17,6 +17,8 @@ package org.springframework.data.elasticsearch.annotations;
 
 import org.springframework.data.annotation.QueryAnnotation;
 import java.lang.annotation.*;
+import java.util.ArrayList;
+import java.util.Collection;
 
 /**
  * Query
@@ -44,6 +46,9 @@ public @interface Query {
 	 * @deprecated since 4.2, not implemented and used anywhere
 	 */
 	String name() default "";
+
+	String includes() default "";
+	String excludes() default "";
 
 	/**
 	 * Returns whether the query defined should be executed as count projection.

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/Query.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/Query.java
@@ -17,8 +17,6 @@ package org.springframework.data.elasticsearch.annotations;
 
 import org.springframework.data.annotation.QueryAnnotation;
 import java.lang.annotation.*;
-import java.util.ArrayList;
-import java.util.Collection;
 
 /**
  * Query
@@ -48,8 +46,6 @@ public @interface Query {
 	 */
 	String name() default "";
 	String valueParams() default "";
-	String includes() default "";
-	String excludes() default "";
 
 	/**
 	 * Returns whether the query defined should be executed as count projection.

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/BaseQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/BaseQuery.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.elasticsearch.core.RuntimeField;
@@ -43,6 +44,7 @@ import org.springframework.util.Assert;
  * @author Farid Azaza
  * @author Peter-Josef Meisch
  * @author Peer Mueller
+ * @author Alexander Torres
  */
 public class BaseQuery implements Query {
 
@@ -69,6 +71,19 @@ public class BaseQuery implements Query {
 	@Nullable protected Boolean requestCache;
 	private List<IdWithRouting> idsWithRouting = Collections.emptyList();
 	private final List<RuntimeField> runtimeFields = new ArrayList<>();
+	@Nullable
+	private SearchSourceBuilder searchSourceBuilder;
+
+	@Override
+	@Nullable
+	public SearchSourceBuilder getSearchSourceBuilder() {
+		return searchSourceBuilder;
+	}
+
+	@Override
+	public void setSearchSourceBuilder(SearchSourceBuilder searchSourceBuilder) {
+		this.searchSourceBuilder = searchSourceBuilder;
+	}
 
 	@Override
 	@Nullable

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/FetchSourceFilterBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/FetchSourceFilterBuilder.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.data.elasticsearch.core.query;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.springframework.lang.Nullable;
 
 /**
@@ -22,11 +23,22 @@ import org.springframework.lang.Nullable;
  *
  * @Author Jon Tsiros
  * @author Peter-Josef Meisch
+ * @author Alexander Torres
  */
 public class FetchSourceFilterBuilder {
 
 	@Nullable private String[] includes;
 	@Nullable private String[] excludes;
+
+	@Nullable
+	public String[] getExcludes() {
+		return excludes;
+	}
+
+	@Nullable
+	public String[] getIncludes() {
+		return includes;
+	}
 
 	public FetchSourceFilterBuilder withIncludes(String... includes) {
 		this.includes = includes;

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/Query.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/Query.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -41,6 +42,7 @@ import org.springframework.util.Assert;
  * @author Farid Azaza
  * @author Peter-Josef Meisch
  * @author Peer Mueller
+ * @author Alexander Torres
  */
 public interface Query {
 
@@ -440,4 +442,9 @@ public interface Query {
 			return routing;
 		}
 	}
+
+	@Nullable
+	SearchSourceBuilder getSearchSourceBuilder();
+
+	void setSearchSourceBuilder(SearchSourceBuilder searchSourceBuilder);
 }

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchQueryMethod.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchQueryMethod.java
@@ -21,8 +21,6 @@ import java.util.Collection;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.elasticsearch.annotations.Highlight;
@@ -140,9 +138,8 @@ public class ElasticsearchQueryMethod extends QueryMethod {
 	 * @return the additional configuration for querying
 	 * @throws JsonProcessingException if the json or elasticsearch argument is malformed
 	 */
-	public JsonNode getValueParams() throws JsonProcessingException {
-		ObjectMapper objectMapper = new ObjectMapper();
-		return objectMapper.readValue(queryAnnotation.valueParams(), JsonNode.class);
+	public String getValueParams() throws JsonProcessingException {
+		return queryAnnotation.valueParams();
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchQueryMethod.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchQueryMethod.java
@@ -20,6 +20,9 @@ import java.lang.reflect.ParameterizedType;
 import java.util.Collection;
 import java.util.stream.Stream;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.elasticsearch.annotations.Highlight;
@@ -122,6 +125,24 @@ public class ElasticsearchQueryMethod extends QueryMethod {
 		return new HighlightQuery(
 				org.springframework.data.elasticsearch.core.query.highlight.Highlight.of(highlightAnnotation),
 				getDomainClass());
+	}
+
+	/**
+	 * @since 4.4
+	 * @return if the method has additional configuration for querying
+	 */
+	public boolean hasValueParams() {
+		return hasAnnotatedQuery() && !queryAnnotation.valueParams().equals("");
+	}
+
+	/**
+	 * @since 4.4
+	 * @return the additional configuration for querying
+	 * @throws JsonProcessingException if the json or elasticsearch argument is malformed
+	 */
+	public JsonNode getValueParams() throws JsonProcessingException {
+		ObjectMapper objectMapper = new ObjectMapper();
+		return objectMapper.readValue(queryAnnotation.valueParams(), JsonNode.class);
 	}
 
 	public boolean hasIncludes() {

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchQueryMethod.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchQueryMethod.java
@@ -50,6 +50,7 @@ import org.springframework.util.ClassUtils;
  * @author Mark Paluch
  * @author Christoph Strobl
  * @author Peter-Josef Meisch
+ * @author Alexander Torres
  */
 public class ElasticsearchQueryMethod extends QueryMethod {
 
@@ -121,6 +122,22 @@ public class ElasticsearchQueryMethod extends QueryMethod {
 		return new HighlightQuery(
 				org.springframework.data.elasticsearch.core.query.highlight.Highlight.of(highlightAnnotation),
 				getDomainClass());
+	}
+
+	public boolean hasIncludes() {
+		return hasAnnotatedQuery() && !queryAnnotation.includes().equals("");
+	}
+
+	public boolean hasExcludes() {
+		return hasAnnotatedQuery() && !queryAnnotation.excludes().equals("");
+	}
+
+	public String getIncludes() {
+		return queryAnnotation.includes();
+	}
+
+	public String getExcludes() {
+		return queryAnnotation.excludes();
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchQueryMethod.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchQueryMethod.java
@@ -145,22 +145,6 @@ public class ElasticsearchQueryMethod extends QueryMethod {
 		return objectMapper.readValue(queryAnnotation.valueParams(), JsonNode.class);
 	}
 
-	public boolean hasIncludes() {
-		return hasAnnotatedQuery() && !queryAnnotation.includes().equals("");
-	}
-
-	public boolean hasExcludes() {
-		return hasAnnotatedQuery() && !queryAnnotation.excludes().equals("");
-	}
-
-	public String getIncludes() {
-		return queryAnnotation.includes();
-	}
-
-	public String getExcludes() {
-		return queryAnnotation.excludes();
-	}
-
 	/**
 	 * @return the {@link ElasticsearchEntityMetadata} for the query methods {@link #getReturnedObjectType() return type}.
 	 * @since 3.2

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchStringQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchStringQuery.java
@@ -54,22 +54,12 @@ public class ElasticsearchStringQuery extends AbstractElasticsearchRepositoryQue
 	private String query;
 	@Nullable
 	private JsonNode valueParams;
-	private String includes;
-	private String excludes;
-	private Boolean hasSourceFilter = false;
 
 	public ElasticsearchStringQuery(ElasticsearchQueryMethod queryMethod, ElasticsearchOperations elasticsearchOperations,
 			String query) {
 		super(queryMethod, elasticsearchOperations);
 		Assert.notNull(query, "Query cannot be empty");
 		this.query = query;
-		this.includes = "";
-		this.excludes = "";
-		if (queryMethod.hasIncludes() || queryMethod.hasExcludes()) {
-			this.includes = queryMethod.getIncludes();
-			this.excludes = queryMethod.getExcludes();
-			this.hasSourceFilter = true;
-		}
 
 		if (queryMethod.hasValueParams()) {
 			try {
@@ -98,10 +88,6 @@ public class ElasticsearchStringQuery extends AbstractElasticsearchRepositoryQue
 
 		if (queryMethod.hasAnnotatedHighlight()) {
 			stringQuery.setHighlightQuery(queryMethod.getAnnotatedHighlightQuery());
-		}
-
-		if (hasSourceFilter) {
-			stringQuery.addSourceFilter(createSourceFilter(accessor));
 		}
 
 		if (valueParams != null) {
@@ -245,24 +231,4 @@ public class ElasticsearchStringQuery extends AbstractElasticsearchRepositoryQue
 				.replacePlaceholders(this.query, parameterAccessor);
 		return new StringQuery(queryString);
 	}
-
-	protected SourceFilter createSourceFilter(ParametersParameterAccessor parameterAccessor) {
-		StringQueryUtil stringQueryUtil = new StringQueryUtil(elasticsearchOperations.getElasticsearchConverter().getConversionService());
-
-		String[] includeList = new String[0];
-		String[] excludeList = new String[0];
-
-		final String sourceFilterDelim = ",";
-		if (includes.length() != 0) {
-			String includeFilter = stringQueryUtil.replacePlaceholders(includes, parameterAccessor);
-			includeList = includeFilter.split(sourceFilterDelim);
-		}
-		if (excludes.length() != 0) {
-			String excludeFilter = stringQueryUtil.replacePlaceholders(excludes, parameterAccessor);
-			excludeList = excludeFilter.split(sourceFilterDelim);
-		}
-
-		return new FetchSourceFilterBuilder().withExcludes(excludeList).withIncludes(includeList).build();
-	}
-
 }

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/StringQueryUtil.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/StringQueryUtil.java
@@ -27,6 +27,7 @@ import org.springframework.util.NumberUtils;
 /**
  * @author Peter-Josef Meisch
  * @author Niklas Herder
+ * @author Alexander Torres
  */
 final public class StringQueryUtil {
 
@@ -38,6 +39,12 @@ final public class StringQueryUtil {
 		this.conversionService = conversionService;
 	}
 
+	/**
+	 * @param input
+	 * @param accessor
+	 * @return
+	 * @since 4.4
+	 */
 	public String replacePlaceholders(String input, ParameterAccessor accessor) {
 
 		Matcher matcher = PARAMETER_PLACEHOLDER.matcher(input);
@@ -46,7 +53,16 @@ final public class StringQueryUtil {
 
 			String placeholder = Pattern.quote(matcher.group()) + "(?!\\d+)";
 			int index = NumberUtils.parseNumber(matcher.group(1), Integer.class);
-			result = result.replaceAll(placeholder, Matcher.quoteReplacement(getParameterWithIndex(accessor, index)));
+			String parameter = getParameterWithIndex(accessor, index);
+			String replacement = Matcher.quoteReplacement(parameter);
+
+			/**
+			 * Without this condition, interpolation fails for collections
+			 */
+			if (replacement.charAt(0) == '[' && replacement.charAt(replacement.length() - 1) == ']') {
+				placeholder = "\"" + placeholder + "\"";
+			}
+			result = result.replaceAll(placeholder, replacement);
 		}
 		return result;
 	}

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/StringQueryUtil.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/StringQueryUtil.java
@@ -27,7 +27,6 @@ import org.springframework.util.NumberUtils;
 /**
  * @author Peter-Josef Meisch
  * @author Niklas Herder
- * @author Alexander Torres
  */
 final public class StringQueryUtil {
 
@@ -56,12 +55,6 @@ final public class StringQueryUtil {
 			String parameter = getParameterWithIndex(accessor, index);
 			String replacement = Matcher.quoteReplacement(parameter);
 
-			/**
-			 * Without this condition, interpolation fails for collections
-			 */
-			if (replacement.charAt(0) == '[' && replacement.charAt(replacement.length() - 1) == ']') {
-				placeholder = "\"" + placeholder + "\"";
-			}
 			result = result.replaceAll(placeholder, replacement);
 		}
 		return result;

--- a/src/test/java/org/springframework/data/elasticsearch/repositories/custommethod/CustomMethodRepositoryBaseTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repositories/custommethod/CustomMethodRepositoryBaseTests.java
@@ -1972,7 +1972,7 @@ public abstract class CustomMethodRepositoryBaseTests {
 				value = "{\"bool\": {\"must\": [{\"term\": {\"type\": \"?0\"}}]}}",
 				valueParams = "{" +
 						"\"_source\": {" +
-							"\"excludes\": \"?1\""  +
+							"\"excludes\": ?1"  +
 						"}" +
 					"}"
 

--- a/src/test/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchStringQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchStringQueryUnitTests.java
@@ -141,27 +141,6 @@ public class ElasticsearchStringQueryUnitTests extends ElasticsearchStringQueryU
 		return elasticsearchStringQuery.createQuery(new ElasticsearchParametersParameterAccessor(queryMethod, args));
 	}
 
-	@Test // #2062
-	@DisplayName("create source filter for query")
-	void shouldCreateSourceFilter() {
-		ElasticsearchQueryMethod queryMethod = mock(ElasticsearchQueryMethod.class);
-		when(queryMethod.hasIncludes()).thenReturn(true);
-		when(queryMethod.getIncludes()).thenReturn("?0");
-		when(queryMethod.getExcludes()).thenReturn("?1");
-
-		ElasticsearchStringQuery elasticsearchStringQuery = spy(new ElasticsearchStringQuery(
-				queryMethod,
-				operations,
-				"{\"match_all\": {}}"
-		));
-		ParametersParameterAccessor parameterAccessor = mock(ParametersParameterAccessor.class);
-		when(parameterAccessor.getBindableValue(0)).thenReturn("foo");
-		when(parameterAccessor.getBindableValue(1)).thenReturn("bar");
-		SourceFilter resp = elasticsearchStringQuery.createSourceFilter(parameterAccessor);
-		assertThat(resp.getIncludes()).isEqualTo(new String[]{"foo"});
-		assertThat(resp.getExcludes()).isEqualTo(new String[]{"bar"});
-	}
-
 	@Test // #1866
 	@DisplayName("should use converter on parameters")
 	void shouldUseConverterOnParameters() throws NoSuchMethodException {


### PR DESCRIPTION
These are improvements to the `@Query` annotation that allow a user two additional parameters for querying: `_source` and `aggs`. These are specified through a new parameter `valueParams` which takes a json string as input and is parsed downstream.

Solves issue found on [this thread](https://stackoverflow.com/questions/71278796/how-exclude-fields-from-source-with-spring-data-elasticsearch).
Relates to #2062 
Closes #2146 
