### PR TITLE
Implement SourceFilters annotation.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/annotations/Query.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/Query.java
@@ -15,8 +15,14 @@
  */
 package org.springframework.data.elasticsearch.annotations;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.core.annotation.AliasFor;
 import org.springframework.data.annotation.QueryAnnotation;
-import java.lang.annotation.*;
 
 /**
  * Query
@@ -34,9 +40,17 @@ import java.lang.annotation.*;
 public @interface Query {
 
 	/**
-	 * @return Elasticsearch query to be used when executing query. May contain placeholders eg. ?0
+	 * @return Elasticsearch query to be used when executing query. May contain placeholders eg. ?0. Alias for query.
 	 */
+	@AliasFor("query")
 	String value() default "";
+
+	/**
+	 * @return Elasticsearch query to be used when executing query. May contain placeholders eg. ?0. Alias for value
+	 * @since 5.0
+	 */
+	@AliasFor("value")
+	String query() default "";
 
 	/**
 	 * Named Query Named looked up by repository.

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/SourceFilters.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/SourceFilters.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.elasticsearch.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation can be placed on repository methods to define the properties that should be requested from
+ * Elasticsearch when the method is run.
+ *
+ * @author Alexander Torres
+ * @author Peter-Josef Meisch
+ * @since 5.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Documented
+public @interface SourceFilters {
+
+	/**
+	 * Properties to be requested from Elasticsearch to be included in the response. These can be passed in as literals
+	 * like
+	 *
+	 * <pre>
+	 * {@code @SourceFilters(includes = {"property1", "property2"})}
+	 * </pre>
+	 *
+	 * or as a parameterized value
+	 *
+	 * <pre>
+	 * {@code @SourceFilters(includes = "?0")}
+	 * </pre>
+	 *
+	 * when the list of properties is passed as a function parameter.
+	 */
+	String[] includes() default "";
+
+	/**
+	 * Properties to be requested from Elasticsearch to be excluded in the response. These can be passed in as literals
+	 * like
+	 *
+	 * <pre>
+	 * {@code @SourceFilters(excludes = {"property1", "property2"})}
+	 * </pre>
+	 *
+	 * or as a parameterized value
+	 *
+	 * <pre>
+	 * {@code @SourceFilters(excludes = "?0")}
+	 * </pre>
+	 *
+	 * when the list of properties is passed as a function parameter.
+	 */
+	String[] excludes() default "";
+}

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/AbstractReactiveElasticsearchRepositoryQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/AbstractReactiveElasticsearchRepositoryQuery.java
@@ -27,6 +27,7 @@ import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersiste
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.core.query.ByQueryResponse;
 import org.springframework.data.elasticsearch.core.query.Query;
+import org.springframework.data.elasticsearch.core.query.SourceFilter;
 import org.springframework.data.elasticsearch.repository.query.ReactiveElasticsearchQueryExecution.ResultProcessingConverter;
 import org.springframework.data.elasticsearch.repository.query.ReactiveElasticsearchQueryExecution.ResultProcessingExecution;
 import org.springframework.data.mapping.context.MappingContext;
@@ -86,6 +87,12 @@ abstract class AbstractReactiveElasticsearchRepositoryQuery implements Repositor
 
 		if (queryMethod.hasAnnotatedHighlight()) {
 			query.setHighlightQuery(queryMethod.getAnnotatedHighlightQuery());
+		}
+
+		var sourceFilter = queryMethod.getSourceFilter(parameterAccessor,
+				elasticsearchOperations.getElasticsearchConverter());
+		if (sourceFilter != null) {
+			query.addSourceFilter(sourceFilter);
 		}
 
 		Class<?> targetType = processor.getReturnedType().getTypeToRead();

--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchStringQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/ElasticsearchStringQuery.java
@@ -21,6 +21,7 @@ import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHitSupport;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.Query;
 import org.springframework.data.elasticsearch.core.query.StringQuery;
 import org.springframework.data.elasticsearch.repository.support.StringQueryUtil;
 import org.springframework.data.repository.query.ParametersParameterAccessor;
@@ -38,13 +39,13 @@ import org.springframework.util.Assert;
  */
 public class ElasticsearchStringQuery extends AbstractElasticsearchRepositoryQuery {
 
-	private String query;
+	private final String queryString;
 
 	public ElasticsearchStringQuery(ElasticsearchQueryMethod queryMethod, ElasticsearchOperations elasticsearchOperations,
-			String query) {
+			String queryString) {
 		super(queryMethod, elasticsearchOperations);
-		Assert.notNull(query, "Query cannot be empty");
-		this.query = query;
+		Assert.notNull(queryString, "Query cannot be empty");
+		this.queryString = queryString;
 	}
 
 	@Override
@@ -56,40 +57,42 @@ public class ElasticsearchStringQuery extends AbstractElasticsearchRepositoryQue
 	public Object execute(Object[] parameters) {
 
 		Class<?> clazz = queryMethod.getResultProcessor().getReturnedType().getDomainType();
-		ParametersParameterAccessor accessor = new ParametersParameterAccessor(queryMethod.getParameters(), parameters);
+		ParametersParameterAccessor parameterAccessor = new ParametersParameterAccessor(queryMethod.getParameters(),
+				parameters);
 
-		StringQuery stringQuery = createQuery(accessor);
-
-		Assert.notNull(stringQuery, "unsupported query");
+		Query query = createQuery(parameterAccessor);
+		Assert.notNull(query, "unsupported query");
 
 		if (queryMethod.hasAnnotatedHighlight()) {
-			stringQuery.setHighlightQuery(queryMethod.getAnnotatedHighlightQuery());
+			query.setHighlightQuery(queryMethod.getAnnotatedHighlightQuery());
 		}
+
+		prepareQuery(query, clazz, parameterAccessor);
 
 		IndexCoordinates index = elasticsearchOperations.getIndexCoordinatesFor(clazz);
 
-		Object result = null;
+		Object result;
 
 		if (isCountQuery()) {
-			result = elasticsearchOperations.count(stringQuery, clazz, index);
+			result = elasticsearchOperations.count(query, clazz, index);
 		} else if (queryMethod.isPageQuery()) {
-			stringQuery.setPageable(accessor.getPageable());
-			SearchHits<?> searchHits = elasticsearchOperations.search(stringQuery, clazz, index);
+			query.setPageable(parameterAccessor.getPageable());
+			SearchHits<?> searchHits = elasticsearchOperations.search(query, clazz, index);
 			if (queryMethod.isSearchPageMethod()) {
-				result = SearchHitSupport.searchPageFor(searchHits, stringQuery.getPageable());
+				result = SearchHitSupport.searchPageFor(searchHits, query.getPageable());
 			} else {
-				result = SearchHitSupport
-						.unwrapSearchHits(SearchHitSupport.searchPageFor(searchHits, stringQuery.getPageable()));
+				result = SearchHitSupport.unwrapSearchHits(SearchHitSupport.searchPageFor(searchHits, query.getPageable()));
 			}
 		} else if (queryMethod.isStreamQuery()) {
-			stringQuery.setPageable(
-					accessor.getPageable().isPaged() ? accessor.getPageable() : PageRequest.of(0, DEFAULT_STREAM_BATCH_SIZE));
-			result = StreamUtils.createStreamFromIterator(elasticsearchOperations.searchForStream(stringQuery, clazz, index));
+			query.setPageable(parameterAccessor.getPageable().isPaged() ? parameterAccessor.getPageable()
+					: PageRequest.of(0, DEFAULT_STREAM_BATCH_SIZE));
+			result = StreamUtils.createStreamFromIterator(elasticsearchOperations.searchForStream(query, clazz, index));
 		} else if (queryMethod.isCollectionQuery()) {
-			stringQuery.setPageable(accessor.getPageable().isPaged() ? accessor.getPageable() : Pageable.unpaged());
-			result = elasticsearchOperations.search(stringQuery, clazz, index);
+			query.setPageable(
+					parameterAccessor.getPageable().isPaged() ? parameterAccessor.getPageable() : Pageable.unpaged());
+			result = elasticsearchOperations.search(query, clazz, index);
 		} else {
-			result = elasticsearchOperations.searchOne(stringQuery, clazz, index);
+			result = elasticsearchOperations.searchOne(query, clazz, index);
 		}
 
 		return (queryMethod.isNotSearchHitMethod() && queryMethod.isNotSearchPageMethod())
@@ -99,7 +102,7 @@ public class ElasticsearchStringQuery extends AbstractElasticsearchRepositoryQue
 
 	protected StringQuery createQuery(ParametersParameterAccessor parameterAccessor) {
 		String queryString = new StringQueryUtil(elasticsearchOperations.getElasticsearchConverter().getConversionService())
-				.replacePlaceholders(this.query, parameterAccessor);
+				.replacePlaceholders(this.queryString, parameterAccessor);
 		return new StringQuery(queryString);
 	}
 


### PR DESCRIPTION
This now is implemented as a separate annotation `@SourceFilters`, not as an additional parameter to `@Query`.

This makes this available not only to `@Query`  annotated repository methods, but to normal repository methods as well.


Closes #1280
Closes #2062
Closes #2146
Closes #2147
Closes #2151

