### PR TITLE
Overload multiSearch method to support list of IndexCoordinates

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/client/elc/ElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/elc/ElasticsearchTemplate.java
@@ -69,6 +69,7 @@ import org.springframework.util.Assert;
  * Elasticsearch client.
  *
  * @author Peter-Josef Meisch
+ * @author Hamid Rahimi
  * @since 4.4
  */
 public class ElasticsearchTemplate extends AbstractElasticsearchTemplate {
@@ -459,6 +460,29 @@ public class ElasticsearchTemplate extends AbstractElasticsearchTemplate {
 		Iterator<Class<?>> it = classes.iterator();
 		for (Query query : queries) {
 			Class<?> clazz = it.next();
+			multiSearchQueryParameters.add(new MultiSearchQueryParameter(query, clazz, index));
+		}
+
+		return doMultiSearch(multiSearchQueryParameters);
+	}
+
+	@Override
+	public List<SearchHits<?>> multiSearch(List<? extends Query> queries, List<Class<?>> classes,
+		   List<IndexCoordinates> indexes) {
+
+		Assert.notNull(queries, "queries must not be null");
+		Assert.notNull(classes, "classes must not be null");
+		Assert.notNull(indexes, "indexes must not be null");
+		Assert.isTrue(queries.size() == classes.size() && queries.size() == indexes.size(),
+				"queries, classes and indexes must have the same size");
+
+		List<MultiSearchQueryParameter> multiSearchQueryParameters = new ArrayList<>(queries.size());
+		Iterator<Class<?>> it = classes.iterator();
+		Iterator<IndexCoordinates> indexesIt = indexes.iterator();
+
+		for (Query query : queries) {
+			Class<?> clazz = it.next();
+			IndexCoordinates index = indexesIt.next();
 			multiSearchQueryParameters.add(new MultiSearchQueryParameter(query, clazz, index));
 		}
 

--- a/src/main/java/org/springframework/data/elasticsearch/client/erhlc/ElasticsearchRestTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/erhlc/ElasticsearchRestTemplate.java
@@ -112,6 +112,7 @@ import org.springframework.util.Assert;
  * @author Massimiliano Poggi
  * @author Farid Faoudi
  * @author Sijia Liu
+ * @author Hamid Rahimi
  * @since 4.4
  * @deprecated since 5.0
  */
@@ -538,6 +539,42 @@ public class ElasticsearchRestTemplate extends AbstractElasticsearchTemplate {
 		Iterator<Class<?>> it1 = classes.iterator();
 		for (int i = 0; i < queries.size(); i++) {
 			Class entityClass = it1.next();
+
+			ReadDocumentCallback<?> documentCallback = new ReadDocumentCallback<>(elasticsearchConverter, entityClass, index);
+			SearchDocumentResponseCallback<SearchHits<?>> callback = new ReadSearchDocumentResponseCallback<>(entityClass,
+					index);
+
+			SearchResponse response = items[i].getResponse();
+			res.add(callback.doWith(SearchDocumentResponseBuilder.from(response, getEntityCreator(documentCallback))));
+		}
+		return res;
+	}
+
+	@Override
+	public List<SearchHits<?>> multiSearch(List<? extends Query> queries, List<Class<?>> classes,
+		   List<IndexCoordinates> indexes) {
+
+		Assert.notNull(queries, "queries must not be null");
+		Assert.notNull(classes, "classes must not be null");
+		Assert.notNull(indexes, "indexes must not be null");
+		Assert.isTrue(queries.size() == classes.size() && queries.size() == indexes.size(),
+				"queries, classes and indexes must have the same size");
+
+		MultiSearchRequest request = new MultiSearchRequest();
+		Iterator<Class<?>> it = classes.iterator();
+		Iterator<IndexCoordinates> indexesIt = indexes.iterator();
+		for (Query query : queries) {
+			request.add(requestFactory.searchRequest(query, it.next(), indexesIt.next()));
+		}
+
+		MultiSearchResponse.Item[] items = getMultiSearchResult(request);
+
+		List<SearchHits<?>> res = new ArrayList<>(queries.size());
+		Iterator<Class<?>> it1 = classes.iterator();
+		Iterator<IndexCoordinates> indexesIt1 = indexes.iterator();
+		for (int i = 0; i < queries.size(); i++) {
+			Class entityClass = it1.next();
+			IndexCoordinates index = indexesIt1.next();
 
 			ReadDocumentCallback<?> documentCallback = new ReadDocumentCallback<>(elasticsearchConverter, entityClass, index);
 			SearchDocumentResponseCallback<SearchHits<?>> callback = new ReadSearchDocumentResponseCallback<>(entityClass,

--- a/src/main/java/org/springframework/data/elasticsearch/core/SearchOperations.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/SearchOperations.java
@@ -30,6 +30,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Peter-Josef Meisch
  * @author Sascha Woo
+ * @author Hamid Rahimi
  * @since 4.0
  */
 public interface SearchOperations {
@@ -127,10 +128,20 @@ public interface SearchOperations {
 	 *
 	 * @param queries the queries to execute
 	 * @param classes the entity classes used for property mapping
-	 * @param index the index to run the query against
+	 * @param index the index to run the queries against
 	 * @return list of SearchHits
 	 */
 	List<SearchHits<?>> multiSearch(List<? extends Query> queries, List<Class<?>> classes, IndexCoordinates index);
+
+	/**
+	 * Execute the multi search query against elasticsearch and return result as {@link List} of {@link SearchHits}.
+	 *
+	 * @param queries the queries to execute
+	 * @param classes the entity classes used for property mapping
+	 * @param indexes the indexes to run the queries against
+	 * @return list of SearchHits
+	 */
+	List<SearchHits<?>> multiSearch(List<? extends Query> queries, List<Class<?>> classes, List<IndexCoordinates> indexes);
 
 	/**
 	 * Execute the criteria query against elasticsearch and return result as {@link SearchHits}


### PR DESCRIPTION
Pretty much copy/paste with the exception of one more list (IndexCoordinates) that is iterated along with the classes and added per query. 

Could've (maybe should've) refactored existing methods to avoid duplicate fragments, but did not want to change existing code too much since this is my first contribution.

Closes #2434
