### PR TITLE
Fix typo in documentation

### DIFF
--- a/src/main/asciidoc/reference/elasticsearch-object-mapping.adoc
+++ b/src/main/asciidoc/reference/elasticsearch-object-mapping.adoc
@@ -3,7 +3,7 @@
 
 Spring Data Elasticsearch Object Mapping is the process that maps a Java object - the domain entity - into the JSON representation that is stored in Elasticsearch and back.
 The class that is internally used for this mapping is the
-`MappingElasticsearcvhConverter`.
+`MappingElasticsearchConverter`.
 
 [[elasticsearch.mapping.meta-model]]
 == Meta Model Object Mapping


### PR DESCRIPTION
fix typo for MappingElasticsearchConverter class name.

Closes #2442 


- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] **There is a ticket in the bug tracker for the project in our [issue tracker](https://github.
  com/spring-projects/spring-data-elasticsearch/issues)**. Add the issue number to the _Closes #issue-number_ line below
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

