### PR TITLE
Extend BulkFailureException.failedDocuments return type to show more details about failure

### DIFF
--- a/src/main/asciidoc/reference/elasticsearch-migration-guide-5.1-5.2.adoc
+++ b/src/main/asciidoc/reference/elasticsearch-migration-guide-5.1-5.2.adoc
@@ -6,6 +6,14 @@ This section describes breaking changes from version 5.1.x to 5.2.x and how remo
 [[elasticsearch-migration-guide-5.1-5.2.breaking-changes]]
 == Breaking Changes
 
+In the `org.springframework.data.elasticsearch.BulkFailureException` class, the return type of the `getFailedDocuments` is changed from `Map<String, String>`
+to `Map<String, FailureDetails>`, which allows to get additional details about failure reasons.
+
+The definition of the `FailureDetails` class (inner to `BulkFailureException`):
+[source,java]
+public record FailureDetails(Integer status, String errorMessage) {
+}
+
 [[elasticsearch-migration-guide-5.1-5.2.deprecations]]
 == Deprecations
 

--- a/src/main/java/org/springframework/data/elasticsearch/BulkFailureException.java
+++ b/src/main/java/org/springframework/data/elasticsearch/BulkFailureException.java
@@ -21,17 +21,27 @@ import java.util.Map;
 
 /**
  * @author Peter-Josef Meisch
+ * @author Illia Ulianov
  * @since 4.1
  */
 public class BulkFailureException extends DataRetrievalFailureException {
-	private final Map<String, String> failedDocuments;
+	private final Map<String, FailureDetails> failedDocuments;
 
-	public BulkFailureException(String msg, Map<String, String> failedDocuments) {
+	public BulkFailureException(String msg, Map<String, FailureDetails> failedDocuments) {
 		super(msg);
 		this.failedDocuments = failedDocuments;
 	}
 
-	public Map<String, String> getFailedDocuments() {
+	public Map<String, FailureDetails> getFailedDocuments() {
 		return failedDocuments;
+	}
+
+	/**
+	 * Details about a document saving failure.
+	 *
+	 * @author Illia Ulianov
+	 * @since 5.2
+	 */
+	public record FailureDetails(Integer status, String errorMessage) {
 	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/client/elc/ElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/elc/ElasticsearchTemplate.java
@@ -55,6 +55,7 @@ import org.springframework.util.Assert;
  *
  * @author Peter-Josef Meisch
  * @author Hamid Rahimi
+ * @author Illia Ulianov
  * @since 4.4
  */
 public class ElasticsearchTemplate extends AbstractElasticsearchTemplate {
@@ -637,11 +638,11 @@ public class ElasticsearchTemplate extends AbstractElasticsearchTemplate {
 	protected List<IndexedObjectInformation> checkForBulkOperationFailure(BulkResponse bulkResponse) {
 
 		if (bulkResponse.errors()) {
-			Map<String, String> failedDocuments = new HashMap<>();
+			Map<String, BulkFailureException.FailureDetails> failedDocuments = new HashMap<>();
 			for (BulkResponseItem item : bulkResponse.items()) {
 
 				if (item.error() != null) {
-					failedDocuments.put(item.id(), item.error().reason());
+					failedDocuments.put(item.id(), new BulkFailureException.FailureDetails(item.status(), item.error().reason()));
 				}
 			}
 			throw new BulkFailureException(

--- a/src/main/java/org/springframework/data/elasticsearch/client/elc/ReactiveElasticsearchTemplate.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/elc/ReactiveElasticsearchTemplate.java
@@ -68,6 +68,7 @@ import org.springframework.util.StringUtils;
  * Elasticsearch client.
  *
  * @author Peter-Josef Meisch
+ * @author Illia Ulianov
  * @since 4.4
  */
 public class ReactiveElasticsearchTemplate extends AbstractReactiveElasticsearchTemplate {
@@ -250,12 +251,12 @@ public class ReactiveElasticsearchTemplate extends AbstractReactiveElasticsearch
 	private Mono<BulkResponse> checkForBulkOperationFailure(BulkResponse bulkResponse) {
 
 		if (bulkResponse.errors()) {
-			Map<String, String> failedDocuments = new HashMap<>();
+			Map<String, BulkFailureException.FailureDetails> failedDocuments = new HashMap<>();
 
 			for (BulkResponseItem item : bulkResponse.items()) {
 
 				if (item.error() != null) {
-					failedDocuments.put(item.id(), item.error().reason());
+					failedDocuments.put(item.id(), new BulkFailureException.FailureDetails(item.status(), item.error().reason()));
 				}
 			}
 			BulkFailureException exception = new BulkFailureException(

--- a/src/test/java/org/springframework/data/elasticsearch/BulkFailureExceptionTest.java
+++ b/src/test/java/org/springframework/data/elasticsearch/BulkFailureExceptionTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.elasticsearch;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Illia Ulianov
+ */
+class BulkFailureExceptionTest {
+
+	@Test // #2619
+	void shouldCreateBulkException() {
+		String documentId = "id1";
+		var failureDetails = new BulkFailureException.FailureDetails(409, "conflict");
+		var exception = new BulkFailureException("Test message", Map.of(documentId, failureDetails));
+		assertThat(exception.getFailedDocuments()).containsEntry(documentId, failureDetails);
+	}
+}


### PR DESCRIPTION
Whenever a bulk operation (insert or update) fails, there maybe a need to handle a failure of every document in a specific way based on a reason of failure. 

Relying on a `String` error message coming from native Elasticsearch library (the current implementation) is not reliable, as requires checking for a specific sub-string, and the message itself may change in the future. 

This PR proposes a change, which will expose an HTTP response code (taken from https://artifacts.elastic.co/javadoc/co/elastic/clients/elasticsearch-java/7.17.0/co/elastic/clients/elasticsearch/core/bulk/BulkResponseItem.html#status()) in addition to currently exposed error message, so that it will be much more convenient to handle specific failure reasons (e.g. 409 - conflict, when trying to save a document with version less than or equal to the currently stored in Elasticsearch).    

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.

When contributing, please make sure an issue exists in issue tracker and comment on this issue with how you want to address it. By this we not only know that someone is working on an issue, we can also align architectural questions and possible solutions before work is invested . We so can prevent that much work is put into Pull Requests that have little or no chances of being merged.

Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] **There is a ticket in the bug tracker for the project in our [issue tracker](https://github.com/spring-projects/spring-data-elasticsearch/issues)**. Add the issue number to the _Closes #issue-number_ line below
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Closes #2619 
