### PR TITLE
 Backport add IndicesOptions to search request.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/query/IndicesOptions.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/IndicesOptions.java
@@ -71,6 +71,27 @@ public class IndicesOptions {
 		this.expandWildcards = expandWildcards;
 	}
 
+	/**
+	 * @since 5.2
+	 */
+	public static IndicesOptions ofOptions(EnumSet<Option> options) {
+		return of(options, EnumSet.noneOf(WildcardStates.class));
+	}
+
+	/**
+	 * @since 5.2
+	 */
+	public static IndicesOptions oFExpandWildcards(EnumSet<WildcardStates> expandWildcards) {
+		return of(EnumSet.noneOf(Option.class), expandWildcards);
+	}
+
+	/**
+	 * @since 5.2
+	 */
+	public static IndicesOptions of(EnumSet<Option> options, EnumSet<WildcardStates> expandWildcards) {
+		return new IndicesOptions(options, expandWildcards);
+	}
+
 	public EnumSet<Option> getOptions() {
 		return options;
 	}


### PR DESCRIPTION
 Closes #2641
 Closes #2639

@sothawo
We are working to upgrade our clients on the 4.4.x line before making the upgrade to the 5.x along with ES server 8.x and encountered the issue as described in #2639 which you have graciously already addressed in the latest version. I'm just looking to backport this change to help others in the same boat upgrading to the 4.4.x line to utilize the new client before making the jump forward to the next major version.
