### PR TITLE
Fix async Rest5 client withHeaders() not seeing ThreadLocal auth (#3300)

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/client/elc/rest5_client/Rest5Clients.java
+++ b/src/main/java/org/springframework/data/elasticsearch/client/elc/rest5_client/Rest5Clients.java
@@ -93,16 +93,18 @@ public final class Rest5Clients {
 					throw new RuntimeException(e);
 				}
 			}
-			httpAsyncClientBuilder.addRequestInterceptorFirst((request, entity, context) -> {
-				clientConfiguration.getHeadersSupplier().get().forEach((header, values) -> {
-					// The accept and content-type headers are already put on the request, despite this being the first
-					// interceptor.
-					if ("Accept".equalsIgnoreCase(header) || " Content-Type".equalsIgnoreCase(header)) {
-						request.removeHeaders(header);
-					}
-					values.forEach(value -> request.addHeader(header, value));
-				});
-			});
+			httpAsyncClientBuilder.addExecInterceptorFirst("es-rest5-client",
+					(request, entityProducer, scope, chain, asyncExecCallback) -> {
+						clientConfiguration.getHeadersSupplier().get().forEach((header, values) -> {
+							// The accept and content-type headers may already be put on the request, despite this being the
+							// first interceptor.
+							if ("Accept".equalsIgnoreCase(header) || "Content-Type".equalsIgnoreCase(header)) {
+								request.removeHeaders(header);
+							}
+							values.forEach(value -> request.addHeader(header, value));
+						});
+						chain.proceed(request, entityProducer, scope, asyncExecCallback);
+					});
 
 			// add httpclient configurator callbacks provided by the configuration
 			for (ClientConfiguration.ClientConfigurationCallback<?> clientConfigurer : clientConfiguration

--- a/src/test/java/org/springframework/data/elasticsearch/client/RestClientsTest.java
+++ b/src/test/java/org/springframework/data/elasticsearch/client/RestClientsTest.java
@@ -32,6 +32,7 @@ import io.specto.hoverfly.junit5.api.HoverflyConfig;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -108,6 +109,8 @@ public class RestClientsTest {
 			AtomicInteger connectionConfigurerCount = new AtomicInteger(0);
 			AtomicInteger connectionManagerConfigurerCount = new AtomicInteger(0);
 			AtomicInteger requestConfigurerCount = new AtomicInteger(0);
+			ThreadLocal<String> threadLocal = ThreadLocal.withInitial(() -> null);
+			AtomicReference<String> supplierThreadName = new AtomicReference<>();
 
 			ClientConfigurationBuilder configurationBuilder = new ClientConfigurationBuilder();
 			configurationBuilder //
@@ -115,7 +118,9 @@ public class RestClientsTest {
 					.withBasicAuth("user", "password") //
 					.withDefaultHeaders(defaultHeaders) //
 					.withHeaders(() -> {
+						supplierThreadName.set(Thread.currentThread().getName());
 						HttpHeaders httpHeaders = new HttpHeaders();
+						httpHeaders.add("thread", threadLocal.get());
 						httpHeaders.add("supplied", "val0");
 						httpHeaders.add("supplied", "val" + supplierCount.getAndIncrement());
 						return httpHeaders;
@@ -179,6 +184,7 @@ public class RestClientsTest {
 			// do several calls to check that the headerSupplier provided values are set
 			int startValue = clientUnderTest.usesInitialRequest() ? 2 : 1;
 			for (int i = startValue; i <= startValue + 2; i++) {
+				threadLocal.set("local");
 				clientUnderTest.ping();
 
 				verify(headRequestedFor(urlEqualTo("/")) //
@@ -189,9 +195,14 @@ public class RestClientsTest {
 						.withHeader("supplied", new EqualToPattern("val0")) //
 						// on the first call Elasticsearch does the version check and thus already increments the counter
 						.withHeader("supplied", new EqualToPattern("val" + i)) //
-						.withHeader("supplied", including("val0", "val" + i)));
+						.withHeader("supplied", including("val0", "val" + i)) //
+						.withHeader("thread", new EqualToPattern("local")));
 				;
 			}
+
+			// the headers supplier must run on the calling thread, so a ThreadLocal set above is visible (#3300).
+			// this guards against future regressions that move the supplier back onto the async I/O thread.
+			assertThat(supplierThreadName.get()).isEqualTo(Thread.currentThread().getName());
 
 			assertThat(restClientConfigurerCount).hasValue(clientUnderTestFactory.getExpectedRestClientConfigurerCalls());
 			assertThat(httpClientConfigurerCount).hasValue(1);


### PR DESCRIPTION
## Summary

`ClientConfiguration.withHeaders()` configured with a `Supplier<HttpHeaders>` that reads a `ThreadLocal` (typical for Spring Security's `SecurityContextHolder`) silently fails on the new Rest5 async client.

## Root cause

`Rest5Clients.getRest5ClientBuilder(...)` registered the headers supplier as an `HttpRequestInterceptor` on the `HttpAsyncClientBuilder`. In HC 5, request interceptors run on the I/O reactor thread, so the supplier executes **off the calling thread** and cannot see any `ThreadLocal` set by the caller.

The legacy `RestClients` (HC 4) used `addInterceptorLast`, which runs synchronously on the calling thread, so the bug does not manifest there.

## Fix

Replace `addRequestInterceptorFirst` with `addExecInterceptorFirst`. The `AsyncExecChain` handler executes on the calling thread before the request is dispatched asynchronously, so the supplier now sees the caller's `ThreadLocal`.

While there, fix a pre-existing typo: `" Content-Type"` had a leading space so the override never matched the real `Content-Type` header.

## Regression test

`RestClientsTest.shouldConfigureClientAndSetAllRequiredHeaders` now:

1. Reads a `ThreadLocal` inside the headers supplier and exposes the value as a `thread` header.
2. Sets the `ThreadLocal` on the calling thread before invoking `client.ping()`.
3. Verifies that wireMock received the `thread: local` header.
4. Asserts the supplier thread name equals the calling thread name, locking in the root cause against future regressions that would move the supplier back onto the async I/O thread.

The test runs against all three client factories (`ElasticsearchRestClient` / `ElasticsearchRest5Client` / `ReactiveElasticsearchClient (ELC based)`). Only the Rest5 factory exercises the changed code; the others serve as a regression net.

#3300