### PR TITLE
Fixes Typo ElasticsearchHttpClientConfigurationCallback

### DIFF
--- a/src/main/antora/modules/ROOT/pages/elasticsearch/clients.adoc
+++ b/src/main/antora/modules/ROOT/pages/elasticsearch/clients.adoc
@@ -150,7 +150,7 @@ ClientConfiguration clientConfiguration = ClientConfiguration.builder()
     return headers;
   })
   .withClientConfigurer(                                                <.>
-    ElasticsearchClientConfigurationCallback.from(clientBuilder -> {
+    ElasticsearchHttpClientConfigurationCallback.from(clientBuilder -> {
   	  // ...
       return clientBuilder;
   	}))


### PR DESCRIPTION
Fixing typo ElasticsearchClientConfigurationCallback to ElasticsearchHttpClientConfigurationCallback.

Since it is a documentation fix, I can't check the other boxes.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] **There is a ticket in the bug tracker for the project in our [issue tracker](https://github.com/spring-projects/spring-data-elasticsearch/issues)**. Add the issue number to the _Closes #issue-number_ line below
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
