### PR TITLE
Correcting a typo in elasticsearch-repository-queries document.

### DIFF
--- a/src/main/asciidoc/reference/elasticsearch-repository-queries.adoc
+++ b/src/main/asciidoc/reference/elasticsearch-repository-queries.adoc
@@ -137,7 +137,7 @@ A list of supported keywords for Elasticsearch is shown below.
 
 
 | `GreaterThanEqual`
-| `findByPriceGreaterThan`
+| `findByPriceGreaterThanEqual`
 | `{ "query" : {
 "bool" : {
 "must" : [


### PR DESCRIPTION
I found a typo in this document.

https://docs.spring.io/spring-data/elasticsearch/docs/current/reference/html/#elasticsearch.query-methods.criterions

findByPriceGreaterThan -> findByPriceGreaterThanEqual

closes #2611