### PR TITLE
Add new Elasticsearch client as an alternative to the existing REST c…

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/client/elc/DocumentAdapters.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/elc/DocumentAdapters.java
@@ -80,8 +80,7 @@ final class DocumentAdapters {
 
 		Explanation explanation = from(hit.explanation());
 
-		// todo #1973 matchedQueries
-		List<String> matchedQueries = null;
+		List<String> matchedQueries = hit.matchedQueries();
 
 		Function<Map<String, JsonData>, EntityAsMap> fromFields = fields -> {
 			StringBuilder sb = new StringBuilder("{");

--- a/src/main/java/org/springframework/data/elasticsearch/client/elc/ElasticsearchExceptionTranslator.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/elc/ElasticsearchExceptionTranslator.java
@@ -106,7 +106,6 @@ public class ElasticsearchExceptionTranslator implements PersistenceExceptionTra
 	}
 
 	private boolean isSeqNoConflict(Throwable exception) {
-		// todo #1973 check if this works
 		Integer status = null;
 		String message = null;
 

--- a/src/main/java/org/springframework/data/elasticsearch/client/elc/HighlightQueryBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/elc/HighlightQueryBuilder.java
@@ -87,10 +87,6 @@ class HighlightQueryBuilder {
 			builder.boundaryScannerLocale(parameters.getBoundaryScannerLocale());
 		}
 
-		if (parameters.getForceSource()) { // default is false
-			// todo #1973 parameter missing in new client
-		}
-
 		if (StringUtils.hasLength(parameters.getFragmenter())) {
 			builder.fragmenter(highlighterFragmenter(parameters.getFragmenter()));
 		}
@@ -109,10 +105,6 @@ class HighlightQueryBuilder {
 
 		if (StringUtils.hasLength(parameters.getOrder())) {
 			builder.order(highlighterOrder(parameters.getOrder()));
-		}
-
-		if (parameters.getPhraseLimit() > -1) {
-			// todo #1973 parameter missing in new client
 		}
 
 		if (parameters.getPreTags().length > 0) {

--- a/src/main/java/org/springframework/data/elasticsearch/client/elc/QueryBuilders.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/elc/QueryBuilders.java
@@ -17,6 +17,7 @@ package org.springframework.data.elasticsearch.client.elc;
 
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.LatLonGeoLocation;
+import co.elastic.clients.elasticsearch._types.query_dsl.IdsQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.MatchAllQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Operator;
@@ -29,6 +30,7 @@ import co.elastic.clients.util.ObjectBuilder;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.List;
 import java.util.function.Function;
 
 import org.springframework.data.elasticsearch.core.geo.GeoPoint;
@@ -45,6 +47,21 @@ public final class QueryBuilders {
 
 	private QueryBuilders() {}
 
+	public static IdsQuery idsQuery(List<String> ids) {
+
+		Assert.notNull(ids, "ids must not be null");
+
+		return IdsQuery.of(i -> i.values(ids));
+	}
+
+	public static Query idsQueryAsQuery(List<String> ids) {
+
+		Assert.notNull(ids, "ids must not be null");
+
+		Function<Query.Builder, ObjectBuilder<Query>> builder = b -> b.ids(idsQuery(ids));
+
+		return builder.apply(new Query.Builder()).build();
+	}
 	public static MatchQuery matchQuery(String fieldName, String query, @Nullable Operator operator,
 			@Nullable Float boost) {
 

--- a/src/main/java/org/springframework/data/elasticsearch/client/elc/ReactiveElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/elc/ReactiveElasticsearchTemplate.java
@@ -177,8 +177,7 @@ public class ReactiveElasticsearchTemplate extends AbstractReactiveElasticsearch
 		return Mono.from(execute( //
 				(ClientCallback<Publisher<co.elastic.clients.elasticsearch.core.ReindexResponse>>) client -> client
 						.reindex(reindexRequestES)))
-				.flatMap(response -> (response.task() == null) ? Mono.error( // todo #1973 check behaviour and create issue in
-																																			// ES if necessary
+				.flatMap(response -> (response.task() == null) ? Mono.error(
 						new UnsupportedBackendOperation("ElasticsearchClient did not return a task id on submit request"))
 						: Mono.just(response.task()));
 	}
@@ -499,7 +498,7 @@ public class ReactiveElasticsearchTemplate extends AbstractReactiveElasticsearch
 
 	@Override
 	public Query idsQuery(List<String> ids) {
-		throw new UnsupportedOperationException("not implemented");
+		return NativeQuery.builder().withQuery(QueryBuilders.idsQueryAsQuery(ids)).build();
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/elasticsearch/client/elc/SearchDocumentResponseBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/elc/SearchDocumentResponseBuilder.java
@@ -116,7 +116,7 @@ class SearchDocumentResponseBuilder {
 		ElasticsearchAggregations aggregationsContainer = aggregations != null ? new ElasticsearchAggregations(aggregations)
 				: null;
 
-		// todo #1973
+		// todo #2154
 		Suggest suggest = null;
 
 		return new SearchDocumentResponse(totalHits, totalHitsRelation, maxScore, scrollId, searchDocuments,

--- a/src/main/java/org/springframework/data/elasticsearch/client/elc/TypeUtils.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/elc/TypeUtils.java
@@ -15,15 +15,7 @@
  */
 package org.springframework.data.elasticsearch.client.elc;
 
-import co.elastic.clients.elasticsearch._types.Conflicts;
-import co.elastic.clients.elasticsearch._types.DistanceUnit;
-import co.elastic.clients.elasticsearch._types.GeoDistanceType;
-import co.elastic.clients.elasticsearch._types.OpType;
-import co.elastic.clients.elasticsearch._types.Refresh;
-import co.elastic.clients.elasticsearch._types.Result;
-import co.elastic.clients.elasticsearch._types.SortMode;
-import co.elastic.clients.elasticsearch._types.Time;
-import co.elastic.clients.elasticsearch._types.VersionType;
+import co.elastic.clients.elasticsearch._types.*;
 import co.elastic.clients.elasticsearch._types.mapping.FieldType;
 import co.elastic.clients.elasticsearch.core.search.BoundaryScanner;
 import co.elastic.clients.elasticsearch.core.search.BuiltinHighlighterType;
@@ -40,6 +32,7 @@ import org.springframework.data.elasticsearch.core.RefreshPolicy;
 import org.springframework.data.elasticsearch.core.query.GeoDistanceOrder;
 import org.springframework.data.elasticsearch.core.query.IndexQuery;
 import org.springframework.data.elasticsearch.core.query.Order;
+import org.springframework.data.elasticsearch.core.query.Query;
 import org.springframework.data.elasticsearch.core.query.RescorerQuery;
 import org.springframework.data.elasticsearch.core.query.UpdateResponse;
 import org.springframework.data.elasticsearch.core.reindex.ReindexRequest;
@@ -299,6 +292,23 @@ final class TypeUtils {
 	}
 
 	@Nullable
+	static SearchType searchType(@Nullable Query.SearchType searchType) {
+
+		if (searchType == null) {
+			return null;
+		}
+
+		switch (searchType) {
+			case QUERY_THEN_FETCH:
+				return SearchType.QueryThenFetch;
+			case DFS_QUERY_THEN_FETCH:
+				return SearchType.DfsQueryThenFetch;
+		}
+
+		return null;
+	}
+
+	@Nullable
 	static SortMode sortMode(Order.Mode mode) {
 
 		switch (mode) {
@@ -323,6 +333,16 @@ final class TypeUtils {
 		}
 
 		return Time.of(t -> t.time(duration.toMillis() + "ms"));
+	}
+
+	@Nullable
+	static String timeStringMs(@Nullable Duration duration) {
+
+		if (duration == null) {
+			return null;
+		}
+
+		return duration.toMillis() + "ms";
 	}
 
 	@Nullable

--- a/src/main/java/org/springframework/data/elasticsearch/core/ReactiveElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/ReactiveElasticsearchTemplate.java
@@ -277,8 +277,7 @@ public class ReactiveElasticsearchTemplate extends AbstractReactiveElasticsearch
 	 */
 	protected Mono<GetResult> doGet(GetRequest request) {
 
-		return Mono.from(execute(client -> client.get(request))) //
-				.onErrorResume(NoSuchIndexException.class, it -> Mono.empty());
+		return Mono.from(execute(client -> client.get(request)));
 	}
 
 	protected Mono<String> doDeleteById(String id, @Nullable String routing, IndexCoordinates index) {
@@ -633,8 +632,7 @@ public class ReactiveElasticsearchTemplate extends AbstractReactiveElasticsearch
 			QUERY_LOGGER.debug(String.format("Executing doCount: %s", request));
 		}
 
-		return Mono.from(execute(client -> client.count(request))) //
-				.onErrorResume(NoSuchIndexException.class, it -> Mono.just(0L));
+		return Mono.from(execute(client -> client.count(request)));
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/elasticsearch/core/document/Explanation.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/document/Explanation.java
@@ -22,7 +22,8 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
- * class that holds explanations returned from an Elasticsearch search.
+ * class that holds explanations returned from an Elasticsearch search. Note: the new Elasticsearch client does not
+ * return the match property in search hits anymore, probably because a returned hit always is a match.
  *
  * @author Peter-Josef Meisch
  */

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/BaseQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/BaseQuery.java
@@ -71,6 +71,7 @@ public class BaseQuery implements Query {
 	@Nullable protected Boolean requestCache;
 	protected List<IdWithRouting> idsWithRouting = Collections.emptyList();
 	protected final List<RuntimeField> runtimeFields = new ArrayList<>();
+	@Nullable protected List<IndexBoost> indicesBoost;
 
 	public BaseQuery() {}
 
@@ -88,7 +89,7 @@ public class BaseQuery implements Query {
 		this.fields = builder.getFields();
 		this.highlightQuery = builder.highlightQuery;
 		this.route = builder.getRoute();
-		// #1973 add the other fields to the builder
+		this.indicesBoost = builder.getIndicesBoost();
 	}
 
 	@Override
@@ -432,5 +433,11 @@ public class BaseQuery implements Query {
 	@Override
 	public List<RuntimeField> getRuntimeFields() {
 		return runtimeFields;
+	}
+
+	@Override
+	@Nullable
+	public List<IndexBoost> getIndicesBoost() {
+		return indicesBoost;
 	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/BaseQueryBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/BaseQueryBuilder.java
@@ -46,6 +46,7 @@ public abstract class BaseQueryBuilder<Q extends BaseQuery, SELF extends BaseQue
 	private List<String> fields = new ArrayList<>();
 	@Nullable protected HighlightQuery highlightQuery;
 	@Nullable private String route;
+	@Nullable private List<IndexBoost> indicesBoost;
 
 	@Nullable
 	public Pageable getPageable() {
@@ -102,6 +103,11 @@ public abstract class BaseQueryBuilder<Q extends BaseQuery, SELF extends BaseQue
 	@Nullable
 	public String getRoute() {
 		return route;
+	}
+
+	@Nullable
+	public List<IndexBoost> getIndicesBoost() {
+		return indicesBoost;
 	}
 
 	public SELF withPageable(Pageable pageable) {
@@ -175,6 +181,16 @@ public abstract class BaseQueryBuilder<Q extends BaseQuery, SELF extends BaseQue
 
 	public SELF withRoute(String route) {
 		this.route = route;
+		return self();
+	}
+
+	public SELF withIndicesBoost(List<IndexBoost> indicesBoost) {
+		this.indicesBoost = indicesBoost;
+		return self();
+	}
+
+	public SELF withIndicesBoost(IndexBoost... indicesBoost) {
+		this.indicesBoost = Arrays.asList(indicesBoost);
 		return self();
 	}
 

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/NativeSearchQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/NativeSearchQuery.java
@@ -55,7 +55,6 @@ public class NativeSearchQuery extends BaseQuery {
 	@Nullable private List<PipelineAggregationBuilder> pipelineAggregations;
 	@Nullable private HighlightBuilder highlightBuilder;
 	@Nullable private HighlightBuilder.Field[] highlightFields;
-	@Nullable private List<IndexBoost> indicesBoost;
 	@Nullable private SearchTemplateRequestBuilder searchTemplate;
 	@Nullable private SuggestBuilder suggestBuilder;
 	@Nullable private List<SearchExtBuilder> searchExtBuilders;
@@ -180,11 +179,6 @@ public class NativeSearchQuery extends BaseQuery {
 
 	public void setPipelineAggregations(List<PipelineAggregationBuilder> pipelineAggregationBuilders) {
 		this.pipelineAggregations = pipelineAggregationBuilders;
-	}
-
-	@Nullable
-	public List<IndexBoost> getIndicesBoost() {
-		return indicesBoost;
 	}
 
 	public void setIndicesBoost(List<IndexBoost> indicesBoost) {

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/NativeSearchQueryBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/NativeSearchQueryBuilder.java
@@ -63,7 +63,6 @@ public class NativeSearchQueryBuilder extends BaseQueryBuilder<NativeSearchQuery
 	@Nullable private List<HighlightBuilder.Field> highlightFields = new ArrayList<>();
 	@Nullable protected List<String> storedFields;
 	@Nullable private CollapseBuilder collapseBuilder;
-	@Nullable private List<IndexBoost> indicesBoost = new ArrayList<>();
 	@Nullable private SearchTemplateRequestBuilder searchTemplateBuilder;
 	@Nullable private SearchType searchType;
 	@Nullable private Boolean trackTotalHits;
@@ -194,19 +193,6 @@ public class NativeSearchQueryBuilder extends BaseQueryBuilder<NativeSearchQuery
 		return this;
 	}
 
-	public NativeSearchQueryBuilder withIndicesBoost(Collection<IndexBoost> indicesBoost) {
-		this.indicesBoost.addAll(indicesBoost);
-		return this;
-	}
-
-	/**
-	 * @since 4.3
-	 */
-	public NativeSearchQueryBuilder withIndicesBoost(IndexBoost... indicesBoost) {
-		Collections.addAll(this.indicesBoost, indicesBoost);
-		return this;
-	}
-
 	public NativeSearchQueryBuilder withSearchTemplate(SearchTemplateRequestBuilder searchTemplateBuilder) {
 		this.searchTemplateBuilder = searchTemplateBuilder;
 		return this;
@@ -288,10 +274,6 @@ public class NativeSearchQueryBuilder extends BaseQueryBuilder<NativeSearchQuery
 
 		if (storedFields != null) {
 			nativeSearchQuery.setStoredFields(storedFields);
-		}
-
-		if (indicesBoost != null) {
-			nativeSearchQuery.setIndicesBoost(indicesBoost);
 		}
 
 		if (searchTemplateBuilder != null) {

--- a/src/main/java/org/springframework/data/elasticsearch/core/query/Query.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/Query.java
@@ -434,6 +434,12 @@ public interface Query {
 	List<RuntimeField> getRuntimeFields();
 
 	/**
+	 * @since 4.4
+	 */
+	@Nullable
+	List<IndexBoost> getIndicesBoost();
+
+	/**
 	 * @since 4.3
 	 */
 	enum SearchType {

--- a/src/main/resources/versions.properties
+++ b/src/main/resources/versions.properties
@@ -1,2 +1,2 @@
 version.spring-data-elasticsearch=${project.version}
-version.elasticsearch-client=${elasticsearch}
+version.elasticsearch-client=${elasticsearch-rhlc}

--- a/src/test/java/org/springframework/data/elasticsearch/NewElasticsearchClientDevelopment.java
+++ b/src/test/java/org/springframework/data/elasticsearch/NewElasticsearchClientDevelopment.java
@@ -16,7 +16,7 @@
 package org.springframework.data.elasticsearch;
 
 /**
- * TODO #1973 remove when the new Elasticsearch client is fully working
+ * TODO remove when the new Elasticsearch client is fully working
  *
  * @author Peter-Josef Meisch
  */

--- a/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchIntegrationTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/ElasticsearchIntegrationTests.java
@@ -1617,7 +1617,7 @@ public abstract class ElasticsearchIntegrationTests implements NewElasticsearchC
 	}
 
 	@DisabledIf(value = "newElasticsearchClient",
-			disabledReason = "todo #1973 can't check response, open ES issue 161 that does not allow seqno")
+			disabledReason = "todo #2138 can't check response, open ES issue 161 that does not allow seqno")
 	// and version to be set in the request
 	@Test // DATAES-487
 	public void shouldReturnSameEntityForMultiSearch() {
@@ -1642,7 +1642,7 @@ public abstract class ElasticsearchIntegrationTests implements NewElasticsearchC
 	}
 
 	@DisabledIf(value = "newElasticsearchClient",
-			disabledReason = "todo #1973 can't check response, open ES issue 161 that does not allow seqno")
+			disabledReason = "todo #2138 can't check response, open ES issue 161 that does not allow seqno")
 	// and version to be set in the request
 	@Test // DATAES-487
 	public void shouldReturnDifferentEntityForMultiSearch() {
@@ -3070,7 +3070,7 @@ public abstract class ElasticsearchIntegrationTests implements NewElasticsearchC
 	}
 
 	@DisabledIf(value = "newElasticsearchClient",
-			disabledReason = "todo #1973 can't check response, open ES issue 161 that does not allow seqno")
+			disabledReason = "todo #2138 can't check response, open ES issue 161 that does not allow seqno")
 																				// and version to be set in the request
 	@Test // DATAES-799
 	void multiSearchShouldReturnSeqNoPrimaryTerm() {

--- a/src/test/java/org/springframework/data/elasticsearch/core/suggest/CompletionIntegrationTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/suggest/CompletionIntegrationTests.java
@@ -116,7 +116,7 @@ public abstract class CompletionIntegrationTests implements NewElasticsearchClie
 		operations.bulkIndex(indexQueries, AnnotatedCompletionEntity.class);
 	}
 
-	@DisabledIf(value = "newElasticsearchClient", disabledReason="todo #1973, ES issue 150")
+	@DisabledIf(value = "newElasticsearchClient", disabledReason = "todo #2139, ES issue 150")
 	@Test
 	public void shouldFindSuggestionsForGivenCriteriaQueryUsingCompletionEntity() {
 
@@ -148,7 +148,7 @@ public abstract class CompletionIntegrationTests implements NewElasticsearchClie
 		operations.get("1", CompletionEntity.class);
 	}
 
-	@DisabledIf(value = "newElasticsearchClient", disabledReason="todo #1973, ES issue 150")
+	@DisabledIf(value = "newElasticsearchClient", disabledReason = "todo #2139, ES issue 150")
 	@Test
 	public void shouldFindSuggestionsForGivenCriteriaQueryUsingAnnotatedCompletionEntity() {
 
@@ -172,7 +172,7 @@ public abstract class CompletionIntegrationTests implements NewElasticsearchClie
 		assertThat(options.get(1).getText()).isIn("Marchand", "Mohsin");
 	}
 
-	@DisabledIf(value = "newElasticsearchClient", disabledReason="todo #1973, ES issue 150")
+	@DisabledIf(value = "newElasticsearchClient", disabledReason = "todo #2139, ES 1issue 150")
 	@Test
 	public void shouldFindSuggestionsWithWeightsForGivenCriteriaQueryUsingAnnotatedCompletionEntity() {
 

--- a/src/test/java/org/springframework/data/elasticsearch/core/suggest/ReactiveSuggestIntegrationTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/suggest/ReactiveSuggestIntegrationTests.java
@@ -67,7 +67,7 @@ public abstract class ReactiveSuggestIntegrationTests implements NewElasticsearc
 		operations.indexOps(IndexCoordinates.of(indexNameProvider.getPrefix() + "*")).delete().block();
 	}
 
-	@DisabledIf(value = "newElasticsearchClient", disabledReason="todo #1973, ES issue 150")
+	@DisabledIf(value = "newElasticsearchClient", disabledReason = "todo #2139, ES issue 150")
 	@Test // #1302
 	@DisplayName("should find suggestions for given prefix completion")
 	void shouldFindSuggestionsForGivenPrefixCompletion() {

--- a/src/test/java/org/springframework/data/elasticsearch/repository/support/SimpleReactiveElasticsearchRepositoryELCIntegrationTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repository/support/SimpleReactiveElasticsearchRepositoryELCIntegrationTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.repository.support;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.elasticsearch.junit.jupiter.ReactiveElasticsearchTemplateConfiguration;
+import org.springframework.data.elasticsearch.repository.config.EnableReactiveElasticsearchRepositories;
+import org.springframework.data.elasticsearch.utils.IndexNameProvider;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author Peter-Josef Meisch
+ * @since 4.4
+ */
+@ContextConfiguration(classes = { SimpleReactiveElasticsearchRepositoryELCIntegrationTests.Config.class })
+public class SimpleReactiveElasticsearchRepositoryELCIntegrationTests
+		extends SimpleReactiveElasticsearchRepositoryIntegrationTests {
+
+	@Configuration
+	@Import({ ReactiveElasticsearchTemplateConfiguration.class })
+	@EnableReactiveElasticsearchRepositories(considerNestedRepositories = true)
+	static class Config {
+		@Bean
+		IndexNameProvider indexNameProvider() {
+			return new IndexNameProvider("simple-reactive-repository");
+		}
+	}
+
+}

--- a/src/test/java/org/springframework/data/elasticsearch/repository/support/SimpleReactiveElasticsearchRepositoryERHLCIntegrationTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/repository/support/SimpleReactiveElasticsearchRepositoryERHLCIntegrationTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.repository.support;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.elasticsearch.junit.jupiter.ReactiveElasticsearchRestTemplateConfiguration;
+import org.springframework.data.elasticsearch.repository.config.EnableReactiveElasticsearchRepositories;
+import org.springframework.data.elasticsearch.utils.IndexNameProvider;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * @author Peter-Josef Meisch
+ */
+@ContextConfiguration(classes = { SimpleReactiveElasticsearchRepositoryERHLCIntegrationTests.Config.class })
+public class SimpleReactiveElasticsearchRepositoryERHLCIntegrationTests
+		extends SimpleReactiveElasticsearchRepositoryIntegrationTests {
+
+	@Configuration
+	@Import({ ReactiveElasticsearchRestTemplateConfiguration.class })
+	@EnableReactiveElasticsearchRepositories(considerNestedRepositories = true)
+	static class Config {
+		@Bean
+		IndexNameProvider indexNameProvider() {
+			return new IndexNameProvider("simple-reactive-repository-es7");
+		}
+	}
+
+}


### PR DESCRIPTION
This PR (almost) finishes integration of the new Elasticsearch client - although there are still some missing features and open issues which are addressed by separate issues.

Partly this is due to functionality missing from the new Elasticsearch client (#2139, #2150), or there was no time to finish this up before the 4.4 release (#2154, #2155, #2156).

I think it is important to have this state in the 4.4.0 release so that the integration of the new Elasticsearch can already be tested by users.

The missing features and updates from the Elasticsearch client will be implemented in both the _main_ and _4.4.x_ branches as soon as possible. 


Closes #1973
