### PR TITLE
SourceFilters Annotation.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/annotations/SourceFilters.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/SourceFilters.java
@@ -21,7 +21,8 @@ import java.lang.annotation.*;
 
 /**
  * SourceFilters
- *
+ * Use this annotation to introduce a _source filter on your elasticsearch query. You may also use parameter interpolation
+ * (i.e. {@literal @SourceFilters(includes = ?0, excludes = "[\"field1\"]") SearchHits filteredSearch(String includesArray)}
  * @author Alexander Torres
  * @since 4.4
  */
@@ -31,13 +32,15 @@ import java.lang.annotation.*;
 @QueryAnnotation
 public @interface SourceFilters {
     /**
-     * Fields to include in the query search hits. (e.g. ["field1", "field2"])
+     * Fields to include in the query search hits.
+     * (e.g. ["field1", "field2"] or ?1)
      * @return
      */
     String includes() default "";
 
     /**
-     * Fields to exclude from the query search hits. (e.g. ["field1", "field2"])
+     * Fields to exclude from the query search hits.
+     * (e.g. ["field1", "field2"] or ?1)
      * @return
      */
     String excludes() default "";

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/SourceFilters.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/SourceFilters.java
@@ -23,6 +23,7 @@ import java.lang.annotation.*;
  * SourceFilters
  *
  * @author Alexander Torres
+ * @since 4.4
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/SourceFilters.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/SourceFilters.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.data.elasticsearch.annotations;
 
 import org.springframework.data.annotation.QueryAnnotation;

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/SourceFilters.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/SourceFilters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/SourceFilters.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/SourceFilters.java
@@ -1,0 +1,28 @@
+package org.springframework.data.elasticsearch.annotations;
+
+import org.springframework.data.annotation.QueryAnnotation;
+
+import java.lang.annotation.*;
+
+/**
+ * SourceFilters
+ *
+ * @author Alexander Torres
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Documented
+@QueryAnnotation
+public @interface SourceFilters {
+    /**
+     * Fields to include in the query search hits. (e.g. ["field1", "field2"])
+     * @return
+     */
+    String includes() default "";
+
+    /**
+     * Fields to exclude from the query search hits. (e.g. ["field1", "field2"])
+     * @return
+     */
+    String excludes() default "";
+}

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchQueryMethod.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchQueryMethod.java
@@ -60,7 +60,7 @@ public class ElasticsearchQueryMethod extends QueryMethod {
 	protected final Method method; // private in base class, but needed here and in derived classes as well
 	@Nullable private final Query queryAnnotation;
 	@Nullable private final Highlight highlightAnnotation;
-	@Nullable private SourceFilters sourceFilters;
+	@Nullable private final SourceFilters sourceFilters;
 	private final Lazy<HighlightQuery> highlightQueryLazy = Lazy.of(this::createAnnotatedHighlightQuery);
 
 	public ElasticsearchQueryMethod(Method method, RepositoryMetadata repositoryMetadata, ProjectionFactory factory,
@@ -265,7 +265,7 @@ public class ElasticsearchQueryMethod extends QueryMethod {
 	 * @return source filters config
 	 * @since 4.4
 	 */
-  @Nullable
+  	@Nullable
 	public SourceFilters getSourceFilters() {
 		return sourceFilters;
 	}

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchQueryMethod.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchQueryMethod.java
@@ -265,6 +265,7 @@ public class ElasticsearchQueryMethod extends QueryMethod {
 	 * @return source filters config
 	 * @since 4.4
 	 */
+  @Nullable
 	public SourceFilters getSourceFilters() {
 		return sourceFilters;
 	}

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchQueryMethod.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchQueryMethod.java
@@ -30,6 +30,7 @@ import org.springframework.data.elasticsearch.core.SearchPage;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentEntity;
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentProperty;
 import org.springframework.data.elasticsearch.core.query.HighlightQuery;
+import org.springframework.data.elasticsearch.annotations.SourceFilters;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.repository.core.RepositoryMetadata;
@@ -50,6 +51,7 @@ import org.springframework.util.ClassUtils;
  * @author Mark Paluch
  * @author Christoph Strobl
  * @author Peter-Josef Meisch
+ * @author Alexander Torres
  */
 public class ElasticsearchQueryMethod extends QueryMethod {
 
@@ -58,6 +60,7 @@ public class ElasticsearchQueryMethod extends QueryMethod {
 	protected final Method method; // private in base class, but needed here and in derived classes as well
 	@Nullable private final Query queryAnnotation;
 	@Nullable private final Highlight highlightAnnotation;
+	@Nullable private SourceFilters sourceFilters;
 	private final Lazy<HighlightQuery> highlightQueryLazy = Lazy.of(this::createAnnotatedHighlightQuery);
 
 	public ElasticsearchQueryMethod(Method method, RepositoryMetadata repositoryMetadata, ProjectionFactory factory,
@@ -71,6 +74,7 @@ public class ElasticsearchQueryMethod extends QueryMethod {
 		this.mappingContext = mappingContext;
 		this.queryAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, Query.class);
 		this.highlightAnnotation = AnnotatedElementUtils.findMergedAnnotation(method, Highlight.class);
+		this.sourceFilters = AnnotatedElementUtils.findMergedAnnotation(method, SourceFilters.class);
 
 		verifyCountQueryTypes();
 	}
@@ -247,4 +251,21 @@ public class ElasticsearchQueryMethod extends QueryMethod {
 		return queryAnnotation != null && queryAnnotation.count();
 	}
 
+	/**
+	 *
+	 * @return if source filters annotation present
+	 * @since 4.4
+	 */
+	public boolean hasSourceFilters() {
+		return sourceFilters != null;
+	}
+
+	/**
+	 *
+	 * @return source filters config
+	 * @since 4.4
+	 */
+	public SourceFilters getSourceFilters() {
+		return sourceFilters;
+	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchStringQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchStringQuery.java
@@ -118,7 +118,6 @@ public class ElasticsearchStringQuery extends AbstractElasticsearchRepositoryQue
 	/**
 	 * Parse the {@link SourceFilters} attributes to construct a SourceFilter {@link SourceFilter}
 	 * @param parameterAccessor the accessor with the query method parameter details
-	 * @throws JsonProcessingException if the json is not formatted properly
 	 * @return source filter with includes and excludes for a  query
 	 * @since 4.4
 	 */


### PR DESCRIPTION
Created a new annotation to be used with `@Query` in order to specify source filters on an elasticsearch search.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] **There is a ticket in the bug tracker for the project in our [issue tracker](https://github.
  com/spring-projects/spring-data-elasticsearch/issues)**. Add the issue number to the _Closes #issue-number_ line below
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Solves issue found on [this thread](https://stackoverflow.com/questions/71278796/how-exclude-fields-from-source-with-spring-data-elasticsearch).
Relates #2062
Relates to #1280
Closes #2146
Closes #2147
