### PR TITLE
Allow field names with dots

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/convert/MappingElasticsearchConverter.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/convert/MappingElasticsearchConverter.java
@@ -1419,7 +1419,7 @@ public class MappingElasticsearchConverter
 
 			}
 
-			if (!fieldName.contains(".")) {
+			if (property.hasExplicitFieldName() || !fieldName.contains(".")) {
 				return target.get(fieldName);
 			}
 

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentProperty.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/ElasticsearchPersistentProperty.java
@@ -40,6 +40,12 @@ public interface ElasticsearchPersistentProperty extends PersistentProperty<Elas
 	String getFieldName();
 
 	/**
+	 * @return {@literal true} if the field name comes from an explicit value in the field annotation
+	 * @since 5.1
+	 */
+	boolean hasExplicitFieldName();
+
+	/**
 	 * Returns whether the current property is a {@link SeqNoPrimaryTerm} property.
 	 *
 	 * @return true if the type is {@link SeqNoPrimaryTerm}

--- a/src/main/java/org/springframework/data/elasticsearch/core/mapping/SimpleElasticsearchPersistentProperty.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/mapping/SimpleElasticsearchPersistentProperty.java
@@ -142,7 +142,8 @@ public class SimpleElasticsearchPersistentProperty extends
 		return storeEmptyValue;
 	}
 
-	protected boolean hasExplicitFieldName() {
+	@Override
+	public boolean hasExplicitFieldName() {
 		return StringUtils.hasText(getAnnotatedFieldName());
 	}
 

--- a/src/test/java/org/springframework/data/elasticsearch/core/convert/MappingElasticsearchConverterUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/convert/MappingElasticsearchConverterUnitTests.java
@@ -1947,6 +1947,48 @@ public class MappingElasticsearchConverterUnitTests {
 		assertEquals(expected, json, true);
 	}
 
+	@Test // #2502
+	@DisplayName("should write entity with dotted field name")
+	void shouldWriteEntityWithDottedFieldName() throws JSONException {
+
+		@Language("JSON")
+		var expected = """
+				{
+					"_class": "org.springframework.data.elasticsearch.core.convert.MappingElasticsearchConverterUnitTests$FieldNameDotsEntity",
+					"id": "42",
+					"dotted.field": "dotted field"
+				}
+			""";
+		var entity = new FieldNameDotsEntity();
+		entity.setId("42");
+		entity.setDottedField("dotted field");
+
+		Document document = Document.create();
+		mappingElasticsearchConverter.write(entity, document);
+		String json = document.toJson();
+
+		assertEquals(expected, json, true);
+	}
+
+	@Test // #2502
+	@DisplayName("should read entity with dotted field name")
+	void shouldReadEntityWithDottedFieldName() {
+
+		@Language("JSON")
+		String json = """
+				{
+				  "id": "42",
+				  "dotted.field": "dotted field"
+				}""";
+
+		Document document = Document.parse(json);
+
+		FieldNameDotsEntity entity = mappingElasticsearchConverter.read(FieldNameDotsEntity.class, document);
+
+		assertThat(entity.id).isEqualTo("42");
+		assertThat(entity.getDottedField()).isEqualTo("dotted field");
+	}
+
 	// region entities
 	public static class Sample {
 		@Nullable public @ReadOnlyProperty String readOnly;
@@ -3150,6 +3192,31 @@ public class MappingElasticsearchConverterUnitTests {
 			this.mapToNotWriteWhenEmpty = mapToNotWriteWhenEmpty;
 		}
 	}
+	static class FieldNameDotsEntity {
+		@Id
+		@Nullable private String id;
+		@Nullable
+		@Field(name = "dotted.field", type = FieldType.Text) private String dottedField;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(@Nullable String id) {
+			this.id = id;
+		}
+
+		@Nullable
+		public String getDottedField() {
+			return dottedField;
+		}
+
+		public void setDottedField(@Nullable String dottedField) {
+			this.dottedField = dottedField;
+		}
+	}
+
 	// endregion
 
 	private static String reverse(Object o) {

--- a/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderIntegrationTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderIntegrationTests.java
@@ -279,6 +279,14 @@ public abstract class MappingBuilderIntegrationTests extends MappingContextBaseT
 		indexOps.createWithMapping();
 	}
 
+	@Test // #2502
+	@DisplayName(" should write mapping with field name with dots")
+	void shouldWriteMappingWithFieldNameWithDots() {
+
+		IndexOperations indexOps = operations.indexOps(FieldNameDotsEntity.class);
+		indexOps.createWithMapping();
+	}
+
 	// region Entities
 	@Document(indexName = "#{@indexNameProvider.indexName()}")
 	static class Book {
@@ -900,6 +908,13 @@ public abstract class MappingBuilderIntegrationTests extends MappingContextBaseT
 		@Field(type = FieldType.Wildcard) String wildcardField;
 		@Nullable
 		@Field(type = FieldType.Dense_Vector, dims = 1) String denseVectorField;
+	}
+	@Document(indexName = "#{@indexNameProvider.indexName()}")
+	private static class FieldNameDotsEntity {
+		@Id
+		@Nullable private String id;
+		@Nullable
+		@Field(name = "dotted.field", type = Text) private String dottedField;
 	}
 	// endregion
 }

--- a/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderUnitTests.java
@@ -1065,6 +1065,30 @@ public class MappingBuilderUnitTests extends MappingContextBaseTests {
 
 		assertEquals(expected, mapping, true);
 	}
+
+	@Test // #2502
+	@DisplayName("should use custom name with dots")
+	void shouldUseCustomNameWithDots() throws JSONException {
+
+		var expected = """
+					{
+					  "properties": {
+					    "_class": {
+					      "type": "keyword",
+					      "index": false,
+					      "doc_values": false
+					    },
+					    "dotted.field": {
+					      "type": "text"
+					    }
+					  }
+					}
+				""";
+		String mapping = getMappingBuilder().buildPropertyMapping(FieldNameDotsEntity.class);
+
+		assertEquals(expected, mapping, true);
+	}
+
 	// region entities
 
 	@Document(indexName = "ignore-above-index")
@@ -2220,8 +2244,14 @@ public class MappingBuilderUnitTests extends MappingContextBaseTests {
 		@Nullable
 		@Field(type = Text) private String someText;
 		@Nullable
-		@IndexedIndexName
-		private String storedIndexName;
+		@IndexedIndexName private String storedIndexName;
+	}
+
+	private static class FieldNameDotsEntity {
+		@Id
+		@Nullable private String id;
+		@Nullable
+		@Field(name = "dotted.field", type = Text) private String dottedField;
 	}
 	// endregion
 }


### PR DESCRIPTION
This PR adds the possbility to to define a custom field name in Elasticsearch that contains dots, for example:

```java
@Nullable
@Field(name = "dotted.text", type = FieldType.Text)
private String dottedText;
```

## terminology

dfn means dotted field name

## field mapping

It is possible to send a mapping with a dfn, and Spring Data Elasticsearch will do so for such a field:

```json
{
	"mappings": {
		"properties": {
			"dotted.field": {
				"type": "text"
			}
		}
	}
}
```

When retrieving the mapping, it is returned like nested object properties:
```json
{
	"indexname": {
		"mappings": {
			"properties": {
				"dotted": {
					"properties": {
						"field": {
							"type": "text"
						}
					}
				}
			}
		}
	}
}
```
The same happens when a document with a dfn is sent to Elasticsearch directly without using Spring Data Elasticsearch. 

## Possible queries

A property that has a dfn name can be queried with:

**`@Query` annotation**:

```java
@Query("""
	{
		"match": {
		"dotted.text": {
			"query": "?0"
			}
		}
	}
	""")
SearchHits<Foo> searchByDottedText(String text);
	}
```

**`CriteriaQuery`**:
```java
return operations.search(CriteriaQuery.builder(
	Criteria.where("dottedText").is(text))
	.build(), Foo.class);
```

**`NativeQuery`**:
```java
return operations.search(NativeQuery.builder()
	.withQuery(QueryBuilders.match(b -> b.field("dotted.text").query(text)))
	.build(), Foo.class);
```

Repository-named based queries like `findByDotted_Text()` do not work, as the parse this as a property path.

Closes #2502

