### PR TITLE
Add environment variable to skip repository initialization.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/SimpleElasticsearchRepository.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/SimpleElasticsearchRepository.java
@@ -82,10 +82,12 @@ public class SimpleElasticsearchRepository<T, ID> implements ElasticsearchReposi
 		this.entityClass = this.entityInformation.getJavaType();
 		this.indexOperations = operations.indexOps(this.entityClass);
 
-		if (shouldCreateIndexAndMapping() && !indexOperations.exists()) {
-			indexOperations.createWithMapping();
-		} else if (shouldAlwaysWriteMapping()) {
-			indexOperations.putMapping();
+		if (!"true".equals(System.getenv("SPRING_DATA_ELASTICSEARCH_SKIP_REPOSITORY_INIT"))) {
+			if (shouldCreateIndexAndMapping() && !indexOperations.exists()) {
+				indexOperations.createWithMapping();
+			} else if (shouldAlwaysWriteMapping()) {
+				indexOperations.putMapping();
+			}
 		}
 	}
 

--- a/src/main/java/org/springframework/data/elasticsearch/repository/support/SimpleReactiveElasticsearchRepository.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/support/SimpleReactiveElasticsearchRepository.java
@@ -61,7 +61,9 @@ public class SimpleReactiveElasticsearchRepository<T, ID> implements ReactiveEla
 		this.operations = operations;
 		this.indexOperations = operations.indexOps(entityInformation.getJavaType());
 
-		createIndexAndMappingIfNeeded();
+		if (!"true".equals(System.getenv("SPRING_DATA_ELASTICSEARCH_SKIP_REPOSITORY_INIT"))) {
+			createIndexAndMappingIfNeeded();
+		}
 	}
 
 	private void createIndexAndMappingIfNeeded() {


### PR DESCRIPTION
lazy intialization (which could probably only be done by a method interceptor on the repository proxy) is problematic in the reactive context, so we are not using this approach.

This PR adds the possibility to just skip the initialization of the data in Elasticsearch by setting the environment variable `SPRING_DATA_ELASTICSEARCH_SKIP_REPOSITORY_INIT=true`.

If an application needs to have the repository initialized when this property is set to `true`, the `createIndexAndMappingIfNeeded()` from the `Simple(Reactive)ElasticsearchRepository` must be explicitly called before writing data with the repository.


Closes #2876 
