### PR TITLE
Fix missing parent document type specification in hasChild query example

### DIFF
--- a/src/main/antora/modules/ROOT/pages/elasticsearch/join-types.adoc
+++ b/src/main/antora/modules/ROOT/pages/elasticsearch/join-types.adoc
@@ -52,7 +52,7 @@ public class Statement {
         return routing;
     }
 
-    public void setRouting(Routing routing) {
+    public void setRouting(String routing) {
         this.routing = routing;
     }
 
@@ -199,7 +199,7 @@ void init() {
     repository.save(
         Statement.builder()
             .withText("+1 for the sun")
-            ,withRouting(savedWeather.getId())
+            .withRouting(savedWeather.getId())
             .withRelation(new JoinField<>("vote", sunnyAnswer.getId()))         <5>
             .build());
 }
@@ -226,6 +226,7 @@ SearchHits<Statement> hasVotes() {
 	Query query = NativeQuery.builder()
 		.withQuery(co.elastic.clients.elasticsearch._types.query_dsl.Query.of(qb -> qb
 			.hasChild(hc -> hc
+				.type("answer")
 				.queryName("vote")
 				.query(matchAllQueryAsQuery())
 				.scoreMode(ChildScoreMode.None)


### PR DESCRIPTION
Description:

1、This pull request addresses an issue in the Spring Data Elasticsearch documentation where the specification of the parent document type is missing in the example code for the hasChild query.

2、The Routing property in the Statement class is incorrectly typed as Routing, when it should be String according to the context.
3、In the example code, there is a typo where a comma is used instead of a period: .withText("+1 for the sun") ,withRouting(savedWeather.getId()), where it should be .withText("+1 for the sun").withRouting(savedWeather.getId()).

In Elasticsearch 8.x, it's essential to specify the parent document type when using the hasChild query. Failure to specify the parent type results in an error from Elasticsearch. This pull request adds the missing .type("answer") statement to ensure the correct behavior of the query.

Changes Made:

Added .type("answer") statement to specify the parent document type in the hasChild query.
Updated the example code to reflect the correct usage of the hasChild query.
References:

Elasticsearch Documentation: [has_child query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-child-query.html)

ClientVersion:
elastic-search-java :8.10.4

Excption：
co.elastic.clients.util.MissingRequiredPropertyException: Missing required property 'HasChildQuery.type'
at co.elastic.clients.util.ApiTypeHelper.requireNonNull(ApiTypeHelper.java:76)
at co.elastic.clients.elasticsearch._types.query_dsl.HasChildQuery.(HasChildQuery.java:82)
at co.elastic.clients.elasticsearch._types.query_dsl.HasChildQuery.(HasChildQuery.java:51)
at co.elastic.clients.elasticsearch._types.query_dsl.HasChildQuery$Builder.build(HasChildQuery.java:349)
at co.elastic.clients.elasticsearch._types.query_dsl.HasChildQuery$Builder.build(HasChildQuery.java:216)
at co.elastic.clients.elasticsearch._types.query_dsl.Query$Builder.hasChild(Query.java:1412)