### PR TITLE
fix bug: IndexQuery's id get ignored in bulkIndexOperation

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/client/elc/RequestConverter.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/elc/RequestConverter.java
@@ -96,6 +96,7 @@ import org.springframework.util.StringUtils;
  * @author Peter-Josef Meisch
  * @author Sascha Woo
  * @author cdalxndr
+ * @author scoobyzhang
  * @since 4.4
  */
 class RequestConverter {
@@ -440,7 +441,7 @@ class RequestConverter {
 		Object queryObject = query.getObject();
 
 		if (queryObject != null) {
-			String id = !StringUtils.hasText(query.getId()) ? getPersistentEntityId(queryObject) : query.getId();
+			String id = StringUtils.hasText(query.getId()) ? query.getId() : getPersistentEntityId(queryObject);
 			builder //
 					.id(id) //
 					.document(elasticsearchConverter.mapObject(queryObject));
@@ -492,7 +493,7 @@ class RequestConverter {
 		Object queryObject = query.getObject();
 
 		if (queryObject != null) {
-			String id = StringUtils.hasText(query.getId()) ? getPersistentEntityId(queryObject) : query.getId();
+			String id = StringUtils.hasText(query.getId()) ? query.getId() : getPersistentEntityId(queryObject);
 			builder //
 					.id(id) //
 					.document(elasticsearchConverter.mapObject(queryObject));
@@ -533,7 +534,7 @@ class RequestConverter {
 		Object queryObject = query.getObject();
 
 		if (queryObject != null) {
-			String id = StringUtils.hasText(query.getId()) ? getPersistentEntityId(queryObject) : query.getId();
+			String id = StringUtils.hasText(query.getId()) ? query.getId() : getPersistentEntityId(queryObject);
 			builder //
 					.id(id) //
 					.document(elasticsearchConverter.mapObject(queryObject));


### PR DESCRIPTION
<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.

When contributing, please make sure an issue exists in issue tracker and comment on this issue with how you want to address it. By this we not only know that someone is working on an issue, we can also align architectural questions and possible solutions before work is invested . We so can prevent that much work is put into Pull Requests that have little or no chances of being merged.

Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] **There is a ticket in the bug tracker for the project in our [issue tracker](https://github.
  com/spring-projects/spring-data-elasticsearch/issues)**. Add the issue number to the _Closes #issue-number_ line below
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Closes #2405 
