### PR TITLE
Fix ReactiveIndicesTemplate: Refresh not called on bound indices #2441

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/client/elc/ReactiveIndicesTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/elc/ReactiveIndicesTemplate.java
@@ -154,7 +154,8 @@ public class ReactiveIndicesTemplate
 
 	@Override
 	public Mono<Void> refresh() {
-		return Mono.from(execute(ReactiveElasticsearchIndicesClient::refresh)).then();
+		RefreshRequest refreshRequest = requestConverter.indicesRefreshRequest(getIndexCoordinates());
+		return Mono.from(execute(client -> client.refresh(refreshRequest))).then();
 	}
 
 	@Override

--- a/src/test/java/org/springframework/data/elasticsearch/client/elc/ReactiveIndicesTemplateTest.java
+++ b/src/test/java/org/springframework/data/elasticsearch/client/elc/ReactiveIndicesTemplateTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch.client.elc;
+
+import co.elastic.clients.elasticsearch.indices.RefreshRequest;
+import co.elastic.clients.json.JsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Urs Keller
+ * @since 5.0
+ */
+@ExtendWith(MockitoExtension.class)
+class ReactiveIndicesTemplateTest {
+	@Mock private ElasticsearchConverter elasticsearchConverter;
+	@Mock private ReactiveElasticsearchIndicesClient client;
+	@Mock private ElasticsearchTransport transport;
+	@Mock private JsonpMapper jsonpMapper;
+	@Captor ArgumentCaptor<RefreshRequest> refreshRequest;
+
+	@BeforeEach
+	void setup() {
+		doReturn(transport).when(client)._transport();
+		doReturn(jsonpMapper).when(transport).jsonpMapper();
+	}
+
+	/**
+	 * Tests that refresh is called with the indices bound to the template
+	 */
+	@Test
+	void refresh() {
+		IndexCoordinates indexCoordinate = IndexCoordinates.of("i1", "i2");
+		ReactiveIndicesTemplate template = new ReactiveIndicesTemplate(client, elasticsearchConverter, indexCoordinate);
+		doReturn(Mono.empty()).when(client).refresh(any(RefreshRequest.class));
+
+		template.refresh().as(StepVerifier::create).verifyComplete();
+
+		verify(client).refresh(refreshRequest.capture());
+		assertEquals(List.of("i1", "i2"), refreshRequest.getValue().index());
+
+		verifyNoMoreInteractions(elasticsearchConverter, client, transport, jsonpMapper);
+	}
+}


### PR DESCRIPTION

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] **There is a ticket in the bug tracker for the project in our [issue tracker](https://github.
  com/spring-projects/spring-data-elasticsearch/issues)**. Add the issue number to the _Closes #issue-number_ line below
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Closes #2441
