### PR TITLE
ClientConfigurer is only available in MaybeSecureClientConfigurationBuilder

### DIFF
--- a/src/main/antora/modules/ROOT/pages/elasticsearch/clients.adoc
+++ b/src/main/antora/modules/ROOT/pages/elasticsearch/clients.adoc
@@ -192,6 +192,7 @@ This callback provides a `org.elasticsearch.client.RestClientBuilder` that can b
 [source,java]
 ----
 ClientConfiguration.builder()
+    .connectedTo("localhost:9200", "localhost:9291")
     .withClientConfigurer(ElasticsearchClients.ElasticsearchRestClientConfigurationCallback.from(restClientBuilder -> {
         // configure the Elasticsearch RestClient
         return restClientBuilder;
@@ -210,6 +211,7 @@ used by the `RestClient`.
 [source,java]
 ----
 ClientConfiguration.builder()
+    .connectedTo("localhost:9200", "localhost:9291")
     .withClientConfigurer(ElasticsearchClients.ElasticsearchHttpClientConfigurationCallback.from(httpAsyncClientBuilder -> {
         // configure the HttpAsyncClient
         return httpAsyncClientBuilder;


### PR DESCRIPTION
The documentation code does not compile and I'm not sure if it's a bug in the code or a miss in the documentation.

When you want to configure a client, the doc says to use:

```java
ClientConfiguration.builder().withClientConfigurer( // ...
```

But `withClientConfigurer(ClientConfiguration.ClientConfigurationCallback<?> clientConfigurer)` is only available in `TerminalClientConfigurationBuilder` interface.

And `ClientConfiguration.builder()` returns a `ClientConfigurationBuilderWithRequiredEndpoint` interface.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.

When contributing, please make sure an issue exists in issue tracker and comment on this issue with how you want to address it. By this we not only know that someone is working on an issue, we can also align architectural questions and possible solutions before work is invested . We so can prevent that much work is put into Pull Requests that have little or no chances of being merged.

Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] **There is a ticket in the bug tracker for the project in our [issue tracker](https://github.com/spring-projects/spring-data-elasticsearch/issues)**. Add the issue number to the _Closes #issue-number_ line below
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Closes #issue-number
