### PR TITLE
Allow to provide non-standard (custom) index options for @Field / @InnerField

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/annotations/CustomIndexOption.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/CustomIndexOption.java
@@ -24,7 +24,7 @@ import org.springframework.data.elasticsearch.core.index.IndexOptionMapper;
  * 
  * @author Andriy Redko
  * 
- * @since 6.1.1
+ * @since 6.2
  */
 public @interface CustomIndexOption {
     /**

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/CustomIndexOption.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/CustomIndexOption.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.elasticsearch.annotations;
+
+import org.springframework.data.elasticsearch.core.index.IndexOptionMapper;
+
+/**
+ * Represents the custom index option, either not provided by the core (fe, custom plugin)
+ * or deviates across different engines.
+ * 
+ * @author Andriy Redko
+ * 
+ * @since 6.1.1
+ */
+public @interface CustomIndexOption {
+    /**
+     * The name of the custom index option 
+     */
+    String name();
+
+    /**
+     * The value(s) of the custom index option 
+     */
+    String[] values() default {};
+
+    /**
+     * Should the index property be overridden if already present or not 
+     */
+    boolean overrideIfPresent() default false;
+    
+    /**
+     * The index option mapper that will be used to populate this custom index option
+     */
+    Class<? extends IndexOptionMapper> mapper();
+}

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/Field.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/Field.java
@@ -252,4 +252,11 @@ public @interface Field {
 	 * @since 5.4
 	 */
 	String mappedTypeName() default "";
+	
+    /**
+     * adds the custom index options for a particular field
+     *
+     * @since 6.1.1
+     */
+	CustomIndexOption[] customIndexOptions() default {};
 }

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/Field.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/Field.java
@@ -256,7 +256,7 @@ public @interface Field {
     /**
      * adds the custom index options for a particular field
      *
-     * @since 6.1.1
+     * @since 6.2
      */
 	CustomIndexOption[] customIndexOptions() default {};
 }

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/InnerField.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/InnerField.java
@@ -183,7 +183,7 @@ public @interface InnerField {
     /**
      * adds the custom index options for a particular field
      *
-     * @since 6.1.1
+     * @since 6.2
      */
     CustomIndexOption[] customIndexOptions() default {};
 }

--- a/src/main/java/org/springframework/data/elasticsearch/annotations/InnerField.java
+++ b/src/main/java/org/springframework/data/elasticsearch/annotations/InnerField.java
@@ -179,4 +179,11 @@ public @interface InnerField {
 	 * @since 5.4
 	 */
 	String mappedTypeName() default "";
+	
+    /**
+     * adds the custom index options for a particular field
+     *
+     * @since 6.1.1
+     */
+    CustomIndexOption[] customIndexOptions() default {};
 }

--- a/src/main/java/org/springframework/data/elasticsearch/core/index/IndexOptionMapper.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/index/IndexOptionMapper.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.elasticsearch.core.index;
+
+import org.springframework.data.elasticsearch.annotations.CustomIndexOption;
+
+import tools.jackson.databind.node.ObjectNode;
+
+
+/**
+ * Writes the particular instance of the {@code CustomIndexOption} into the mapping, 
+ * represented by objectNode.
+ * 
+ * @author Andriy Redko
+ * 
+ * @since 6.1.1
+ */
+public interface IndexOptionMapper {
+    void writeIndexOptionTo(CustomIndexOption indexOption, ObjectNode objectNode);
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/index/IndexOptionMapper.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/index/IndexOptionMapper.java
@@ -27,7 +27,7 @@ import tools.jackson.databind.node.ObjectNode;
  * 
  * @author Andriy Redko
  * 
- * @since 6.1.1
+ * @since 6.2
  */
 public interface IndexOptionMapper {
     void writeIndexOptionTo(CustomIndexOption indexOption, ObjectNode objectNode);

--- a/src/main/java/org/springframework/data/elasticsearch/core/index/IndexOptionMappers.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/index/IndexOptionMappers.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.elasticsearch.core.index;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+
+import org.springframework.data.elasticsearch.annotations.CustomIndexOption;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.BigIntegerNode;
+import tools.jackson.databind.node.BooleanNode;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.StringNode;
+import tools.jackson.databind.node.DecimalNode;
+
+/**
+ * The collection of predefined {@link IndexOptionMapper}s
+ * 
+ * @author Andriy Redko
+ * 
+ * @since 6.1.1
+ */
+public final class IndexOptionMappers {
+	private IndexOptionMappers() {
+	}
+
+	/**
+	 * Writes the {@link CustomIndexOption} instance into mapping as JSON string (or array of strings) property
+	 */
+	public static final class StringMapper implements IndexOptionMapper {
+	@Override
+		public void writeIndexOptionTo(CustomIndexOption indexOption, ObjectNode objectNode) {
+			final String[] values = indexOption.values();
+			if (values.length == 1) {
+				writePropertyAsString(indexOption.name(), indexOption.overrideIfPresent(), values[0], objectNode);
+			} else if (values.length > 1) {
+				writePropertyAsArray(indexOption.name(), indexOption.overrideIfPresent(), values, objectNode);
+			} else {
+				removeProperty(indexOption.name(), objectNode);
+			}
+		}
+	}
+
+	/**
+	 * Writes the {@link CustomIndexOption} instance into mapping as JSON number (or array of numbers) property
+	 */
+	public static final class NumberMapper implements IndexOptionMapper {
+		@Override
+		public void writeIndexOptionTo(CustomIndexOption indexOption, ObjectNode objectNode) {
+			final Number[] values = toNumbers(indexOption.values());
+			if (values.length == 1) {
+				writePropertyAsNumber(indexOption.name(), indexOption.overrideIfPresent(), values[0], objectNode);
+			} else if (values.length > 1) {
+				writePropertyAsArray(indexOption.name(), indexOption.overrideIfPresent(), values, objectNode);
+			} else {
+				removeProperty(indexOption.name(), objectNode);
+			}
+		}
+	}
+
+	/**
+	 * Writes the {@link CustomIndexOption} instance into mapping as JSON boolean (or array of booleans) property
+	 */
+	public static final class BooleanMapper implements IndexOptionMapper {
+		@Override
+		public void writeIndexOptionTo(CustomIndexOption indexOption, ObjectNode objectNode) {
+			final Boolean[] values = toBoolean(indexOption.values());
+			if (values.length == 1) {
+				writePropertyAsBoolean(indexOption.name(), indexOption.overrideIfPresent(), values[0], objectNode);
+			} else if (values.length > 1) {
+				writePropertyAsArray(indexOption.name(), indexOption.overrideIfPresent(), values, objectNode);
+			} else {
+				removeProperty(indexOption.name(), objectNode);
+			}
+		}
+	}
+
+	/**
+	 * Convert the array of strings to array of booleans.
+	 * 
+	 * @param values array of strings
+	 * @return array of booleans
+	 */
+	private static Boolean[] toBoolean(String[] values) {
+		return Arrays.stream(values).map(Boolean::valueOf).toArray(Boolean[]::new);
+	}
+
+	/**
+	 * Convert the array of strings to array of numbers, throwing {@link NumberFormatException} if the conversion 
+	 * is not possible.
+	 * 
+	 * @param values array of strings
+	 * @return array of numbers
+	 * 
+	 * @throws NumberFormatException
+	 */
+	private static Number[] toNumbers(String[] values) {
+		final Number[] numbers = new Number[values.length];
+		for (int j = 0; j < values.length; ++j) {
+			if (values[j] == null) {
+				numbers[j] = null;
+			} else if(values[j].isBlank()) {
+				throw new NumberFormatException("Unable to convert empty/blank string to number");
+			} else {
+				final String s = values[j].trim();
+
+				boolean isInteger = false;
+				for (int i = 0; i < s.length(); i++) {
+					if (i == 0 && (s.charAt(i) == '-' || s.charAt(i) == '+')) {
+						if (s.length() == 1) {
+							throw new NumberFormatException("Unable to convert string  '" + s + "' to number");
+						} else {
+							continue;
+						}
+					}
+
+					if (Character.digit(s.charAt(i), 10) < 0) {
+						isInteger = false;
+						break;
+					}
+				}
+
+				if (isInteger) {
+					numbers[j] = new BigInteger(s);
+				} else {
+					numbers[j] = new BigDecimal(s);
+				}
+			}
+		}
+
+		return numbers;
+	}
+
+	/**
+	 * Writes a property as a JSON boolean value.
+	 * 
+	 * @param name property name
+	 * @param override override if present
+	 * @param value property value
+	 * @param objectNode JSON object node
+	 */
+	private static void writePropertyAsBoolean(String name, boolean override, Boolean value, ObjectNode objectNode) {
+		final boolean exists = objectNode.has(name);
+		final JsonNode node = BooleanNode.valueOf(value);
+		if (exists && override) {
+			objectNode.replace(name, node);
+		} else {
+			objectNode.putIfAbsent(name, node);
+		}
+	}
+
+	/**
+	 * Writes a property as a JSON number value.
+	 * 
+	 * @param name property name
+	 * @param override override if present
+	 * @param value property value
+	 * @param objectNode JSON object node
+	 */
+	private static void writePropertyAsNumber(String name, boolean override, Number value, ObjectNode objectNode) {
+		final boolean exists = objectNode.has(name);
+		final JsonNode node = toJsonNode(value);
+		if (exists && override) {
+			objectNode.replace(name, node);
+		} else {
+			objectNode.putIfAbsent(name, node);
+		}
+	}
+
+	/**
+	 * Writes a property as a JSON string value.
+	 * 
+	 * @param name property name
+	 * @param override override if present
+	 * @param value property value
+	 * @param objectNode JSON object node
+	 */
+	private static void writePropertyAsString(String name, boolean override, String value, ObjectNode objectNode) {
+		final boolean exists = objectNode.has(name);
+		final StringNode node = StringNode.valueOf(value);
+		if (exists && override) {
+			objectNode.replace(name, node);
+		} else {
+			objectNode.putIfAbsent(name, node);
+		}
+	}
+
+	/**
+	 * Removes the property if present.
+	 * 
+	 * @param name property name
+	 * @param objectNode JSON object node
+	 */
+	private static void removeProperty(String name, ObjectNode objectNode) {
+		if (objectNode.has(name)) {
+			objectNode.remove(name);
+		}
+	}
+
+	/**
+	 * Writes a property as a JSON array of boolean values.
+	 * 
+	 * @param name property name
+	 * @param override override if present
+	 * @param values property values
+	 * @param objectNode JSON object node
+	 */
+	private static void writePropertyAsArray(String name, boolean override, Boolean[] values, ObjectNode objectNode) {
+		writePropertyAsArray(
+			name, 
+			override, 
+			objectNode
+				.arrayNode()
+				.addAll(Arrays.stream(values).map(BooleanNode::valueOf).toList()), 
+			objectNode);
+	}
+
+	/**
+	 * Writes a property as a JSON array of number values.
+	 * 
+	 * @param name property name
+	 * @param override override if present
+	 * @param values property values
+	 * @param objectNode JSON object node
+	 */
+	private static void writePropertyAsArray(String name, boolean override, Number[] values, ObjectNode objectNode) {
+		writePropertyAsArray(
+			name, 
+			override, 
+			objectNode
+				.arrayNode()
+				.addAll(Arrays.stream(values).map(IndexOptionMappers::toJsonNode).toList()), 
+			objectNode);
+	}
+
+	/**
+	 * Writes a property as a JSON array of string values.
+	 * 
+	 * @param name property name
+	 * @param override override if present
+	 * @param values property values
+	 * @param objectNode JSON object node
+	 */
+	private static void writePropertyAsArray(String name, boolean override, String[] values, ObjectNode objectNode) {
+		writePropertyAsArray(
+			name, 
+			override, 
+			objectNode
+				.arrayNode()
+				.addAll(Arrays.stream(values).map(StringNode::valueOf).toList()), 
+			objectNode);
+	}
+
+	/**
+	 * Writes a property as a JSON array.
+	 * 
+	 * @param name property name
+	 * @param override override if present
+	 * @param arrayNode JSON array
+	 * @param objectNode JSON object node
+	 */
+	private static void writePropertyAsArray(String name, boolean override, ArrayNode arrayNode, ObjectNode objectNode) {
+		final boolean exists = objectNode.has(name);
+		if (exists && override) {
+			objectNode.replace(name, arrayNode);
+		} else {
+			objectNode.putIfAbsent(name, arrayNode);
+		}
+	}
+
+	/**
+	 * Converts a number into appropriate JSON node.
+	 * Only {@link DecimalNode} and {@link BigInteger} types are supported.
+	 * 
+	 * @param value {@link Number} instance to convert
+	 * @throws IllegalArgumentException
+	 */
+	private static JsonNode toJsonNode(Number value) {
+		if (value instanceof BigDecimal d) {
+			return DecimalNode.valueOf(d);
+		} else if (value instanceof BigInteger i) {
+			return BigIntegerNode.valueOf(i);
+		} else {
+			// We only support BigDecimal or BigInteger numeric values, should never happen since the
+			// conversion is constrained within this class only.
+			throw new IllegalArgumentException("Only BigDecimal or BigInteger numbers are supported");
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/elasticsearch/core/index/IndexOptionMappers.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/index/IndexOptionMappers.java
@@ -20,6 +20,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.data.elasticsearch.annotations.CustomIndexOption;
 
 import tools.jackson.databind.JsonNode;
@@ -35,7 +36,7 @@ import tools.jackson.databind.node.DecimalNode;
  * 
  * @author Andriy Redko
  * 
- * @since 6.1.1
+ * @since 6.2
  */
 public final class IndexOptionMappers {
 	private IndexOptionMappers() {
@@ -64,7 +65,7 @@ public final class IndexOptionMappers {
 	public static final class NumberMapper implements IndexOptionMapper {
 		@Override
 		public void writeIndexOptionTo(CustomIndexOption indexOption, ObjectNode objectNode) {
-			final Number[] values = toNumbers(indexOption.values());
+			final @Nullable Number[] values = toNumbers(indexOption.values());
 			if (values.length == 1) {
 				writePropertyAsNumber(indexOption.name(), indexOption.overrideIfPresent(), values[0], objectNode);
 			} else if (values.length > 1) {
@@ -98,7 +99,7 @@ public final class IndexOptionMappers {
 	 * @param values array of strings
 	 * @return array of booleans
 	 */
-	private static Boolean[] toBoolean(String[] values) {
+	private static @Nullable Boolean[] toBoolean(@Nullable String[] values) {
 		return Arrays.stream(values).map(Boolean::valueOf).toArray(Boolean[]::new);
 	}
 
@@ -111,7 +112,7 @@ public final class IndexOptionMappers {
 	 * 
 	 * @throws NumberFormatException
 	 */
-	private static Number[] toNumbers(String[] values) {
+	private static @Nullable Number[] toNumbers(@Nullable String[] values) {
 		final Number[] numbers = new Number[values.length];
 		for (int j = 0; j < values.length; ++j) {
 			if (values[j] == null) {
@@ -121,7 +122,7 @@ public final class IndexOptionMappers {
 			} else {
 				final String s = values[j].trim();
 
-				boolean isInteger = false;
+				boolean isInteger = true;
 				for (int i = 0; i < s.length(); i++) {
 					if (i == 0 && (s.charAt(i) == '-' || s.charAt(i) == '+')) {
 						if (s.length() == 1) {

--- a/src/main/java/org/springframework/data/elasticsearch/core/index/IndexOptionMappers.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/index/IndexOptionMappers.java
@@ -20,6 +20,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.data.elasticsearch.annotations.CustomIndexOption;
 
 import tools.jackson.databind.JsonNode;
@@ -64,7 +65,7 @@ public final class IndexOptionMappers {
 	public static final class NumberMapper implements IndexOptionMapper {
 		@Override
 		public void writeIndexOptionTo(CustomIndexOption indexOption, ObjectNode objectNode) {
-			final Number[] values = toNumbers(indexOption.values());
+			final @Nullable Number[] values = toNumbers(indexOption.values());
 			if (values.length == 1) {
 				writePropertyAsNumber(indexOption.name(), indexOption.overrideIfPresent(), values[0], objectNode);
 			} else if (values.length > 1) {
@@ -98,7 +99,7 @@ public final class IndexOptionMappers {
 	 * @param values array of strings
 	 * @return array of booleans
 	 */
-	private static Boolean[] toBoolean(String[] values) {
+	private static @Nullable Boolean[] toBoolean(@Nullable String[] values) {
 		return Arrays.stream(values).map(Boolean::valueOf).toArray(Boolean[]::new);
 	}
 
@@ -111,7 +112,7 @@ public final class IndexOptionMappers {
 	 * 
 	 * @throws NumberFormatException
 	 */
-	private static Number[] toNumbers(String[] values) {
+	private static @Nullable Number[] toNumbers(@Nullable String[] values) {
 		final Number[] numbers = new Number[values.length];
 		for (int j = 0; j < values.length; ++j) {
 			Number number = null;

--- a/src/main/java/org/springframework/data/elasticsearch/core/index/IndexOptionMappers.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/index/IndexOptionMappers.java
@@ -19,6 +19,7 @@ package org.springframework.data.elasticsearch.core.index;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.Objects;
 
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.elasticsearch.annotations.CustomIndexOption;
@@ -48,7 +49,7 @@ public final class IndexOptionMappers {
 	public static final class StringMapper implements IndexOptionMapper {
 	@Override
 		public void writeIndexOptionTo(CustomIndexOption indexOption, ObjectNode objectNode) {
-			final String[] values = indexOption.values();
+			final String[] values = Objects.requireNonNull(indexOption.values(), "Values are required");
 			if (values.length == 1) {
 				writePropertyAsString(indexOption.name(), indexOption.overrideIfPresent(), values[0], objectNode);
 			} else if (values.length > 1) {
@@ -65,7 +66,7 @@ public final class IndexOptionMappers {
 	public static final class NumberMapper implements IndexOptionMapper {
 		@Override
 		public void writeIndexOptionTo(CustomIndexOption indexOption, ObjectNode objectNode) {
-			final @Nullable Number[] values = toNumbers(indexOption.values());
+			final @Nullable Number[] values = toNumbers(Objects.requireNonNull(indexOption.values(), "Values are required"));
 			if (values.length == 1) {
 				writePropertyAsNumber(indexOption.name(), indexOption.overrideIfPresent(), values[0], objectNode);
 			} else if (values.length > 1) {
@@ -82,7 +83,7 @@ public final class IndexOptionMappers {
 	public static final class BooleanMapper implements IndexOptionMapper {
 		@Override
 		public void writeIndexOptionTo(CustomIndexOption indexOption, ObjectNode objectNode) {
-			final Boolean[] values = toBoolean(indexOption.values());
+			final Boolean[] values = toBoolean(Objects.requireNonNull(indexOption.values(), "Values are required"));
 			if (values.length == 1) {
 				writePropertyAsBoolean(indexOption.name(), indexOption.overrideIfPresent(), values[0], objectNode);
 			} else if (values.length > 1) {

--- a/src/main/java/org/springframework/data/elasticsearch/core/index/IndexOptionMappers.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/index/IndexOptionMappers.java
@@ -20,7 +20,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
 
-import org.jspecify.annotations.Nullable;
 import org.springframework.data.elasticsearch.annotations.CustomIndexOption;
 
 import tools.jackson.databind.JsonNode;
@@ -65,7 +64,7 @@ public final class IndexOptionMappers {
 	public static final class NumberMapper implements IndexOptionMapper {
 		@Override
 		public void writeIndexOptionTo(CustomIndexOption indexOption, ObjectNode objectNode) {
-			final @Nullable Number[] values = toNumbers(indexOption.values());
+			final Number[] values = toNumbers(indexOption.values());
 			if (values.length == 1) {
 				writePropertyAsNumber(indexOption.name(), indexOption.overrideIfPresent(), values[0], objectNode);
 			} else if (values.length > 1) {
@@ -99,7 +98,7 @@ public final class IndexOptionMappers {
 	 * @param values array of strings
 	 * @return array of booleans
 	 */
-	private static @Nullable Boolean[] toBoolean(@Nullable String[] values) {
+	private static Boolean[] toBoolean(String[] values) {
 		return Arrays.stream(values).map(Boolean::valueOf).toArray(Boolean[]::new);
 	}
 
@@ -112,38 +111,21 @@ public final class IndexOptionMappers {
 	 * 
 	 * @throws NumberFormatException
 	 */
-	private static @Nullable Number[] toNumbers(@Nullable String[] values) {
+	private static Number[] toNumbers(String[] values) {
 		final Number[] numbers = new Number[values.length];
 		for (int j = 0; j < values.length; ++j) {
-			if (values[j] == null) {
-				numbers[j] = null;
-			} else if(values[j].isBlank()) {
-				throw new NumberFormatException("Unable to convert empty/blank string to number");
-			} else {
-				final String s = values[j].trim();
+			Number number = null;
+			var value = values[j];
 
-				boolean isInteger = true;
-				for (int i = 0; i < s.length(); i++) {
-					if (i == 0 && (s.charAt(i) == '-' || s.charAt(i) == '+')) {
-						if (s.length() == 1) {
-							throw new NumberFormatException("Unable to convert string  '" + s + "' to number");
-						} else {
-							continue;
-						}
-					}
-
-					if (Character.digit(s.charAt(i), 10) < 0) {
-						isInteger = false;
-						break;
-					}
-				}
-
-				if (isInteger) {
-					numbers[j] = new BigInteger(s);
-				} else {
-					numbers[j] = new BigDecimal(s);
+			if (value != null) {
+				try {
+					number = new BigInteger(value);
+				} catch (NumberFormatException e) {
+					number = new BigDecimal(value);
 				}
 			}
+
+			numbers[j] = number;
 		}
 
 		return numbers;

--- a/src/main/java/org/springframework/data/elasticsearch/core/index/MappingParameters.java
+++ b/src/main/java/org/springframework/data/elasticsearch/core/index/MappingParameters.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.jspecify.annotations.Nullable;
+import org.springframework.beans.BeanUtils;
 import org.springframework.data.elasticsearch.annotations.*;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -120,6 +121,7 @@ public class MappingParameters {
 	private final TermVector termVector;
 	private final FieldType type;
 	private final String mappedTypeName;
+	private final CustomIndexOption[] customIndexOptions;
 
 	/**
 	 * extracts the mapping parameters from the relevant annotations.
@@ -185,6 +187,7 @@ public class MappingParameters {
 		Assert.isTrue(field.enabled() || type == FieldType.Object, "enabled false is only allowed for field type object");
 		enabled = field.enabled();
 		eagerGlobalOrdinals = field.eagerGlobalOrdinals();
+		customIndexOptions = field.customIndexOptions();
 	}
 
 	protected MappingParameters(InnerField field) {
@@ -231,6 +234,7 @@ public class MappingParameters {
 		knnIndexOptions = field.knnIndexOptions().length > 0 ? field.knnIndexOptions()[0] : null;
 		enabled = true;
 		eagerGlobalOrdinals = field.eagerGlobalOrdinals();
+		customIndexOptions = field.customIndexOptions();
 	}
 
 	public boolean isStore() {
@@ -419,6 +423,12 @@ public class MappingParameters {
 		if (eagerGlobalOrdinals) {
 			objectNode.put(FIELD_PARAM_EAGER_GLOBAL_ORDINALS, eagerGlobalOrdinals);
 		}
+		
+		// At last, check the custom index options
+		for (CustomIndexOption customIndexOption: customIndexOptions) {
+			final IndexOptionMapper mapper = BeanUtils.instantiateClass(customIndexOption.mapper());
+		    mapper.writeIndexOptionTo(customIndexOption, objectNode);
+		}
 	}
 
 	protected String analyzer() {
@@ -547,5 +557,9 @@ public class MappingParameters {
 
 	protected String mappedTypeName() {
 		return mappedTypeName;
+	}
+	
+	protected CustomIndexOption[] customIndexOptions() {
+		return customIndexOptions;
 	}
 }

--- a/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderIntegrationTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderIntegrationTests.java
@@ -41,6 +41,9 @@ import org.springframework.data.elasticsearch.annotations.*;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.IndexOperations;
 import org.springframework.data.elasticsearch.core.MappingContextBaseTests;
+import org.springframework.data.elasticsearch.core.index.IndexOptionMappers.BooleanMapper;
+import org.springframework.data.elasticsearch.core.index.IndexOptionMappers.NumberMapper;
+import org.springframework.data.elasticsearch.core.index.IndexOptionMappers.StringMapper;
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
 import org.springframework.data.elasticsearch.junit.jupiter.SpringIntegrationTest;
 import org.springframework.data.elasticsearch.utils.IndexNameProvider;
@@ -272,6 +275,12 @@ public abstract class MappingBuilderIntegrationTests extends MappingContextBaseT
 	@DisplayName("should write correct mapping for dense vector property")
 	void shouldWriteCorrectMappingForDenseVectorProperty() {
 		operations.indexOps(SimilarityEntity.class).createWithMapping();
+	}
+	
+	@Test // #3299
+	@DisplayName("should write correct mapping for dense vector property with custom index options")
+	void shouldWriteCorrectMappingForDenseVectorPropertyWithCustomIndexOptions() {
+		operations.indexOps(SimilarityCustomIndexOptionEntity.class).createWithMapping();
 	}
 
 	@Test // #2845
@@ -914,6 +923,22 @@ public abstract class MappingBuilderIntegrationTests extends MappingContextBaseT
 		@Field(name = "dotted.field", type = Text) private String dottedField;
 	}
 
+	@Document(indexName = "#{@indexNameProvider.indexName()}")
+	static class SimilarityCustomIndexOptionEntity {
+		@Nullable
+		@Id private String id;
+
+		@Field(type = FieldType.Dense_Vector, dims = 42,
+				knnSimilarity = KnnSimilarity.COSINE, 
+				customIndexOptions = {
+					@CustomIndexOption(name = "similarity", values = "l2_norm", overrideIfPresent = true, mapper = StringMapper.class),
+					@CustomIndexOption(name = "element_type", values = "bit", overrideIfPresent = false, mapper = StringMapper.class),
+					@CustomIndexOption(name = "dims", values = "64", overrideIfPresent = true, mapper = NumberMapper.class),
+					@CustomIndexOption(name = "index", values = "true", overrideIfPresent = true, mapper = BooleanMapper.class)
+				}) private double @Nullable [] denseVector;
+	}
+
+	
 	@Document(indexName = "#{@indexNameProvider.indexName()}")
 	static class SimilarityEntity {
 		@Nullable

--- a/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderUnitTests.java
+++ b/src/test/java/org/springframework/data/elasticsearch/core/index/MappingBuilderUnitTests.java
@@ -41,6 +41,9 @@ import org.springframework.data.domain.Range;
 import org.springframework.data.elasticsearch.annotations.*;
 import org.springframework.data.elasticsearch.core.MappingContextBaseTests;
 import org.springframework.data.elasticsearch.core.geo.GeoPoint;
+import org.springframework.data.elasticsearch.core.index.IndexOptionMappers.BooleanMapper;
+import org.springframework.data.elasticsearch.core.index.IndexOptionMappers.NumberMapper;
+import org.springframework.data.elasticsearch.core.index.IndexOptionMappers.StringMapper;
 import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
 import org.springframework.data.elasticsearch.core.query.SeqNoPrimaryTerm;
 import org.springframework.data.elasticsearch.core.suggest.Completion;
@@ -1371,6 +1374,37 @@ public class MappingBuilderUnitTests extends MappingContextBaseTests {
 
 		assertEquals(expected, mapping, false);
 	}
+
+	
+	@Test // #3299
+	@DisplayName("should write dense_vector properties for knn search with custom index options")
+	void shouldWriteDenseVectorPropertiesWithKnnSearchCustomIndexOptions() throws JSONException {
+		String expected = """
+				{
+				  "properties":{
+					"my_vector":{
+					  "dims":32,
+					  "element_type":"bit",
+					  "similarity":"dot_product",
+					  "index": true,
+					  "floats": [0.5644, 0.4445, 0.95442],
+					  "ints": [-1, 0, 1],
+					  "strings": ["s1", "", "s2"],
+					  "bools": [true, false],
+					  "index_options":{
+						"type":"hnsw",
+						"m":16,
+						"ef_construction":100
+					  }
+					}
+				  }
+				}
+				""";
+
+		String mapping = getMappingBuilder().buildPropertyMapping(DenseVectorEntityWithKnnSearchCustomIndexOptions.class);
+
+		assertEquals(expected, mapping, false);
+	}
 	// region entities
 
 	@Document(indexName = "ignore-above-index")
@@ -2229,6 +2263,45 @@ public class MappingBuilderUnitTests extends MappingContextBaseTests {
 		@Field(type = FieldType.Dense_Vector, dims = 16, elementType = FieldElementType.FLOAT,
 				knnIndexOptions = @KnnIndexOptions(type = KnnAlgorithmType.HNSW, m = 16, efConstruction = 100),
 				knnSimilarity = KnnSimilarity.DOT_PRODUCT) private float @Nullable [] my_vector;
+
+		@Nullable
+		public String getId() {
+			return id;
+		}
+
+		public void setId(@Nullable String id) {
+			this.id = id;
+		}
+
+		public float @Nullable [] getMy_vector() {
+			return my_vector;
+		}
+
+		public void setMy_vector(float @Nullable [] my_vector) {
+			this.my_vector = my_vector;
+		}
+	}
+
+	@SuppressWarnings("unused")
+	static class DenseVectorEntityWithKnnSearchCustomIndexOptions {
+		@Nullable
+		@Id private String id;
+
+		@Field(type = FieldType.Dense_Vector, dims = 16, 
+				knnIndexOptions = @KnnIndexOptions(type = KnnAlgorithmType.HNSW, m = 16, efConstruction = 100),
+				knnSimilarity = KnnSimilarity.DOT_PRODUCT,
+				customIndexOptions = {
+					@CustomIndexOption(name = "similarity", values = "l2_norm", mapper = StringMapper.class),
+					@CustomIndexOption(name = "element_type", values = "bit", mapper = StringMapper.class),
+					@CustomIndexOption(name = "dims", values = "32", overrideIfPresent = true, mapper = NumberMapper.class),
+					@CustomIndexOption(name = "index", values = "true", mapper = BooleanMapper.class),
+					@CustomIndexOption(name = "floats", values = { "0.5644", "0.4445", "0.95442" }, mapper = NumberMapper.class),
+					@CustomIndexOption(name = "ints", values = { "-1", "0", "1" }, mapper = NumberMapper.class),
+					@CustomIndexOption(name = "strings", values = { "s1", "", "s2" }, mapper = StringMapper.class),
+					@CustomIndexOption(name = "bools", values = { "false", "true" }, mapper = BooleanMapper.class),
+					@CustomIndexOption(name = "type", mapper = StringMapper.class)
+				}
+				) private float @Nullable [] my_vector;
 
 		@Nullable
 		public String getId() {


### PR DESCRIPTION
The @Field / @InnerField annotations have very rich but predefined set of attributes (properties). It does work for the majority of the applications but often, especially when Spring Data OpenSearch is involved, it is not enough. The good example is K-NN indexing support, were the algorithms / engines / parameters are vastly different.

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] **There is a ticket in the bug tracker for the project in our [issue tracker](https://github.com/spring-projects/spring-data-elasticsearch/issues)**. Add the issue number to the _Closes #issue-number_ line below
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).

Closes #3299
