### PR TITLE
Allow to customize the mapped type name for @InnerField and @Field annotations

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/annotations/Field.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/Field.java
@@ -243,9 +243,9 @@ public @interface Field {
 	boolean storeEmptyValue() default true;
 	
 	/**
-	 * overrides the mapping field type which otherwise will be taken from corresponding {@link FieldType}
+	 * overrides the field type in the mapping which otherwise will be taken from corresponding {@link FieldType}
 	 *
 	 * @since 5.4
 	 */
-	String mappedName() default "";
+	String mappedTypeName() default "";
 }

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/Field.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/Field.java
@@ -38,6 +38,7 @@ import org.springframework.core.annotation.AliasFor;
  * @author Morgan Lutz
  * @author Sascha Woo
  * @author Haibo Liu
+ * @author Andriy Redko
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.METHOD })
@@ -240,4 +241,11 @@ public @interface Field {
 	 * @since 5.1
 	 */
 	boolean storeEmptyValue() default true;
+	
+	/**
+	 * overrides the mapping field type which otherwise will be taken from corresponding {@link FieldType}
+	 *
+	 * @since 5.4
+	 */
+	String mappedName() default "";
 }

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/InnerField.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/InnerField.java
@@ -30,6 +30,7 @@ import java.lang.annotation.Target;
  * @author Brian Kimmig
  * @author Morgan Lutz
  * @author Haibo Liu
+ * @author Andriy Redko
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.ANNOTATION_TYPE)
@@ -171,4 +172,11 @@ public @interface InnerField {
 	 * @since 5.4
 	 */
 	KnnIndexOptions[] knnIndexOptions() default {};
+	
+	/**
+	 * overrides the mapping field type which otherwise will be taken from corresponding {@link FieldType}
+	 *
+	 * @since 5.4
+	 */
+	String mappedName() default "";
 }

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/InnerField.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/InnerField.java
@@ -174,9 +174,9 @@ public @interface InnerField {
 	KnnIndexOptions[] knnIndexOptions() default {};
 	
 	/**
-	 * overrides the mapping field type which otherwise will be taken from corresponding {@link FieldType}
+	 * overrides the field type in the mapping which otherwise will be taken from corresponding {@link FieldType}
 	 *
 	 * @since 5.4
 	 */
-	String mappedName() default "";
+	String mappedTypeName() default "";
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/index/MappingBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/index/MappingBuilder.java
@@ -212,7 +212,7 @@ public class MappingBuilder {
 		}
 
 		private void mapEntity(ObjectNode objectNode, @Nullable ElasticsearchPersistentEntity<?> entity,
-				boolean isRootObject, String nestedObjectFieldName, boolean nestedOrObjectField, FieldType fieldType, String mappedName,
+				boolean isRootObject, String nestedObjectFieldName, boolean nestedOrObjectField, FieldType fieldType, String fieldTypeMappedName,
 				@Nullable Field parentFieldAnnotation, @Nullable Dynamic dynamicMapping, @Nullable Document runtimeFields)
 				throws IOException {
 
@@ -246,7 +246,7 @@ public class MappingBuilder {
 			boolean writeNestedProperties = !isRootObject && (isAnyPropertyAnnotatedWithField(entity) || nestedOrObjectField);
 			if (writeNestedProperties) {
 
-				String type = nestedOrObjectField ? mappedName : FieldType.Object.getMappedName();
+				String type = nestedOrObjectField ? fieldTypeMappedName : FieldType.Object.getMappedName();
 
 				ObjectNode nestedObjectNode = objectMapper.createObjectNode();
 				nestedObjectNode.put(FIELD_PARAM_TYPE, type);
@@ -372,7 +372,7 @@ public class MappingBuilder {
 					nestedPropertyPrefix = nestedPropertyPath;
 
 					mapEntity(propertiesNode, persistentEntity, false, property.getFieldName(), true, fieldAnnotation.type(),
-							getMappedName(fieldAnnotation), fieldAnnotation, dynamicMapping, null);
+							getMappedTypeName(fieldAnnotation), fieldAnnotation, dynamicMapping, null);
 
 					nestedPropertyPrefix = currentNestedPropertyPrefix;
 					return;
@@ -475,7 +475,7 @@ public class MappingBuilder {
 				}
 
 				propertiesNode.set(property.getFieldName(), objectMapper.createObjectNode() //
-						.put(FIELD_PARAM_TYPE, getMappedName(field)) //
+						.put(FIELD_PARAM_TYPE, getMappedTypeName(field)) //
 						.put(MAPPING_ENABLED, false) //
 				);
 
@@ -489,8 +489,8 @@ public class MappingBuilder {
 		 * @param field field to return the mapping type name for
 		 * @return the mapping type name
 		 */
-		private String getMappedName(Field field) {
-			return StringUtils.hasText(field.mappedName()) ? field.mappedName() : field.type().getMappedName();
+		private String getMappedTypeName(Field field) {
+			return StringUtils.hasText(field.mappedTypeName()) ? field.mappedTypeName() : field.type().getMappedName();
 		}
 
 		/**

--- a/src/main/java/org/springframework/data/elasticsearch/core/index/MappingBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/index/MappingBuilder.java
@@ -69,6 +69,7 @@ import com.fasterxml.jackson.databind.util.RawValue;
  * @author Peter-Josef Meisch
  * @author Xiao Yu
  * @author Subhobrata Dey
+ * @author Andriy Redko
  */
 public class MappingBuilder {
 
@@ -175,7 +176,8 @@ public class MappingBuilder {
 						.findAnnotation(org.springframework.data.elasticsearch.annotations.Document.class);
 				var dynamicMapping = docAnnotation != null ? docAnnotation.dynamic() : null;
 
-				mapEntity(objectNode, entity, true, "", false, FieldType.Auto, null, dynamicMapping, runtimeFields);
+				final FieldType fieldType = FieldType.Auto;
+				mapEntity(objectNode, entity, true, "", false, fieldType, fieldType.getMappedName(), null, dynamicMapping, runtimeFields);
 
 				if (!excludeFromSource.isEmpty()) {
 					ObjectNode sourceNode = objectNode.putObject(SOURCE);
@@ -210,7 +212,7 @@ public class MappingBuilder {
 		}
 
 		private void mapEntity(ObjectNode objectNode, @Nullable ElasticsearchPersistentEntity<?> entity,
-				boolean isRootObject, String nestedObjectFieldName, boolean nestedOrObjectField, FieldType fieldType,
+				boolean isRootObject, String nestedObjectFieldName, boolean nestedOrObjectField, FieldType fieldType, String mappedName,
 				@Nullable Field parentFieldAnnotation, @Nullable Dynamic dynamicMapping, @Nullable Document runtimeFields)
 				throws IOException {
 
@@ -244,7 +246,7 @@ public class MappingBuilder {
 			boolean writeNestedProperties = !isRootObject && (isAnyPropertyAnnotatedWithField(entity) || nestedOrObjectField);
 			if (writeNestedProperties) {
 
-				String type = nestedOrObjectField ? fieldType.getMappedName() : FieldType.Object.getMappedName();
+				String type = nestedOrObjectField ? mappedName : FieldType.Object.getMappedName();
 
 				ObjectNode nestedObjectNode = objectMapper.createObjectNode();
 				nestedObjectNode.put(FIELD_PARAM_TYPE, type);
@@ -370,7 +372,7 @@ public class MappingBuilder {
 					nestedPropertyPrefix = nestedPropertyPath;
 
 					mapEntity(propertiesNode, persistentEntity, false, property.getFieldName(), true, fieldAnnotation.type(),
-							fieldAnnotation, dynamicMapping, null);
+							getMappedName(fieldAnnotation), fieldAnnotation, dynamicMapping, null);
 
 					nestedPropertyPrefix = currentNestedPropertyPrefix;
 					return;
@@ -473,13 +475,22 @@ public class MappingBuilder {
 				}
 
 				propertiesNode.set(property.getFieldName(), objectMapper.createObjectNode() //
-						.put(FIELD_PARAM_TYPE, field.type().getMappedName()) //
+						.put(FIELD_PARAM_TYPE, getMappedName(field)) //
 						.put(MAPPING_ENABLED, false) //
 				);
 
 			} catch (Exception e) {
 				throw new MappingException("Could not write enabled: false mapping for " + property.getFieldName(), e);
 			}
+		}
+
+		/**
+		 * Return the mapping type name to be used for the {@link Field}
+		 * @param field field to return the mapping type name for
+		 * @return the mapping type name
+		 */
+		private String getMappedName(Field field) {
+			return StringUtils.hasText(field.mappedName()) ? field.mappedName() : field.type().getMappedName();
 		}
 
 		/**

--- a/src/main/java/org/springframework/data/elasticsearch/core/index/MappingParameters.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/index/MappingParameters.java
@@ -116,6 +116,7 @@ public final class MappingParameters {
 	private final boolean store;
 	private final TermVector termVector;
 	private final FieldType type;
+	private final String mappedName;
 
 	/**
 	 * extracts the mapping parameters from the relevant annotations.
@@ -141,6 +142,7 @@ public final class MappingParameters {
 		store = field.store();
 		fielddata = field.fielddata();
 		type = field.type();
+		mappedName = StringUtils.hasText(field.mappedName()) ? field.mappedName() : type.getMappedName();
 		dateFormats = field.format();
 		dateFormatPatterns = field.pattern();
 		analyzer = field.analyzer();
@@ -187,6 +189,7 @@ public final class MappingParameters {
 		store = field.store();
 		fielddata = field.fielddata();
 		type = field.type();
+		mappedName = StringUtils.hasText(field.mappedName()) ? field.mappedName() : type.getMappedName();
 		dateFormats = field.format();
 		dateFormatPatterns = field.pattern();
 		analyzer = field.analyzer();
@@ -245,7 +248,7 @@ public final class MappingParameters {
 		}
 
 		if (type != FieldType.Auto) {
-			objectNode.put(FIELD_PARAM_TYPE, type.getMappedName());
+			objectNode.put(FIELD_PARAM_TYPE, mappedName);
 
 			if (type == FieldType.Date || type == FieldType.Date_Nanos || type == FieldType.Date_Range) {
 				List<String> formats = new ArrayList<>();

--- a/src/main/java/org/springframework/data/elasticsearch/core/index/MappingParameters.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/index/MappingParameters.java
@@ -116,7 +116,7 @@ public final class MappingParameters {
 	private final boolean store;
 	private final TermVector termVector;
 	private final FieldType type;
-	private final String mappedName;
+	private final String mappedTypeName;
 
 	/**
 	 * extracts the mapping parameters from the relevant annotations.
@@ -142,7 +142,7 @@ public final class MappingParameters {
 		store = field.store();
 		fielddata = field.fielddata();
 		type = field.type();
-		mappedName = StringUtils.hasText(field.mappedName()) ? field.mappedName() : type.getMappedName();
+		mappedTypeName = StringUtils.hasText(field.mappedTypeName()) ? field.mappedTypeName() : type.getMappedName();
 		dateFormats = field.format();
 		dateFormatPatterns = field.pattern();
 		analyzer = field.analyzer();
@@ -189,7 +189,7 @@ public final class MappingParameters {
 		store = field.store();
 		fielddata = field.fielddata();
 		type = field.type();
-		mappedName = StringUtils.hasText(field.mappedName()) ? field.mappedName() : type.getMappedName();
+		mappedTypeName = StringUtils.hasText(field.mappedTypeName()) ? field.mappedTypeName() : type.getMappedName();
 		dateFormats = field.format();
 		dateFormatPatterns = field.pattern();
 		analyzer = field.analyzer();
@@ -248,7 +248,7 @@ public final class MappingParameters {
 		}
 
 		if (type != FieldType.Auto) {
-			objectNode.put(FIELD_PARAM_TYPE, mappedName);
+			objectNode.put(FIELD_PARAM_TYPE, mappedTypeName);
 
 			if (type == FieldType.Date || type == FieldType.Date_Nanos || type == FieldType.Date_Range) {
 				List<String> formats = new ArrayList<>();

--- a/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderIntegrationTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderIntegrationTests.java
@@ -59,6 +59,7 @@ import org.springframework.lang.Nullable;
  * @author Brian Kimmig
  * @author Morgan Lutz
  * @author Haibo Liu
+ * @author Andriy Redko
  */
 @SpringIntegrationTest
 public abstract class MappingBuilderIntegrationTests extends MappingContextBaseTests {
@@ -75,6 +76,12 @@ public abstract class MappingBuilderIntegrationTests extends MappingContextBaseT
 	@Order(java.lang.Integer.MAX_VALUE)
 	void cleanup() {
 		operations.indexOps(IndexCoordinates.of(indexNameProvider.getPrefix() + "*")).delete();
+	}
+
+	@Test
+	public void shouldSupportAllTypes() {
+		IndexOperations indexOperations = operations.indexOps(EntityWithAllTypes.class);
+		indexOperations.createWithMapping();
 	}
 
 	@Test

--- a/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderUnitTests.java
@@ -2561,14 +2561,14 @@ public class MappingBuilderUnitTests extends MappingContextBaseTests {
 	@SuppressWarnings("unused")
 	private static class FieldMappedNameEntity {
 		@Nullable
-		@Field(type = Text, mappedName = "match_only_text") private String someText;
+		@Field(type = Text, mappedTypeName = "match_only_text") private String someText;
 	}
 
 	@SuppressWarnings("unused")
 	private static class MultiFieldMappedNameEntity {
 		@Nullable
-		@MultiField(mainField = @Field(type = FieldType.Text, mappedName = "match_only_text"), otherFields = { @InnerField(suffix = "lower_case",
-				type = FieldType.Keyword, normalizer = "lower_case_normalizer", mappedName = "constant_keyword") }) private String description;
+		@MultiField(mainField = @Field(type = FieldType.Text, mappedTypeName = "match_only_text"), otherFields = { @InnerField(suffix = "lower_case",
+				type = FieldType.Keyword, normalizer = "lower_case_normalizer", mappedTypeName = "constant_keyword") }) private String description;
 	}
 	// endregion
 }

--- a/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderUnitTests.java
@@ -63,6 +63,7 @@ import org.springframework.lang.Nullable;
  * @author Brian Kimmig
  * @author Morgan Lutz
  * @author Haibo Liu
+ * @author Andriy Redko
  */
 public class MappingBuilderUnitTests extends MappingContextBaseTests {
 
@@ -1242,6 +1243,59 @@ public class MappingBuilderUnitTests extends MappingContextBaseTests {
 
 		assertEquals(expected, mapping, true);
 	}
+	
+	@Test // #2942
+	@DisplayName("should use custom  mapped name")
+	void shouldUseCustomMappedName() throws JSONException {
+
+		var expected = """
+					{
+					  "properties": {
+						"_class": {
+						  "type": "keyword",
+						  "index": false,
+						  "doc_values": false
+						},
+						"someText": {
+						  "type": "match_only_text"
+						}
+					  }
+					}
+				""";
+		String mapping = getMappingBuilder().buildPropertyMapping(FieldMappedNameEntity.class);
+
+		assertEquals(expected, mapping, true);
+	}
+
+	@Test // #2942
+	@DisplayName("should use custom  mapped name for multifield")
+	void shouldUseCustomMappedNameMultiField() throws JSONException {
+
+		var expected = """
+					{
+					  "properties": {
+						"_class": {
+						  "type": "keyword",
+						  "index": false,
+						  "doc_values": false
+						},
+						"description": {
+						  "type": "match_only_text",
+						  "fields": {
+							"lower_case": {
+							  "type": "constant_keyword",
+							  "normalizer": "lower_case_normalizer"
+							}
+						  }
+						}
+					  }
+					}
+				""";
+		String mapping = getMappingBuilder().buildPropertyMapping(MultiFieldMappedNameEntity.class);
+
+		assertEquals(expected, mapping, true);
+	}
+
 	// region entities
 
 	@Document(indexName = "ignore-above-index")
@@ -2502,6 +2556,19 @@ public class MappingBuilderUnitTests extends MappingContextBaseTests {
 		@Field(type = Text) private String someText;
 		@Nullable
 		@Field(type = Text) private String otherText;
+	}
+
+	@SuppressWarnings("unused")
+	private static class FieldMappedNameEntity {
+		@Nullable
+		@Field(type = Text, mappedName = "match_only_text") private String someText;
+	}
+
+	@SuppressWarnings("unused")
+	private static class MultiFieldMappedNameEntity {
+		@Nullable
+		@MultiField(mainField = @Field(type = FieldType.Text, mappedName = "match_only_text"), otherFields = { @InnerField(suffix = "lower_case",
+				type = FieldType.Keyword, normalizer = "lower_case_normalizer", mappedName = "constant_keyword") }) private String description;
 	}
 	// endregion
 }


### PR DESCRIPTION

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.

When contributing, please make sure an issue exists in issue tracker and comment on this issue with how you want to address it. By this we not only know that someone is working on an issue, we can also align architectural questions and possible solutions before work is invested . We so can prevent that much work is put into Pull Requests that have little or no chances of being merged.

Make sure that:

-->

In Spring Data OpenSearch [1], which is built on top of Spring Data Elasticsearch, we are  running into cases where both projects differ in incompatible ways. One of such cases is supported mapping field types (baked by `org.springframework.data.elasticsearch.annotations.FieldType`), for example:

```
Flattened("flattened"), //
```

would have to become 

```
Flat_Object("flat_oblect"), //
```

for OpenSearch. 

This pull request adds optional `mappedName` attribute to `@InnerField` and` @Field` annotations (and model classes respectively), to address the possible divergence, for example:

```
@Field(type = FieldType.Flattened, mappedName = "flat_oblect") String flattenedField;
```

It would require a bit more work for OpenSearch users but not the Elasticsearch ones. The change would be non-breaking (defaults to `""` and `FieldType::getMappedType`) and work seamlessly. 

- [X] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [X] **There is a ticket in the bug tracker for the project in our [issue tracker](https://github.com/spring-projects/spring-data-elasticsearch/issues)**. Add the issue number to the _Closes #issue-number_ line below
- [X] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [X] You submit test cases (unit or integration tests) that back your changes.
- [X] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Closes https://github.com/spring-projects/spring-data-elasticsearch/issues/2942
