### PR TITLE
make AOT hints for ELC optional

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/client/elc/aot/ElasticsearchClientRuntimeHints.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/elc/aot/ElasticsearchClientRuntimeHints.java
@@ -15,15 +15,10 @@
  */
 package org.springframework.data.elasticsearch.client.elc.aot;
 
-import co.elastic.clients.elasticsearch._types.mapping.RuntimeFieldType;
-import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
-import co.elastic.clients.elasticsearch.indices.IndexSettings;
-import co.elastic.clients.elasticsearch.indices.PutMappingRequest;
-import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
-import org.springframework.aot.hint.TypeReference;
 import org.springframework.lang.Nullable;
+import org.springframework.util.ClassUtils;
 
 /**
  * runtime hints for the Elasticsearch client libraries, as these do not provide any of their own.
@@ -37,17 +32,22 @@ public class ElasticsearchClientRuntimeHints implements RuntimeHintsRegistrar {
 	public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
 
 		hints.reflection()
-				.registerType(TypeReference.of(IndexSettings.class), builder -> builder.withField("_DESERIALIZER")) //
-				.registerType(TypeReference.of(PutMappingRequest.class), builder -> builder.withField("_DESERIALIZER")) //
-				.registerType(TypeReference.of(RuntimeFieldType.class), builder -> builder.withField("_DESERIALIZER"))//
-				.registerType(TypeReference.of(TypeMapping.class), builder -> builder.withField("_DESERIALIZER")) //
-		;
+				.registerTypeIfPresent(classLoader, "co.elastic.clients.elasticsearch.indices.IndexSettings",
+						builder -> builder.withField("_DESERIALIZER"))
+				.registerTypeIfPresent(classLoader, "co.elastic.clients.elasticsearch.indices.PutMappingRequest",
+						builder -> builder.withField("_DESERIALIZER"))
+				.registerTypeIfPresent(classLoader, "co.elastic.clients.elasticsearch._types.mapping.RuntimeFieldType",
+						builder -> builder.withField("_DESERIALIZER"))
+				.registerTypeIfPresent(classLoader, "co.elastic.clients.elasticsearch._types.mapping.TypeMapping",
+						builder -> builder.withField("_DESERIALIZER"));
 
-		hints.serialization() //
-				.registerType(org.apache.http.impl.auth.BasicScheme.class) //
-				.registerType(org.apache.http.impl.auth.RFC2617Scheme.class) //
-				.registerType(java.util.HashMap.class) //
-		;
+		if (ClassUtils.isPresent("org.apache.http.impl.auth.BasicScheme", classLoader)) {
+			hints.serialization() //
+					.registerType(org.apache.http.impl.auth.BasicScheme.class) //
+					.registerType(org.apache.http.impl.auth.RFC2617Scheme.class) //
+					.registerType(java.util.HashMap.class) //
+			;
+		}
 
 		hints.resources() //
 				.registerPattern("co/elastic/clients/version.properties") //


### PR DESCRIPTION
cherry-pick of #3267 (6.1.x) & 6b3646bcc1ef0541df63fbbbc569d1a3c786c5a2 (6.0.x) to 5.5.x since i saw that you plan on a new release there as well (#3256) => that'd allow me to start using it immediately without having to upgrade from SB 3.5.x to SB 4.0.x first (i have some blockers in my dependency tree for that 😕)

tracked by #3268