### PR TITLE
Fix syntax errors in link formatting in adoc files

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -62,7 +62,7 @@ public class MyService {
 
 === Using the RestClient
 
-Please check the https://docs.spring.io/spring-data/elasticsearch/docs/current/reference/html/#elasticsearch.clients.configuration[official documentation] 
+Please check the https://docs.spring.io/spring-data/elasticsearch/docs/current/reference/html/#elasticsearch.clients.configuration[official documentation].
 
 === Maven configuration
 

--- a/README.adoc
+++ b/README.adoc
@@ -62,7 +62,7 @@ public class MyService {
 
 === Using the RestClient
 
-Please check the [official documentation](https://docs.spring.io/spring-data/elasticsearch/docs/current/reference/html/#elasticsearch.clients.configuration).
+Please check the https://docs.spring.io/spring-data/elasticsearch/docs/current/reference/html/#elasticsearch.clients.configuration[official documentation] 
 
 === Maven configuration
 


### PR DESCRIPTION
fix
<img width="896" alt="image" src="https://github.com/user-attachments/assets/cddadcdd-b314-4738-a2b9-5c15f17b26ed" />


