### PR TITLE
Migrate to Jackson3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,16 +159,31 @@
 
 		<!-- Jackson JSON Mapper -->
 		<dependency>
+			<groupId>tools.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<version>3.0.2</version>
+		</dependency>
+		<dependency>
+			<groupId>tools.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>3.0.2</version>
+		</dependency>
+
+        <!-- Version 2 to use with the legacy RestClient -->
+		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
 		</dependency>
 
 		<!-- CDI -->
-
 		<dependency>
 			<groupId>javax.interceptor</groupId>
 			<artifactId>javax.interceptor-api</artifactId>

--- a/src/main/java/org/springframework/data/elasticsearch/client/elc/ElasticsearchConfiguration.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/elc/ElasticsearchConfiguration.java
@@ -17,12 +17,14 @@ package org.springframework.data.elasticsearch.client.elc;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.json.JsonpMapper;
-import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.json.jackson.Jackson3JsonpMapper;
 import co.elastic.clients.transport.ElasticsearchTransport;
 import co.elastic.clients.transport.TransportOptions;
 import co.elastic.clients.transport.rest5_client.Rest5ClientOptions;
 import co.elastic.clients.transport.rest5_client.low_level.RequestOptions;
 import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
+import tools.jackson.databind.cfg.JsonNodeFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
@@ -31,10 +33,6 @@ import org.springframework.data.elasticsearch.config.ElasticsearchConfigurationS
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
 import org.springframework.util.Assert;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 
 /**
  * Base class for a @{@link org.springframework.context.annotation.Configuration} class to set up the Elasticsearch
@@ -128,10 +126,11 @@ public abstract class ElasticsearchConfiguration extends ElasticsearchConfigurat
 		// we need to create our own objectMapper that keeps null values in order to provide the storeNullValue
 		// functionality. The one Elasticsearch would provide removes the nulls. We remove unwanted nulls before they get
 		// into this mapper, so we can safely keep them here.
-		var objectMapper = (new ObjectMapper())
-				.configure(SerializationFeature.INDENT_OUTPUT, false)
-				.setSerializationInclusion(JsonInclude.Include.ALWAYS);
-		return new JacksonJsonpMapper(objectMapper);
+		JsonMapper jsonMapper = JsonMapper.builder()
+				.enable(JsonNodeFeature.WRITE_NULL_PROPERTIES)
+				.enable(JsonNodeFeature.READ_NULL_PROPERTIES)
+				.build();
+		return new Jackson3JsonpMapper(jsonMapper);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/elasticsearch/client/elc/ElasticsearchLegacyRestClientConfiguration.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/elc/ElasticsearchLegacyRestClientConfiguration.java
@@ -47,7 +47,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
  * @since 4.4
  * @deprecated since 6.0, use {@link ElasticsearchConfiguration}
  */
-@Deprecated(since = "6.0", forRemoval=true)
+@Deprecated(since = "6.0", forRemoval = true)
 public abstract class ElasticsearchLegacyRestClientConfiguration extends ElasticsearchConfigurationSupport {
 
 	/**

--- a/src/main/java/org/springframework/data/elasticsearch/client/elc/ReactiveElasticsearchConfiguration.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/elc/ReactiveElasticsearchConfiguration.java
@@ -16,12 +16,14 @@
 package org.springframework.data.elasticsearch.client.elc;
 
 import co.elastic.clients.json.JsonpMapper;
-import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.json.jackson.Jackson3JsonpMapper;
 import co.elastic.clients.transport.ElasticsearchTransport;
 import co.elastic.clients.transport.TransportOptions;
 import co.elastic.clients.transport.rest5_client.Rest5ClientOptions;
 import co.elastic.clients.transport.rest5_client.low_level.RequestOptions;
 import co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
+import tools.jackson.databind.cfg.JsonNodeFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 import org.elasticsearch.client.RestClient;
 import org.springframework.context.annotation.Bean;
@@ -31,10 +33,6 @@ import org.springframework.data.elasticsearch.config.ElasticsearchConfigurationS
 import org.springframework.data.elasticsearch.core.ReactiveElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
 import org.springframework.util.Assert;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 
 /**
  * Base class for a @{@link org.springframework.context.annotation.Configuration} class to set up the Elasticsearch
@@ -127,10 +125,11 @@ public abstract class ReactiveElasticsearchConfiguration extends ElasticsearchCo
 		// we need to create our own objectMapper that keeps null values in order to provide the storeNullValue
 		// functionality. The one Elasticsearch would provide removes the nulls. We remove unwanted nulls before they get
 		// into this mapper, so we can safely keep them here.
-		var objectMapper = (new ObjectMapper())
-				.configure(SerializationFeature.INDENT_OUTPUT, false)
-				.setSerializationInclusion(JsonInclude.Include.ALWAYS);
-		return new JacksonJsonpMapper(objectMapper);
+		JsonMapper jsonMapper = JsonMapper.builder()
+				.enable(JsonNodeFeature.WRITE_NULL_PROPERTIES)
+				.enable(JsonNodeFeature.READ_NULL_PROPERTIES)
+				.build();
+		return new Jackson3JsonpMapper(jsonMapper);
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/elasticsearch/core/document/Document.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/document/Document.java
@@ -15,7 +15,8 @@
  */
 package org.springframework.data.elasticsearch.core.document;
 
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -87,7 +88,7 @@ public interface Document extends StringObjectMap<Document> {
 		clear();
 		try {
 			putAll(MapDocument.OBJECT_MAPPER.readerFor(Map.class).readValue(json));
-		} catch (IOException e) {
+		} catch (JacksonException e) {
 			throw new ConversionException("Cannot parse JSON", e);
 		}
 		return this;

--- a/src/main/java/org/springframework/data/elasticsearch/core/document/MapDocument.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/document/MapDocument.java
@@ -15,6 +15,9 @@
  */
 package org.springframework.data.elasticsearch.core.document;
 
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -24,9 +27,6 @@ import java.util.function.BiConsumer;
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.elasticsearch.support.DefaultStringObjectMap;
 import org.springframework.data.mapping.MappingException;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * {@link Document} implementation backed by a {@link LinkedHashMap}.
@@ -344,7 +344,7 @@ class MapDocument implements Document {
 	public String toJson() {
 		try {
 			return OBJECT_MAPPER.writeValueAsString(this);
-		} catch (JsonProcessingException e) {
+		} catch (JacksonException e) {
 			throw new MappingException("Cannot render document to JSON", e);
 		}
 	}

--- a/src/main/java/org/springframework/data/elasticsearch/core/geo/CustomGeoModule.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/geo/CustomGeoModule.java
@@ -1,26 +1,25 @@
 package org.springframework.data.elasticsearch.core.geo;
 
-import java.io.IOException;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.Version;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.ValueSerializer;
+
 import org.springframework.data.geo.Point;
 
-class PointSerializer extends JsonSerializer<Point> {
+class PointSerializer extends ValueSerializer<Point> {
 	@Override
-	public void serialize(Point value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-		gen.writeObject(GeoPoint.fromPoint(value));
+	public void serialize(Point value, JsonGenerator gen, SerializationContext serializers) throws JacksonException {
+		gen.writePOJO(GeoPoint.fromPoint(value));
 	}
 }
 
-class PointDeserializer extends JsonDeserializer<Point> {
+class PointDeserializer extends ValueDeserializer<Point> {
 	@Override
-	public Point deserialize(JsonParser p, DeserializationContext context) throws IOException {
+	public Point deserialize(JsonParser p, DeserializationContext context) throws JacksonException {
 		return GeoPoint.toPoint(p.readValueAs(GeoPoint.class));
 	}
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/index/GeoShapeMappingParameters.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/index/GeoShapeMappingParameters.java
@@ -15,13 +15,13 @@
  */
 package org.springframework.data.elasticsearch.core.index;
 
+import tools.jackson.databind.node.ObjectNode;
+
 import java.io.IOException;
 
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.elasticsearch.annotations.GeoShapeField;
 import org.springframework.util.Assert;
-
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * @author Peter-Josef Meisch

--- a/src/main/java/org/springframework/data/elasticsearch/core/index/MappingBuilder.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/index/MappingBuilder.java
@@ -18,6 +18,13 @@ package org.springframework.data.elasticsearch.core.index;
 import static org.springframework.data.elasticsearch.core.index.MappingParameters.*;
 import static org.springframework.util.StringUtils.*;
 
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.StringNode;
+import tools.jackson.databind.util.RawValue;
+
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.nio.charset.Charset;
@@ -47,13 +54,6 @@ import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.PropertyHandler;
 import org.springframework.util.StreamUtils;
 import org.springframework.util.StringUtils;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
-import com.fasterxml.jackson.databind.util.RawValue;
 
 /**
  * @author Rizwan Idrees
@@ -184,7 +184,7 @@ public class MappingBuilder {
 				if (!excludeFromSource.isEmpty()) {
 					ObjectNode sourceNode = objectNode.putObject(SOURCE);
 					ArrayNode excludes = sourceNode.putArray(SOURCE_EXCLUDES);
-					excludeFromSource.stream().map(TextNode::new).forEach(excludes::add);
+					excludeFromSource.stream().map(StringNode::new).forEach(excludes::add);
 				}
 
 				return objectMapper.writer().writeValueAsString(objectNode);
@@ -238,7 +238,7 @@ public class MappingBuilder {
 
 				if (mappingAnnotation.dynamicDateFormats().length > 0) {
 					objectNode.putArray(DYNAMIC_DATE_FORMATS).addAll(Arrays.stream(mappingAnnotation.dynamicDateFormats())
-							.map(TextNode::valueOf).collect(Collectors.toList()));
+							.map(StringNode::valueOf).collect(Collectors.toList()));
 				}
 
 				if (runtimeFields != null) {
@@ -546,7 +546,7 @@ public class MappingBuilder {
 
 				if (children.length > 1) {
 					relationsNode.putArray(parent)
-							.addAll(Arrays.stream(children).map(TextNode::valueOf).collect(Collectors.toList()));
+							.addAll(Arrays.stream(children).map(StringNode::valueOf).collect(Collectors.toList()));
 				} else if (children.length == 1) {
 					relationsNode.put(parent, children[0]);
 				}

--- a/src/main/java/org/springframework/data/elasticsearch/core/index/MappingParameters.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/index/MappingParameters.java
@@ -15,6 +15,9 @@
  */
 package org.springframework.data.elasticsearch.core.index;
 
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.StringNode;
+
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
@@ -27,9 +30,6 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.data.elasticsearch.annotations.*;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
-
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
 
 /**
  * A class to hold the mapping parameters that might be set on
@@ -285,7 +285,7 @@ public final class MappingParameters {
 
 		if (copyTo != null && copyTo.length > 0) {
 			objectNode.putArray(FIELD_PARAM_COPY_TO)
-					.addAll(Arrays.stream(copyTo).map(TextNode::valueOf).collect(Collectors.toList()));
+					.addAll(Arrays.stream(copyTo).map(StringNode::valueOf).collect(Collectors.toList()));
 		}
 
 		if (ignoreAbove != null) {

--- a/src/main/java/org/springframework/data/elasticsearch/support/DefaultStringObjectMap.java
+++ b/src/main/java/org/springframework/data/elasticsearch/support/DefaultStringObjectMap.java
@@ -15,7 +15,9 @@
  */
 package org.springframework.data.elasticsearch.support;
 
-import java.io.IOException;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -24,9 +26,6 @@ import java.util.function.BiConsumer;
 
 import org.jspecify.annotations.Nullable;
 import org.springframework.util.Assert;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Peter-Josef Meisch
@@ -48,7 +47,7 @@ public class DefaultStringObjectMap<T extends StringObjectMap<T>> implements Str
 	public String toJson() {
 		try {
 			return OBJECT_MAPPER.writeValueAsString(this);
-		} catch (JsonProcessingException e) {
+		} catch (JacksonException e) {
 			throw new IllegalArgumentException("Cannot render document to JSON", e);
 		}
 	}
@@ -61,7 +60,7 @@ public class DefaultStringObjectMap<T extends StringObjectMap<T>> implements Str
 		delegate.clear();
 		try {
 			delegate.putAll(OBJECT_MAPPER.readerFor(Map.class).readValue(json));
-		} catch (IOException e) {
+		} catch (JacksonException e) {
 			throw new IllegalArgumentException("Cannot parse JSON", e);
 		}
 		return (T) this;


### PR DESCRIPTION
Jackson2 ist still needed as runtime optional dependency for users that still use the old RestClient.

Closes #3113
