### PR TITLE
fix scripted-and-runtime-fields.adoc

### DIFF
--- a/src/main/antora/modules/ROOT/pages/elasticsearch/scripted-and-runtime-fields.adoc
+++ b/src/main/antora/modules/ROOT/pages/elasticsearch/scripted-and-runtime-fields.adoc
@@ -194,7 +194,7 @@ In the following code this is used to run a query for a given gender and maximum
 
         var runtimeField = new RuntimeField("age", "long", """                    <.>
                                 Instant currentDate = Instant.ofEpochMilli(new Date().getTime());
-                                Instant startDate = doc['birth-date'].value.toInstant();
+                                Instant startDate = doc['birthDate'].value.toInstant();
                                 emit (ChronoUnit.DAYS.between(startDate, currentDate) / 365);
                 """);
 


### PR DESCRIPTION
Entity birthDate field mismatch result in a mistake
1、Person record
@Document(indexName = "persons")
public record Person(
        @Id
        @Nullable
        String id,
        @Field(type = Text)
        String lastName,
        @Field(type = Text)
        String firstName,
        @Field(type = Keyword)
        String gender,
        @Field(type = Date, format = DateFormat.basic_date)
        LocalDate birthDate,
    }
}
2、demo script 
"""
                                Instant currentDate = Instant.ofEpochMilli(new Date().getTime());
                                Instant startDate = doc['birth-date'].value.toInstant();
                                return (ChronoUnit.DAYS.between(startDate, currentDate) / 365);
  """))
  3、error log
  [es/search] failed: [search_phase_execution_exception] all shards failed
co.elastic.clients.elasticsearch._types.ElasticsearchException: [es/search] failed: [search_phase_execution_exception] all shards failed
                                
