### PR TITLE
"NativeQueryBuilder" class : the "withSearchExtensions" function does not set the expected field

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/client/elc/NativeQueryBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/elc/NativeQueryBuilder.java
@@ -185,7 +185,7 @@ public class NativeQueryBuilder extends BaseQueryBuilder<NativeQuery, NativeQuer
 
 		Assert.notNull(searchExtensions, "searchExtensions must not be null");
 
-		searchExtensions.putAll(searchExtensions);
+		this.searchExtensions.putAll(searchExtensions);
 		return this;
 	}
 


### PR DESCRIPTION
This a proposal to correct this ticket : [#2542](https://github.com/spring-projects/spring-data-elasticsearch/issues/2542)