### PR TITLE
Refine the configuration callbacks in the ClientConfiguration.

### DIFF
--- a/src/main/asciidoc/reference/elasticsearch-clients.adoc
+++ b/src/main/asciidoc/reference/elasticsearch-clients.adoc
@@ -38,16 +38,17 @@ ElasticsearchClient elasticsearchClient; <.>
 @Autowired
 RestClient restClient;                   <.>
 ----
+
 the following can be injected:
 
-<.> an implementation of `ElasticsearchOperations` 
-<.> the `co.elastic.clients.elasticsearch.ElasticsearchClient` that is used. This is new Elasticsearch client 
-implementation.
+<.> an implementation of `ElasticsearchOperations`
+<.> the `co.elastic.clients.elasticsearch.ElasticsearchClient` that is used.
+This is new Elasticsearch client implementation.
 <.> the low level `RestClient` from the Elasticsearch libraries
 ====
 
-Basically one should just use the `ElasticsearchOperations` to interact with the Elasticsearch cluster. When using 
-repositories, this instance is used under the hood as well.
+Basically one should just use the `ElasticsearchOperations` to interact with the Elasticsearch cluster.
+When using repositories, this instance is used under the hood as well.
 
 [[elasticsearch.clients.reactiverestclient]]
 == Reactive Rest Client
@@ -81,21 +82,22 @@ ReactiveElasticsearchClient elasticsearchClient; <.>
 @Autowired
 RestClient restClient;                           <.>
 ----
+
 the following can be injected:
 
 <.> an implementation of `ElasticsearchOperations`
-<.> the `org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient` that is used. This is based 
-on the new Elasticsearch client implementation.
+<.> the `org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient` that is used.
+This is based on the new Elasticsearch client implementation.
 <.> the low level `RestClient` from the Elasticsearch libraries
 ====
 
-Basically one should just use the `ReactiveElasticsearchOperations` to interact with the Elasticsearch cluster. When 
-using repositories, this instance is used under the hood as well.
+Basically one should just use the `ReactiveElasticsearchOperations` to interact with the Elasticsearch cluster.
+When using repositories, this instance is used under the hood as well.
 
 [[elasticsearch.clients.resthighlevelclient]]
 == High Level REST Client (deprecated)
 
-The Java RestHighLevelClient is deprecated, but still can be configured like shown (read 
+The Java RestHighLevelClient is deprecated, but still can be configured like shown (read
 <<elasticsearch-migration-guide-4.4-5.0.old-client>> as well):
 
 .RestHighLevelClient
@@ -231,11 +233,48 @@ Default is 5 sec.
 <.> Optionally set headers.
 <.> Add basic authentication.
 <.> A `Supplier<Header>` function can be specified which is called every time before a request is sent to Elasticsearch - here, as an example, the current time is written in a header.
-<.> a function configuring the low level REST client (the same for the imperative and reactive stack)
+<.> a function to configure the created client (see <<elasticsearch.clients.configuration.callbacks>>), can be added multiple times.
 ====
 
 IMPORTANT: Adding a Header supplier as shown in above example allows to inject headers that may change over the time, like authentication JWT tokens.
 If this is used in the reactive setup, the supplier function *must not* block!
+
+[[elasticsearch.clients.configuration.callbacks]]
+=== Client configuration callbacks
+
+The `ClientConfiguration` class offers the most common parameters to configure the client. In the case this is not 
+enough, the user can add callback functions by using the `withClientConfigurer(ClientConfigurationCallback<?>)` method.
+
+The following callbacks are provided:
+
+==== Configuration of the low level Elasticsearch `RestClient`:
+
+====
+[source,java]
+----
+ClientConfiguration.builder()
+    .withClientConfigurer(ElasticsearchClients.ElasticsearchRestClientConfigurationCallback.from(restClientBuilder -> {
+        // configure the Elasticsearch RestClient
+        return restClientBuilder;
+    }))
+    .build();
+----
+====
+
+==== Configuration of the HttpAsyncClient used by the low level Elasticsearch `RestClient`:
+
+====
+[source,java]
+----
+ClientConfiguration.builder()
+    .withClientConfigurer(ElasticsearchClients.ElasticsearchHttpClientConfigurationCallback.from(httpAsyncClientBuilder -> {
+        // configure the HttpAsyncClient
+        return httpAsyncClientBuilder;
+    }))
+    .build();
+----
+====
+
 
 === Elasticsearch 7 compatibility headers
 

--- a/src/main/asciidoc/reference/elasticsearch-migration-guide-4.4-5.0.adoc
+++ b/src/main/asciidoc/reference/elasticsearch-migration-guide-4.4-5.0.adoc
@@ -36,7 +36,7 @@ If you are using `ElasticsearchRestTemplate` directly and not the `Elasticsearch
 adjust your imports as well.
 
 When working with the `NativeSearchQuery` class, you'll need to switch to the `NativeQuery` class, which can take a 
-`Query` instance comign from the new Elasticsearch client libraries. You'll find plenty of examples in the test code. 
+`Query` instance comign from the new Elasticsearch client libraries. You'll find plenty of examples in the test code.
 
 [[elasticsearch-migration-guide-4.4-5.0.new-clients]]
 == New Elasticsearch client

--- a/src/main/java/org/springframework/data/elasticsearch/client/erhlc/ReactiveRestClients.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/erhlc/ReactiveRestClients.java
@@ -72,7 +72,9 @@ public final class ReactiveRestClients {
 	 * the ReactiveElasticsearchClient with a {@link WebClient}
 	 *
 	 * @since 4.3
+	 * @deprecated
 	 */
+	@Deprecated
 	public interface WebClientConfigurationCallback extends ClientConfiguration.ClientConfigurationCallback<WebClient> {
 
 		static WebClientConfigurationCallback from(Function<WebClient, WebClient> webClientCallback) {

--- a/src/main/java/org/springframework/data/elasticsearch/client/erhlc/RestClients.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/erhlc/RestClients.java
@@ -252,7 +252,9 @@ public final class RestClients {
 	 * the RestClient with a {@link HttpAsyncClientBuilder}
 	 *
 	 * @since 4.3
+	 * @deprecated since 5.0
 	 */
+	@Deprecated
 	public interface RestClientConfigurationCallback
 			extends ClientConfiguration.ClientConfigurationCallback<HttpAsyncClientBuilder> {
 

--- a/src/main/java/org/springframework/data/elasticsearch/client/erhlc/WebClientProvider.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/erhlc/WebClientProvider.java
@@ -35,7 +35,6 @@ import java.util.function.Function;
 import javax.net.ssl.SSLContext;
 
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
-import org.springframework.data.elasticsearch.client.elc.ElasticsearchClients;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.reactive.ClientHttpConnector;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
@@ -238,11 +237,6 @@ public interface WebClientProvider {
 
 				if (clientConfigurer instanceof ReactiveRestClients.WebClientConfigurationCallback) {
 					ReactiveRestClients.WebClientConfigurationCallback webClientConfigurationCallback = (ReactiveRestClients.WebClientConfigurationCallback) clientConfigurer;
-					webClient = webClientConfigurationCallback.configure(webClient);
-				}
-
-				if (clientConfigurer instanceof ElasticsearchClients.WebClientConfigurationCallback) {
-					ElasticsearchClients.WebClientConfigurationCallback webClientConfigurationCallback = (ElasticsearchClients.WebClientConfigurationCallback) clientConfigurer;
 					webClient = webClientConfigurationCallback.configure(webClient);
 				}
 			}


### PR DESCRIPTION
compression can now be set on the `RestClient` by using a `ElasticsearchClients.ElasticsearchRestClientConfigurationCallback` when configuring Spring Data Elasticsearch.

Closes #2149