### PR TITLE
Adjust Rest5Client building by using and exposing the callbacks proded by the Elasticsearch Java client library.

### DIFF
--- a/src/main/antora/modules/ROOT/pages/elasticsearch/clients.adoc
+++ b/src/main/antora/modules/ROOT/pages/elasticsearch/clients.adoc
@@ -389,6 +389,63 @@ ClientConfiguration.builder()
 ----
 ====
 
+[[elasticsearch.clients.configurationcallbacks.connectionconfig]]
+==== Configuration of the ConnectionConfig used by the low level Elasticsearch `Rest5Client`:
+
+This callback provides a `org.apache.hc.client5.http.config.ConnectionConfig` to configure the connection that is
+used by the `Rest5Client`.
+
+====
+[source,java]
+----
+ClientConfiguration.builder()
+    .connectedTo("localhost:9200", "localhost:9291")
+    .withClientConfigurer(Rest5Clients.ElasticsearchConnectionConfigurationCallback.from(connectionConfigBuilder -> {
+        // configure the connection
+        return connectionConfigBuilder;
+    }))
+    .build();
+----
+====
+
+[[elasticsearch.clients.configurationcallbacks.connectioncmanager]]
+==== Configuration of the ConnectionManager used by the low level Elasticsearch `Rest5Client`:
+
+This callback provides a `org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder` to configure the connection manager that is
+used by the `Rest5Client`.
+
+====
+[source,java]
+----
+ClientConfiguration.builder()
+    .connectedTo("localhost:9200", "localhost:9291")
+    .withClientConfigurer(Rest5Clients.ElasticsearchConnectionManagerCallback.from(connectionManagerBuilder -> {
+        // configure the connection manager
+        return connectionManagerBuilder;
+    }))
+    .build();
+----
+====
+
+[[elasticsearch.clients.configurationcallbacks.requestconfig]]
+==== Configuration of the RequestConfig used by the low level Elasticsearch `Rest5Client`:
+
+This callback provides a `org.apache.hc.client5.http.config.RequestConfig` to configure the RequestConfig that is
+used by the `Rest5Client`.
+
+====
+[source,java]
+----
+ClientConfiguration.builder()
+    .connectedTo("localhost:9200", "localhost:9291")
+    .withClientConfigurer(Rest5Clients.ElasticsearchRequestConfigCallback.from(requestConfigBuilder -> {
+        // configure the request config
+        return requestConfigBuilder;
+    }))
+    .build();
+----
+====
+
 [[elasticsearch.clients.logging]]
 == Client Logging
 

--- a/src/main/java/org/springframework/data/elasticsearch/client/elc/rest5_client/Rest5Clients.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/elc/rest5_client/Rest5Clients.java
@@ -13,20 +13,14 @@ import java.net.URISyntaxException;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.List;
-import java.util.Locale;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 
 import javax.net.ssl.SSLContext;
 
 import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
-import org.apache.hc.client5.http.impl.DefaultAuthenticationStrategy;
-import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder;
-import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager;
 import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.impl.routing.DefaultProxyRoutePlanner;
 import org.apache.hc.core5.http.Header;
@@ -48,227 +42,269 @@ import org.springframework.util.Assert;
  */
 public final class Rest5Clients {
 
-	// values copied from Rest5ClientBuilder
-	public static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 1000;
-	public static final int DEFAULT_SOCKET_TIMEOUT_MILLIS = 30000;
-	public static final int DEFAULT_RESPONSE_TIMEOUT_MILLIS = 0; // meaning infinite
-	public static final int DEFAULT_MAX_CONN_PER_ROUTE = 10;
-	public static final int DEFAULT_MAX_CONN_TOTAL = 30;
+    // values copied from Rest5ClientBuilder
+    public static final int DEFAULT_SOCKET_TIMEOUT_MILLIS = 30000;
+    public static final int DEFAULT_RESPONSE_TIMEOUT_MILLIS = 0; // meaning infinite
 
-	private Rest5Clients() {}
+    private Rest5Clients() {
+    }
 
-	/**
-	 * Creates a low level {@link Rest5Client} for the given configuration.
-	 *
-	 * @param clientConfiguration must not be {@literal null}
-	 * @return the {@link Rest5Client}
-	 */
-	public static Rest5Client getRest5Client(ClientConfiguration clientConfiguration) {
-		return getRest5ClientBuilder(clientConfiguration).build();
-	}
+    /**
+     * Creates a low level {@link Rest5Client} for the given configuration.
+     *
+     * @param clientConfiguration must not be {@literal null}
+     * @return the {@link Rest5Client}
+     */
+    public static Rest5Client getRest5Client(ClientConfiguration clientConfiguration) {
+        return getRest5ClientBuilder(clientConfiguration).build();
+    }
 
-	private static Rest5ClientBuilder getRest5ClientBuilder(ClientConfiguration clientConfiguration) {
+    private static Rest5ClientBuilder getRest5ClientBuilder(ClientConfiguration clientConfiguration) {
 
-		HttpHost[] httpHosts = getHttpHosts(clientConfiguration);
-		Rest5ClientBuilder builder = Rest5Client.builder(httpHosts);
+        HttpHost[] httpHosts = getHttpHosts(clientConfiguration);
+        Rest5ClientBuilder builder = Rest5Client.builder(httpHosts);
 
-		if (clientConfiguration.getPathPrefix() != null) {
-			builder.setPathPrefix(clientConfiguration.getPathPrefix());
-		}
+        if (clientConfiguration.getPathPrefix() != null) {
+            builder.setPathPrefix(clientConfiguration.getPathPrefix());
+        }
 
-		HttpHeaders headers = clientConfiguration.getDefaultHeaders();
+        HttpHeaders headers = clientConfiguration.getDefaultHeaders();
 
-		if (!headers.isEmpty()) {
-			builder.setDefaultHeaders(toHeaderArray(headers));
-		}
+        if (!headers.isEmpty()) {
+            builder.setDefaultHeaders(toHeaderArray(headers));
+        }
 
-		// we need to provide our own HttpClient, as the Rest5ClientBuilder
-		// does not provide a callback for configuration the http client as the old RestClientBuilder.
-		var httpClient = createHttpClient(clientConfiguration);
-		builder.setHttpClient(httpClient);
+        // RestClientBuilder configuration callbacks from the consumer
+        for (ClientConfiguration.ClientConfigurationCallback<?> clientConfigurationCallback : clientConfiguration
+                .getClientConfigurers()) {
+            if (clientConfigurationCallback instanceof ElasticsearchRest5ClientConfigurationCallback configurationCallback) {
+                builder = configurationCallback.configure(builder);
+            }
+        }
 
-		for (ClientConfiguration.ClientConfigurationCallback<?> clientConfigurationCallback : clientConfiguration
-				.getClientConfigurers()) {
-			if (clientConfigurationCallback instanceof ElasticsearchRest5ClientConfigurationCallback configurationCallback) {
-				builder = configurationCallback.configure(builder);
-			}
-		}
+        Duration connectTimeout = clientConfiguration.getConnectTimeout();
+        Duration socketTimeout = clientConfiguration.getSocketTimeout();
 
-		return builder;
-	}
+        builder.setHttpClientConfigCallback(httpAsyncClientBuilder -> {
 
-	private static HttpHost @NonNull [] getHttpHosts(ClientConfiguration clientConfiguration) {
-		List<InetSocketAddress> hosts = clientConfiguration.getEndpoints();
-		boolean useSsl = clientConfiguration.useSsl();
-		return hosts.stream()
-				.map(it -> (useSsl ? "https" : "http") + "://" + it.getHostString() + ':' + it.getPort())
-				.map(URI::create)
-				.map(HttpHost::create)
-				.toArray(HttpHost[]::new);
-	}
+            httpAsyncClientBuilder.setUserAgent(VersionInfo.clientVersions());
+            if (clientConfiguration.getProxy().isPresent()) {
+                var proxy = clientConfiguration.getProxy().get();
+                try {
+                    var proxyRoutePlanner = new DefaultProxyRoutePlanner(HttpHost.create(proxy));
+                    httpAsyncClientBuilder.setRoutePlanner(proxyRoutePlanner);
+                } catch (URISyntaxException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            httpAsyncClientBuilder.addRequestInterceptorFirst((request, entity, context) -> {
+                clientConfiguration.getHeadersSupplier().get().forEach((header, values) -> {
+                    // The accept and content-type headers are already put on the request, despite this being the first
+                    // interceptor.
+                    if ("Accept".equalsIgnoreCase(header) || " Content-Type".equalsIgnoreCase(header)) {
+                        request.removeHeaders(header);
+                    }
+                    values.forEach(value -> request.addHeader(header, value));
+                });
+            });
 
-	private static Header[] toHeaderArray(HttpHeaders headers) {
-		return headers.entrySet().stream() //
-				.flatMap(entry -> entry.getValue().stream() //
-						.map(value -> new BasicHeader(entry.getKey(), value))) //
-				.toList().toArray(new Header[0]);
-	}
+            // add httpclient configurator callbacks provided by the configuration
+            for (ClientConfiguration.ClientConfigurationCallback<?> clientConfigurer : clientConfiguration
+                    .getClientConfigurers()) {
+                if (clientConfigurer instanceof ElasticsearchHttpClientConfigurationCallback httpClientConfigurer) {
+                    httpAsyncClientBuilder = httpClientConfigurer.configure(httpAsyncClientBuilder);
+                }
+            }
+        });
 
-	// the basic logic to create the http client is copied from the Rest5ClientBuilder class, this is taken from the
-	// Elasticsearch code, as there is no public usable instance in that
-	private static CloseableHttpAsyncClient createHttpClient(ClientConfiguration clientConfiguration) {
+        builder.setConnectionConfigCallback(connectionConfigBuilder -> {
 
-		var requestConfigBuilder = RequestConfig.custom();
-		var connectionConfigBuilder = ConnectionConfig.custom();
+            if (!connectTimeout.isNegative()) {
+                connectionConfigBuilder.setConnectTimeout(
+                        Timeout.of(Math.toIntExact(connectTimeout.toMillis()), TimeUnit.MILLISECONDS));
+            }
+            if (!socketTimeout.isNegative()) {
+                var soTimeout = Timeout.of(Math.toIntExact(socketTimeout.toMillis()), TimeUnit.MILLISECONDS);
+                connectionConfigBuilder.setSocketTimeout(soTimeout);
+            } else {
+                connectionConfigBuilder.setSocketTimeout(Timeout.of(DEFAULT_SOCKET_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
+            }
 
-		Duration connectTimeout = clientConfiguration.getConnectTimeout();
+            // add connectionConfig configurator callbacks provided by the configuration
+            for (ClientConfiguration.ClientConfigurationCallback<?> clientConfigurer : clientConfiguration
+                    .getClientConfigurers()) {
+                if (clientConfigurer instanceof ElasticsearchConnectionConfigurationCallback connectionConfigurationCallback) {
+                    connectionConfigBuilder = connectionConfigurationCallback.configure(connectionConfigBuilder);
+                }
+            }
+        });
 
-		if (!connectTimeout.isNegative()) {
-			connectionConfigBuilder.setConnectTimeout(
-					Timeout.of(Math.toIntExact(connectTimeout.toMillis()), TimeUnit.MILLISECONDS));
-		}
+        builder.setConnectionManagerCallback(poolingAsyncClientConnectionManagerBuilder -> {
 
-		Duration socketTimeout = clientConfiguration.getSocketTimeout();
+            SSLContext sslContext = null;
+            try {
+                sslContext = clientConfiguration.getCaFingerprint().isPresent()
+                        ? TransportUtils.sslContextFromCaFingerprint(clientConfiguration.getCaFingerprint().get())
+                        : (clientConfiguration.getSslContext().isPresent()
+                        ? clientConfiguration.getSslContext().get()
+                        : SSLContext.getDefault());
+            } catch (NoSuchAlgorithmException e) {
+                throw new IllegalStateException("could not create the default ssl context", e);
+            }
+            poolingAsyncClientConnectionManagerBuilder.setTlsStrategy(new BasicClientTlsStrategy(sslContext));
 
-		if (!socketTimeout.isNegative()) {
-			var soTimeout = Timeout.of(Math.toIntExact(socketTimeout.toMillis()), TimeUnit.MILLISECONDS);
-			connectionConfigBuilder.setSocketTimeout(soTimeout);
-			requestConfigBuilder.setConnectionRequestTimeout(soTimeout);
-		} else {
-			connectionConfigBuilder.setSocketTimeout(Timeout.of(DEFAULT_SOCKET_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
-			requestConfigBuilder
-					.setConnectionRequestTimeout(Timeout.of(DEFAULT_RESPONSE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
-		}
+            // add connectionManager configurator callbacks provided by the configuration
+            for (ClientConfiguration.ClientConfigurationCallback<?> clientConfigurer : clientConfiguration
+                    .getClientConfigurers()) {
+                if (clientConfigurer instanceof ElasticsearchConnectionManagerCallback connectionManagerCallback) {
+                    poolingAsyncClientConnectionManagerBuilder = connectionManagerCallback.configure(poolingAsyncClientConnectionManagerBuilder);
+                }
+            }
+        });
 
-		try {
-			SSLContext sslContext = clientConfiguration.getCaFingerprint().isPresent()
-					? TransportUtils.sslContextFromCaFingerprint(clientConfiguration.getCaFingerprint().get())
-					: (clientConfiguration.getSslContext().isPresent()
-							? clientConfiguration.getSslContext().get()
-							: SSLContext.getDefault());
+        builder.setRequestConfigCallback(requestConfigBuilder -> {
 
-			ConnectionConfig connectionConfig = connectionConfigBuilder.build();
+            if (!socketTimeout.isNegative()) {
+                var soTimeout = Timeout.of(Math.toIntExact(socketTimeout.toMillis()), TimeUnit.MILLISECONDS);
+                requestConfigBuilder.setConnectionRequestTimeout(soTimeout);
+            } else {
+                requestConfigBuilder
+                        .setConnectionRequestTimeout(Timeout.of(DEFAULT_RESPONSE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
+            }
+            // add connectionConfig configurator callbacks provided by the configuration
+            for (ClientConfiguration.ClientConfigurationCallback<?> clientConfigurer : clientConfiguration
+                    .getClientConfigurers()) {
+                if (clientConfigurer instanceof ElasticsearchRequestConfigCallback requestConfigCallback) {
+                    requestConfigBuilder = requestConfigCallback.configure(requestConfigBuilder);
+                }
+            }
+        });
 
-			PoolingAsyncClientConnectionManager defaultConnectionManager = PoolingAsyncClientConnectionManagerBuilder.create()
-					.setDefaultConnectionConfig(connectionConfig)
-					.setMaxConnPerRoute(DEFAULT_MAX_CONN_PER_ROUTE)
-					.setMaxConnTotal(DEFAULT_MAX_CONN_TOTAL)
-					.setTlsStrategy(new BasicClientTlsStrategy(sslContext))
-					.build();
+        return builder;
+    }
 
-			var requestConfig = requestConfigBuilder.build();
+    private static HttpHost @NonNull [] getHttpHosts(ClientConfiguration clientConfiguration) {
+        List<InetSocketAddress> hosts = clientConfiguration.getEndpoints();
+        boolean useSsl = clientConfiguration.useSsl();
+        return hosts.stream()
+                .map(it -> (useSsl ? "https" : "http") + "://" + it.getHostString() + ':' + it.getPort())
+                .map(URI::create)
+                .map(HttpHost::create)
+                .toArray(HttpHost[]::new);
+    }
 
-            var immutableRefToHttpClientBuilder = new Object() {
-                HttpAsyncClientBuilder httpClientBuilder = HttpAsyncClientBuilder.create()
-                        .setDefaultRequestConfig(requestConfig)
-                        .setConnectionManager(defaultConnectionManager)
-                        .setUserAgent(VersionInfo.clientVersions())
-                        .setTargetAuthenticationStrategy(new DefaultAuthenticationStrategy())
-                        .setThreadFactory(new RestClientThreadFactory());
-            };
+    private static Header[] toHeaderArray(HttpHeaders headers) {
+        return headers.entrySet().stream() //
+                .flatMap(entry -> entry.getValue().stream() //
+                        .map(value -> new BasicHeader(entry.getKey(), value))) //
+                .toList().toArray(new Header[0]);
+    }
 
-			clientConfiguration.getProxy().ifPresent(proxy -> {
-				try {
-					var proxyRoutePlanner = new DefaultProxyRoutePlanner(HttpHost.create(proxy));
-					immutableRefToHttpClientBuilder.httpClientBuilder.setRoutePlanner(proxyRoutePlanner);
-				} catch (URISyntaxException e) {
-					throw new RuntimeException(e);
-				}
-			});
+    /**
+     * {@link ClientConfiguration.ClientConfigurationCallback} to configure the Rest5Client client with a
+     * {@link Rest5ClientBuilder}
+     *
+     * @since 6.0
+     */
+    public interface ElasticsearchRest5ClientConfigurationCallback
+            extends ClientConfiguration.ClientConfigurationCallback<Rest5ClientBuilder> {
 
-			immutableRefToHttpClientBuilder.httpClientBuilder.addRequestInterceptorFirst((request, entity, context) -> {
-				clientConfiguration.getHeadersSupplier().get().forEach((header, values) -> {
-					// The accept and content-type headers are already put on the request, despite this being the first
-					// interceptor.
-					if ("Accept".equalsIgnoreCase(header) || " Content-Type".equalsIgnoreCase(header)) {
-						request.removeHeaders(header);
-					}
-					values.forEach(value -> request.addHeader(header, value));
-				});
-			});
+        static ElasticsearchRest5ClientConfigurationCallback from(
+                Function<Rest5ClientBuilder, Rest5ClientBuilder> rest5ClientBuilderCallback) {
 
-			for (ClientConfiguration.ClientConfigurationCallback<?> clientConfigurer : clientConfiguration
-					.getClientConfigurers()) {
-				if (clientConfigurer instanceof ElasticsearchHttpClientConfigurationCallback httpClientConfigurer) {
-					immutableRefToHttpClientBuilder.httpClientBuilder = httpClientConfigurer.configure(immutableRefToHttpClientBuilder.httpClientBuilder);
-				}
-			}
+            Assert.notNull(rest5ClientBuilderCallback, "rest5ClientBuilderCallback must not be null");
 
-			return immutableRefToHttpClientBuilder.httpClientBuilder.build();
-		} catch (NoSuchAlgorithmException e) {
-			throw new IllegalStateException("could not create the default ssl context", e);
-		}
-	}
+            return rest5ClientBuilderCallback::apply;
+        }
 
-	/*
-	 * Copied from the Elasticsearch code as this class is not public there.
-	 */
-	private static class RestClientThreadFactory implements ThreadFactory {
-		private static final AtomicLong CLIENT_THREAD_POOL_ID_GENERATOR = new AtomicLong();
-		private final long clientThreadPoolId;
-		private final AtomicLong clientThreadId;
+    }
 
-		private RestClientThreadFactory() {
-			this.clientThreadPoolId = CLIENT_THREAD_POOL_ID_GENERATOR.getAndIncrement();
-			this.clientThreadId = new AtomicLong();
-		}
+    /**
+     * {@link org.springframework.data.elasticsearch.client.ClientConfiguration.ClientConfigurationCallback} to configure
+     * the Elasticsearch Rest5Client's Http client with a {@link HttpAsyncClientBuilder}
+     *
+     * @since 6.0
+     */
+    public interface ElasticsearchHttpClientConfigurationCallback
+            extends ClientConfiguration.ClientConfigurationCallback<HttpAsyncClientBuilder> {
 
-		public Thread newThread(Runnable runnable) {
-			return new Thread(runnable, String.format(Locale.ROOT, "elasticsearch-rest-client-%d-thread-%d",
-					this.clientThreadPoolId, this.clientThreadId.incrementAndGet()));
-		}
-	}
+        static Rest5Clients.ElasticsearchHttpClientConfigurationCallback from(
+                Function<HttpAsyncClientBuilder, HttpAsyncClientBuilder> httpClientBuilderCallback) {
 
-	/**
-	 * {@link org.springframework.data.elasticsearch.client.ClientConfiguration.ClientConfigurationCallback} to configure
-	 * the Elasticsearch Rest5Client's Http client with a {@link HttpAsyncClientBuilder}
-	 *
-	 * @since 6.0
-	 */
-	public interface ElasticsearchHttpClientConfigurationCallback
-			extends ClientConfiguration.ClientConfigurationCallback<HttpAsyncClientBuilder> {
+            Assert.notNull(httpClientBuilderCallback, "httpClientBuilderCallback must not be null");
 
-		static Rest5Clients.ElasticsearchHttpClientConfigurationCallback from(
-				Function<HttpAsyncClientBuilder, HttpAsyncClientBuilder> httpClientBuilderCallback) {
+            return httpClientBuilderCallback::apply;
+        }
+    }
 
-			Assert.notNull(httpClientBuilderCallback, "httpClientBuilderCallback must not be null");
+    /**
+     * {@link org.springframework.data.elasticsearch.client.ClientConfiguration.ClientConfigurationCallback} to configure
+     * the Elasticsearch Rest5Client's connection with a {@link ConnectionConfig.Builder}
+     *
+     * @since 6.0
+     */
+    public interface ElasticsearchConnectionConfigurationCallback
+            extends ClientConfiguration.ClientConfigurationCallback<ConnectionConfig.Builder> {
 
-			return httpClientBuilderCallback::apply;
-		}
-	}
+        static ElasticsearchConnectionConfigurationCallback from(
+                Function<ConnectionConfig.Builder, ConnectionConfig.Builder> connectionConfigBuilderCallback) {
 
-	/**
-	 * {@link ClientConfiguration.ClientConfigurationCallback} to configure the Rest5Client client with a
-	 * {@link Rest5ClientBuilder}
-	 *
-	 * @since 6.0
-	 */
-	public interface ElasticsearchRest5ClientConfigurationCallback
-			extends ClientConfiguration.ClientConfigurationCallback<Rest5ClientBuilder> {
+            Assert.notNull(connectionConfigBuilderCallback, "connectionConfigBuilderCallback must not be null");
 
-		static ElasticsearchRest5ClientConfigurationCallback from(
-				Function<Rest5ClientBuilder, Rest5ClientBuilder> rest5ClientBuilderCallback) {
+            return connectionConfigBuilderCallback::apply;
+        }
+    }
 
-			Assert.notNull(rest5ClientBuilderCallback, "rest5ClientBuilderCallback must not be null");
+    /**
+     * {@link org.springframework.data.elasticsearch.client.ClientConfiguration.ClientConfigurationCallback} to configure
+     * the Elasticsearch Rest5Client's connection manager with a {@link PoolingAsyncClientConnectionManagerBuilder}
+     *
+     * @since 6.0
+     */
+    public interface ElasticsearchConnectionManagerCallback
+            extends ClientConfiguration.ClientConfigurationCallback<PoolingAsyncClientConnectionManagerBuilder> {
 
-			return rest5ClientBuilderCallback::apply;
-		}
-	}
+        static ElasticsearchConnectionManagerCallback from(
+                Function<PoolingAsyncClientConnectionManagerBuilder, PoolingAsyncClientConnectionManagerBuilder> connectionManagerBuilderCallback) {
 
-	public static Rest5ClientOptions.Builder getRest5ClientOptionsBuilder(@Nullable TransportOptions transportOptions) {
+            Assert.notNull(connectionManagerBuilderCallback, "connectionManagerBuilderCallback must not be null");
 
-		if (transportOptions instanceof Rest5ClientOptions rest5ClientOptions) {
-			return rest5ClientOptions.toBuilder();
-		}
+            return connectionManagerBuilderCallback::apply;
+        }
+    }
 
-		var builder = new Rest5ClientOptions.Builder(RequestOptions.DEFAULT.toBuilder());
+    /**
+     * {@link org.springframework.data.elasticsearch.client.ClientConfiguration.ClientConfigurationCallback} to configure
+     * the Elasticsearch Rest5Client's connection manager with a {@link RequestConfig.Builder}
+     *
+     * @since 6.0
+     */
+    public interface ElasticsearchRequestConfigCallback
+            extends ClientConfiguration.ClientConfigurationCallback<RequestConfig.Builder> {
 
-		if (transportOptions != null) {
-			transportOptions.headers().forEach(header -> builder.addHeader(header.getKey(), header.getValue()));
-			transportOptions.queryParameters().forEach(builder::setParameter);
-			builder.onWarnings(transportOptions.onWarnings());
-		}
+        static ElasticsearchRequestConfigCallback from(
+                Function<RequestConfig.Builder, RequestConfig.Builder> requestConfigBuilderCallback) {
 
-		return builder;
-	}
+            Assert.notNull(requestConfigBuilderCallback, "requestConfigBuilderCallback must not be null");
+
+            return requestConfigBuilderCallback::apply;
+        }
+    }
+
+    public static Rest5ClientOptions.Builder getRest5ClientOptionsBuilder(@Nullable TransportOptions transportOptions) {
+
+        if (transportOptions instanceof Rest5ClientOptions rest5ClientOptions) {
+            return rest5ClientOptions.toBuilder();
+        }
+
+        var builder = new Rest5ClientOptions.Builder(RequestOptions.DEFAULT.toBuilder());
+
+        if (transportOptions != null) {
+            transportOptions.headers().forEach(header -> builder.addHeader(header.getKey(), header.getValue()));
+            transportOptions.queryParameters().forEach(builder::setParameter);
+            builder.onWarnings(transportOptions.onWarnings());
+        }
+
+        return builder;
+    }
 }


### PR DESCRIPTION
Closes #3129
