### PR TITLE
Fix issue #2743

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/core/query/Criteria.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/query/Criteria.java
@@ -387,7 +387,7 @@ public class Criteria {
 
 		Assert.notNull(s, "s may not be null");
 
-		assertNoBlankInWildcardQuery(s, true, false);
+		assertNoBlankInWildcardQuery(s, false, true);
 		queryCriteriaEntries.add(new CriteriaEntry(OperationKey.STARTS_WITH, s));
 		return this;
 	}
@@ -419,7 +419,7 @@ public class Criteria {
 
 		Assert.notNull(s, "s may not be null");
 
-		assertNoBlankInWildcardQuery(s, false, true);
+		assertNoBlankInWildcardQuery(s, true, false);
 		queryCriteriaEntries.add(new CriteriaEntry(OperationKey.ENDS_WITH, s));
 		return this;
 	}


### PR DESCRIPTION
[Linked Issue #2743](https://github.com/spring-projects/spring-data-elasticsearch/issues/2743)

By swap the positions of two parameter values to fix it.

``` java
public Criteria startsWith(String s) {
        ...
        // if error, the message contains '"<s>"*'
	assertNoBlankInWildcardQuery(s, false, true); 
	...
}

public Criteria endsWith(String s) {
        ...
	// if error, the message contains '*"<s>"'
	assertNoBlankInWildcardQuery(s, true, false);
	...
}
```

