### PR TITLE
Remove duplicated "the"

### DIFF
--- a/src/main/java/org/springframework/data/elasticsearch/repository/query/RepositoryPartQuery.java
+++ b/src/main/java/org/springframework/data/elasticsearch/repository/query/RepositoryPartQuery.java
@@ -24,7 +24,7 @@ import org.springframework.data.repository.query.ValueExpressionDelegate;
 import org.springframework.data.repository.query.parser.PartTree;
 
 /**
- * A repository query that is built from the the method name in the repository definition. Was originally named
+ * A repository query that is built from the method name in the repository definition. Was originally named
  * ElasticsearchPartQuery.
  *
  * @author Rizwan Idrees


### PR DESCRIPTION
This PR fixes a typo of "the the" to "the".