### PR TITLE
Fix inner hits metadata mapping.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/SearchHitMapping.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/SearchHitMapping.java
@@ -45,6 +45,7 @@ import org.springframework.util.Assert;
  * @author Roman Puchkovskiy
  * @author Matt Gilene
  * @author Sascha Woo
+ * @author Jakob Hoeper
  * @since 4.0
  */
 public class SearchHitMapping<T> {
@@ -154,7 +155,8 @@ public class SearchHitMapping<T> {
 		}
 
 		return highlightFields.entrySet().stream().collect(Collectors.toMap(entry -> {
-			ElasticsearchPersistentProperty property = persistentEntity.getPersistentPropertyWithFieldName(entry.getKey());
+			ElasticsearchPersistentProperty property = persistentEntity
+					.getPersistentPropertyWithFieldName(entry.getKey());
 			return property != null ? property.getName() : entry.getKey();
 		}, Map.Entry::getValue));
 	}
@@ -199,9 +201,10 @@ public class SearchHitMapping<T> {
 		}
 
 		try {
+			ElasticsearchPersistentEntity<?> persistentEntityForType = mappingContext.getPersistentEntity(type);
 			NestedMetaData nestedMetaData = searchHits.getSearchHit(0).getContent().getNestedMetaData();
 			ElasticsearchPersistentEntityWithNestedMetaData persistentEntityWithNestedMetaData = getPersistentEntity(
-					mappingContext.getPersistentEntity(type), nestedMetaData);
+					persistentEntityForType, nestedMetaData);
 
 			if (persistentEntityWithNestedMetaData.entity != null) {
 				List<SearchHit<Object>> convertedSearchHits = new ArrayList<>();
@@ -219,7 +222,8 @@ public class SearchHitMapping<T> {
 							searchDocument.getSortValues(), //
 							searchDocument.getHighlightFields(), //
 							searchHit.getInnerHits(), //
-							persistentEntityWithNestedMetaData.nestedMetaData, //
+							getPersistentEntity(persistentEntityForType, //
+									searchHit.getContent().getNestedMetaData()).nestedMetaData, //
 							searchHit.getExplanation(), //
 							searchHit.getMatchedQueries(), //
 							targetObject));


### PR DESCRIPTION
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] **There is a ticket in the bug tracker for the project in our [issue tracker](https://github.com/spring-projects/spring-data-elasticsearch/issues)**. Add the issue number to the _Closes #issue-number_ line below
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Closes #2521 


In case of multiple inner hits within e.g. a nested query, all inner hits get assigned the same `_nested` metadata (i.e. offset etc.). This change fixes that, so that inner hits have the nested metadata that Elasticsearch actually returns.