### PR TITLE
Add count methods to ELC's ReactiveElasticsearchClient.

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/client/elc/ReactiveElasticsearchClient.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/elc/ReactiveElasticsearchClient.java
@@ -36,6 +36,7 @@ import org.springframework.util.Assert;
  * Reactive version of {@link co.elastic.clients.elasticsearch.ElasticsearchClient}.
  *
  * @author Peter-Josef Meisch
+ * @author maryantocinn
  * @since 4.4
  */
 public class ReactiveElasticsearchClient extends ApiClient<ElasticsearchTransport, ReactiveElasticsearchClient>
@@ -225,6 +226,26 @@ public class ReactiveElasticsearchClient extends ApiClient<ElasticsearchTranspor
 		Assert.notNull(fn, "fn must not be null");
 
 		return deleteByQuery(fn.apply(new DeleteByQueryRequest.Builder()).build());
+	}
+
+	/**
+	 * @since 5.4
+	 */
+	public Mono<CountResponse> count(CountRequest request) {
+
+		Assert.notNull(request, "request must not be null");
+
+		return Mono.fromFuture(transport.performRequestAsync(request, CountRequest._ENDPOINT, transportOptions));
+	}
+
+	/**
+	 * @since 5.4
+	 */
+	public Mono<CountResponse> count(Function<CountRequest.Builder, ObjectBuilder<CountRequest>> fn) {
+
+		Assert.notNull(fn, "fn must not be null");
+
+		return count(fn.apply(new CountRequest.Builder()).build());
 	}
 
 	// endregion


### PR DESCRIPTION
Please let me know if i've missed anything as this is my first time contributing to an open source project.

- Implemented count methods using CountRequest directly with ELC's ReactiveElasticsearchClient, eliminating the need to initialize any entity or repository. 
- Refactored the existing doCount method in ReactiveElasticsearchTemplate to utilize the newly added count method.

<!--

Thank you for proposing a pull request. This template will guide you through the essential steps necessary for a pull request.

When contributing, please make sure an issue exists in issue tracker and comment on this issue with how you want to address it. By this we not only know that someone is working on an issue, we can also align architectural questions and possible solutions before work is invested . We so can prevent that much work is put into Pull Requests that have little or no chances of being merged.

Make sure that:

-->

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] **There is a ticket in the bug tracker for the project in our [issue tracker](https://github.com/spring-projects/spring-data-elasticsearch/issues)**. Add the issue number to the _Closes #issue-number_ line below
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Closes #2749
